### PR TITLE
feat: Derive Eq/Ord/Hash for (Archived) PreimageKey(Type)

### DIFF
--- a/crates/proof-sdk/preimage/src/key.rs
+++ b/crates/proof-sdk/preimage/src/key.rs
@@ -10,9 +10,13 @@ use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
 use crate::errors::PreimageOracleError;
 
 /// <https://specs.optimism.io/experimental/fault-proof/index.html#pre-image-key-types>
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(u8)]
-#[cfg_attr(feature = "rkyv", derive(Archive, RkyvSerialize, RkyvDeserialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(Archive, RkyvSerialize, RkyvDeserialize),
+    rkyv(derive(Eq, PartialEq, Ord, PartialOrd, Hash))
+)]
 #[cfg_attr(feature = "serde", derive(SerdeSerialize, SerdeDeserialize))]
 pub enum PreimageKeyType {
     /// Local key types are local to a given instance of a fault-proof and context dependent.
@@ -62,8 +66,12 @@ impl TryFrom<u8> for PreimageKeyType {
 /// |---------|-------------|
 /// | [0, 1)  | Type byte   |
 /// | [1, 32) | Data        |
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "rkyv", derive(Archive, RkyvSerialize, RkyvDeserialize))]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(Archive, RkyvSerialize, RkyvDeserialize),
+    rkyv(derive(Eq, PartialEq, Ord, PartialOrd, Hash))
+)]
 #[cfg_attr(feature = "serde", derive(SerdeSerialize, SerdeDeserialize))]
 pub struct PreimageKey {
     data: [u8; 31],


### PR DESCRIPTION
This PR derives Eq/Ord/Hash implementations for the (Archived) PreimageKey(Type) struct, enabling its usage in more collections.