### PR TITLE
fix: pin two dependencies due to upstream semver issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2649,9 +2649,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e17dfa6c70fdf14ea5199cca1e1d37e10adf4b68f28b6e94e600f28c0846e2"
+checksum = "767fd3026c514f4d2ebdb4ebda5ed8857660dd1ef5bfed2aaa2ae8e42019630e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ async-trait = "0.1.80"
 alloy-primitives = { version = "0.7.6", default-features = false }
 alloy-rlp = { version = "0.3.5", default-features = false }
 alloy-consensus = { version = "0.1", default-features = false }
-op-alloy-consensus = { version = "0.1.0", default-features = false }
+op-alloy-consensus = { version = "=0.1.1", default-features = false }
 alloy-eips = { version = "0.1", default-features = false }
 revm = { git = "https://github.com/bluealloy/revm", tag = "v37", version = "10.0.0", default-features = false }
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -17,7 +17,7 @@ alloy-eips.workspace = true
 op-alloy-consensus.workspace = true
 
 # Superchain Registry
-superchain-primitives = { version = "0.1.1", default-features = false }
+superchain-primitives = { version = "=0.1.1", default-features = false }
 
 # Alloy Types
 alloy-sol-types = { version = "0.7.6", default-features = false }


### PR DESCRIPTION
**Description**

Two upstream dependencies had patch releases that changes interfaces. This causes `kona` to break if `cargo update` is called. Pinning these two dependencies on the previous versions fixes the issue.

**Tests**

N/A

**Additional context**

N/A

**Metadata**

N/A