### PR TITLE
chore(mpt): Remove `anyhow` dev-dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2519,7 +2519,6 @@ dependencies = [
  "alloy-rpc-types",
  "alloy-transport-http",
  "alloy-trie",
- "anyhow",
  "criterion",
  "pprof",
  "proptest",
@@ -2613,7 +2612,6 @@ dependencies = [
 name = "kona-std-fpvm-proc"
 version = "0.1.2"
 dependencies = [
- "anyhow",
  "cfg-if",
  "kona-std-fpvm",
  "proc-macro2",

--- a/crates/executor/src/db/mod.rs
+++ b/crates/executor/src/db/mod.rs
@@ -48,7 +48,6 @@ pub use traits::{NoopTrieDBProvider, TrieDBProvider};
 /// ```rust
 /// use alloy_consensus::{Header, Sealable};
 /// use alloy_primitives::{Bytes, B256};
-/// use anyhow::Result;
 /// use kona_executor::{NoopTrieDBProvider, TrieDB};
 /// use kona_mpt::NoopTrieHinter;
 /// use revm::{db::states::bundle_state::BundleRetention, EvmBuilder, StateBuilder};

--- a/crates/executor/src/db/traits.rs
+++ b/crates/executor/src/db/traits.rs
@@ -16,7 +16,7 @@ pub trait TrieDBProvider: TrieProvider {
     ///
     /// ## Returns
     /// - Ok(Bytes): The bytecode of the contract.
-    /// - Err(anyhow::Error): If the bytecode hash could not be fetched.
+    /// - Err(Self::Error): If the bytecode hash could not be fetched.
     ///
     /// [TrieDB]: crate::TrieDB
     fn bytecode_by_hash(&self, code_hash: B256) -> Result<Bytes, Self::Error>;
@@ -28,7 +28,7 @@ pub trait TrieDBProvider: TrieProvider {
     ///
     /// ## Returns
     /// - Ok(Bytes): The [Header].
-    /// - Err(anyhow::Error): If the [Header] could not be fetched.
+    /// - Err(Self::Error): If the [Header] could not be fetched.
     ///
     /// [TrieDB]: crate::TrieDB
     fn header_by_hash(&self, hash: B256) -> Result<Header, Self::Error>;

--- a/crates/mpt/Cargo.toml
+++ b/crates/mpt/Cargo.toml
@@ -30,7 +30,6 @@ alloy-rpc-types = { workspace = true, features = ["eth", "debug"] }
 
 # General
 rand.workspace = true
-anyhow.workspace = true
 reqwest.workspace = true
 proptest.workspace = true
 tokio = { workspace = true, features = ["full"] }

--- a/crates/mpt/src/traits.rs
+++ b/crates/mpt/src/traits.rs
@@ -18,7 +18,7 @@ pub trait TrieProvider {
     ///
     /// ## Returns
     /// - Ok(TrieNode): The trie node preimage.
-    /// - Err(anyhow::Error): If the trie node preimage could not be fetched.
+    /// - Err(Self::Error): If the trie node preimage could not be fetched.
     fn trie_node_by_hash(&self, key: B256) -> Result<TrieNode, Self::Error>;
 }
 
@@ -45,7 +45,7 @@ pub trait TrieHinter {
     ///
     /// ## Returns
     /// - Ok(()): If the hint was successful.
-    /// - Err(anyhow::Error): If the hint was unsuccessful.
+    /// - Err(Self::Error): If the hint was unsuccessful.
     fn hint_account_proof(&self, address: Address, block_number: u64) -> Result<(), Self::Error>;
 
     /// Hints the host to fetch the trie node preimages on the path to the storage slot within the
@@ -58,7 +58,7 @@ pub trait TrieHinter {
     ///
     /// ## Returns
     /// - Ok(()): If the hint was successful.
-    /// - Err(anyhow::Error): If the hint was unsuccessful.
+    /// - Err(Self::Error): If the hint was unsuccessful.
     fn hint_storage_proof(
         &self,
         address: Address,

--- a/crates/proof-sdk/std-fpvm-proc/Cargo.toml
+++ b/crates/proof-sdk/std-fpvm-proc/Cargo.toml
@@ -13,7 +13,6 @@ proc-macro = true
 
 [dependencies]
 # General
-anyhow.workspace = true
 cfg-if.workspace = true
 
 # Workspace


### PR DESCRIPTION
## Overview

Removes `anyhow` as a dev-dependency within `kona-mpt`, by converting the error used within the test utilities.

Also cleans up some broken doc comments.

closes #918 