### PR TITLE
feat: use empty requests hash when isthmus enabled

### DIFF
--- a/crates/executor/src/executor/mod.rs
+++ b/crates/executor/src/executor/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 use alloc::vec::Vec;
 use alloy_consensus::{Header, Sealable, Transaction, EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH};
 use alloy_eips::eip2718::{Decodable2718, Encodable2718};
-use alloy_primitives::{keccak256, logs_bloom, Bytes, Log, B256, U256};
+use alloy_primitives::{b256, keccak256, logs_bloom, Bytes, Log, B256, U256};
 use kona_mpt::{ordered_trie_with_encoder, TrieHinter};
 use maili_genesis::RollupConfig;
 use op_alloy_consensus::{OpReceiptEnvelope, OpTxEnvelope};
@@ -28,6 +28,11 @@ mod env;
 
 mod util;
 use util::encode_holocene_eip_1559_params;
+
+
+/// Empty SHA-256 hash.
+const SHA256_EMPTY: B256 =
+    b256!("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470");
 
 /// The block executor for the L2 client program. Operates off of a [TrieDB] backed [State],
 /// allowing for stateless block execution of OP Stack blocks.
@@ -328,6 +333,11 @@ where
         // Compute the parent hash.
         let parent_hash = state.database.parent_block_header().seal();
 
+        let requests_hash = self
+            .config
+            .is_isthmus_active(payload.payload_attributes.timestamp)
+            .then_some(SHA256_EMPTY);
+
         // Construct the new header.
         let header = Header {
             parent_hash,
@@ -337,7 +347,7 @@ where
             transactions_root,
             receipts_root,
             withdrawals_root,
-            requests_hash: None,
+            requests_hash,
             logs_bloom,
             difficulty: U256::ZERO,
             number: block_number,

--- a/crates/executor/src/executor/mod.rs
+++ b/crates/executor/src/executor/mod.rs
@@ -29,7 +29,6 @@ mod env;
 mod util;
 use util::encode_holocene_eip_1559_params;
 
-
 /// Empty SHA-256 hash.
 const SHA256_EMPTY: B256 =
     b256!("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470");


### PR DESCRIPTION
If Isthmus is enabled, pass empty SHA-256 hash as the requests root. Checked that this matches op-geth when passing in an empty array.

Wasn't totally sure where to put the constant for empty sha-256, but let me know if I should move it.

Spec: https://eips.ethereum.org/EIPS/eip-7685#block-header

Fixes https://github.com/op-rs/kona/issues/949