### PR TITLE
Move temporary error logs to lower level than WARN

### DIFF
--- a/crates/derive/src/pipeline/core.rs
+++ b/crates/derive/src/pipeline/core.rs
@@ -177,7 +177,7 @@ where
                     StepResult::AdvancedOrigin
                 }
                 PipelineErrorKind::Temporary(_) => {
-                    debug!(target: "pipeline", "Attributes queue step failed temporarily: {:?}", err);
+                    trace!(target: "pipeline", "Attributes queue step failed temporarily: {:?}", err);
                     StepResult::StepFailed(err)
                 }
                 _ => {

--- a/crates/derive/src/pipeline/core.rs
+++ b/crates/derive/src/pipeline/core.rs
@@ -177,7 +177,7 @@ where
                     StepResult::AdvancedOrigin
                 }
                 PipelineErrorKind::Temporary(_) => {
-                    trace!(target: "pipeline", "Attributes queue step failed temporarily: {:?}", err);
+                    trace!(target: "pipeline", "Attributes queue step failed due to temporary error: {:?}", err);
                     StepResult::StepFailed(err)
                 }
                 _ => {

--- a/crates/derive/src/pipeline/core.rs
+++ b/crates/derive/src/pipeline/core.rs
@@ -176,6 +176,10 @@ where
                     }
                     StepResult::AdvancedOrigin
                 }
+                PipelineErrorKind::Temporary(_) => {
+                    debug!(target: "pipeline", "Attributes queue step failed temporarily: {:?}", err);
+                    StepResult::StepFailed(err)
+                }
                 _ => {
                     warn!(target: "pipeline", "Attributes queue step failed: {:?}", err);
                     StepResult::StepFailed(err)

--- a/crates/driver/src/pipeline.rs
+++ b/crates/driver/src/pipeline.rs
@@ -40,14 +40,16 @@ where
                     info!(target: "client_derivation_driver", "Advanced origin")
                 }
                 StepResult::OriginAdvanceErr(e) | StepResult::StepFailed(e) => {
-                    warn!(target: "client_derivation_driver", "Failed to step derivation pipeline: {:?}", e);
-
                     // Break the loop unless the error signifies that there is not enough data to
                     // complete the current step. In this case, we retry the step to see if other
                     // stages can make progress.
                     match e {
-                        PipelineErrorKind::Temporary(_) => continue,
+                        PipelineErrorKind::Temporary(_) => {
+                            debug!(target: "client_derivation_driver", "Failed to step derivation pipeline temporarily: {:?}", e);
+                            continue
+                        }
                         PipelineErrorKind::Reset(e) => {
+                            warn!(target: "client_derivation_driver", "Failed to step derivation pipeline due to reset: {:?}", e);
                             let system_config = self
                                 .system_config_by_number(l2_safe_head.block_info.number)
                                 .await?;
@@ -85,7 +87,10 @@ where
                                 .await?;
                             }
                         }
-                        PipelineErrorKind::Critical(_) => return Err(e),
+                        PipelineErrorKind::Critical(_) => {
+                            warn!(target: "client_derivation_driver", "Failed to step derivation pipeline: {:?}", e);
+                            return Err(e)
+                        }
                     }
                 }
             }

--- a/crates/driver/src/pipeline.rs
+++ b/crates/driver/src/pipeline.rs
@@ -45,7 +45,7 @@ where
                     // stages can make progress.
                     match e {
                         PipelineErrorKind::Temporary(_) => {
-                            debug!(target: "client_derivation_driver", "Failed to step derivation pipeline temporarily: {:?}", e);
+                            trace!(target: "client_derivation_driver", "Failed to step derivation pipeline temporarily: {:?}", e);
                             continue
                         }
                         PipelineErrorKind::Reset(e) => {


### PR DESCRIPTION
Closes #896

Refactors logging around some `PipelineErrorKind::TemporaryError`s to be lower level than WARN.