### PR TITLE
feat(kona-host): export `HostCli`, fix compilation

### DIFF
--- a/bin/host/src/interop/fetcher.rs
+++ b/bin/host/src/interop/fetcher.rs
@@ -2,7 +2,7 @@
 //! preimages from a remote source serving the super-chain (interop) proof mode.
 
 use super::InteropHostCli;
-use crate::{single::SingleChainFetcher, KeyValueStore};
+use crate::{single::SingleChainFetcher, KeyValueStore, PreimageServer};
 use alloy_consensus::{Header, Sealed, TxEnvelope, EMPTY_ROOT_HASH};
 use alloy_eips::{
     eip2718::Encodable2718,
@@ -19,7 +19,6 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use kona_driver::Driver;
 use kona_executor::TrieDBProvider;
-use kona_host::{KeyValueStore, PreimageServer};
 use kona_preimage::{
     errors::{PreimageOracleError, PreimageOracleResult},
     BidirectionalChannel, HintReader, HintRouter, HintWriter, OracleReader, OracleServer,

--- a/bin/host/src/interop/fetcher.rs
+++ b/bin/host/src/interop/fetcher.rs
@@ -2,7 +2,7 @@
 //! preimages from a remote source serving the super-chain (interop) proof mode.
 
 use super::InteropHostCli;
-use crate::single::SingleChainFetcher;
+use crate::{single::SingleChainFetcher, KeyValueStore};
 use alloy_consensus::{Header, Sealed, TxEnvelope, EMPTY_ROOT_HASH};
 use alloy_eips::{
     eip2718::Encodable2718,

--- a/bin/host/src/interop/local_kv.rs
+++ b/bin/host/src/interop/local_kv.rs
@@ -2,9 +2,9 @@
 //! using the [InteropHostCli] config.
 
 use super::InteropHostCli;
+use crate::KeyValueStore;
 use alloy_primitives::{keccak256, B256};
 use anyhow::Result;
-use kona_host::KeyValueStore;
 use kona_preimage::PreimageKey;
 use kona_proof_interop::boot::{
     L1_HEAD_KEY, L2_AGREED_PRE_STATE_KEY, L2_CLAIMED_POST_STATE_KEY, L2_CLAIMED_TIMESTAMP_KEY,

--- a/bin/host/src/interop/orchestrator.rs
+++ b/bin/host/src/interop/orchestrator.rs
@@ -1,15 +1,14 @@
 //! [SingleChainHostCli]'s [HostOrchestrator] + [DetachedHostOrchestrator] implementations.
 
 use super::{InteropFetcher, InteropHostCli, LocalKeyValueStore};
-use crate::eth::http_provider;
+use crate::{
+    eth::http_provider, DetachedHostOrchestrator, DiskKeyValueStore, Fetcher, HostOrchestrator,
+    MemoryKeyValueStore, SharedKeyValueStore, SplitKeyValueStore,
+};
 use alloy_primitives::map::HashMap;
 use alloy_provider::{Provider, RootProvider};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use kona_host::{
-    DetachedHostOrchestrator, DiskKeyValueStore, Fetcher, HostOrchestrator, MemoryKeyValueStore,
-    SharedKeyValueStore, SplitKeyValueStore,
-};
 use kona_preimage::{HintWriter, NativeChannel, OracleReader};
 use kona_providers_alloy::{OnlineBeaconClient, OnlineBlobProvider};
 use std::sync::Arc;

--- a/bin/host/src/interop/orchestrator.rs
+++ b/bin/host/src/interop/orchestrator.rs
@@ -1,4 +1,4 @@
-//! [SingleChainHostCli]'s [HostOrchestrator] + [DetachedHostOrchestrator] implementations.
+//! [InteropHostCli]'s [HostOrchestrator] + [DetachedHostOrchestrator] implementations.
 
 use super::{InteropFetcher, InteropHostCli, LocalKeyValueStore};
 use crate::{

--- a/bin/host/src/lib.rs
+++ b/bin/host/src/lib.rs
@@ -19,3 +19,8 @@ pub use preimage::{
 
 mod server;
 pub use server::PreimageServer;
+
+pub mod cli;
+pub mod eth;
+pub mod interop;
+pub mod single;

--- a/bin/host/src/main.rs
+++ b/bin/host/src/main.rs
@@ -4,16 +4,13 @@
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-use crate::cli::{init_tracing_subscriber, HostCli, HostMode};
 use anyhow::Result;
 use clap::Parser;
-use kona_host::DetachedHostOrchestrator;
+use kona_host::{
+    cli::{init_tracing_subscriber, HostCli, HostMode},
+    DetachedHostOrchestrator,
+};
 use tracing::info;
-
-pub mod cli;
-pub mod eth;
-pub mod interop;
-pub mod single;
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {

--- a/bin/host/src/single/fetcher.rs
+++ b/bin/host/src/single/fetcher.rs
@@ -1,6 +1,7 @@
 //! This module contains the [SingleChainFetcher] struct, which is responsible for fetching
 //! preimages from a remote source serving the single-chain proof mode.
 
+use crate::KeyValueStore;
 use alloy_consensus::{Header, TxEnvelope, EMPTY_ROOT_HASH};
 use alloy_eips::{
     eip2718::Encodable2718,
@@ -15,7 +16,6 @@ use alloy_rpc_types::{
     Transaction,
 };
 use anyhow::{anyhow, Result};
-use kona_host::KeyValueStore;
 use kona_preimage::{
     errors::{PreimageOracleError, PreimageOracleResult},
     HintRouter, PreimageFetcher, PreimageKey, PreimageKeyType,

--- a/bin/host/src/single/local_kv.rs
+++ b/bin/host/src/single/local_kv.rs
@@ -2,9 +2,9 @@
 //! using the [SingleChainHostCli] config.
 
 use super::SingleChainHostCli;
+use crate::KeyValueStore;
 use alloy_primitives::B256;
 use anyhow::Result;
-use kona_host::KeyValueStore;
 use kona_preimage::PreimageKey;
 use kona_proof::boot::{
     L1_HEAD_KEY, L2_CHAIN_ID_KEY, L2_CLAIM_BLOCK_NUMBER_KEY, L2_CLAIM_KEY, L2_OUTPUT_ROOT_KEY,

--- a/bin/host/src/single/orchestrator.rs
+++ b/bin/host/src/single/orchestrator.rs
@@ -1,14 +1,13 @@
 //! [SingleChainHostCli]'s [HostOrchestrator] + [DetachedHostOrchestrator] implementations.
 
 use super::{LocalKeyValueStore, SingleChainFetcher, SingleChainHostCli};
-use crate::eth::http_provider;
-use alloy_provider::RootProvider;
+use crate::{
+    eth::http_provider, DetachedHostOrchestrator, DiskKeyValueStore, Fetcher, HostOrchestrator,
+    MemoryKeyValueStore, SharedKeyValueStore, SplitKeyValueStore,
+};
+use alloy_provider::{ReqwestProvider, RootProvider};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use kona_host::{
-    DetachedHostOrchestrator, DiskKeyValueStore, Fetcher, HostOrchestrator, MemoryKeyValueStore,
-    SharedKeyValueStore, SplitKeyValueStore,
-};
 use kona_preimage::{HintWriter, NativeChannel, OracleReader};
 use kona_providers_alloy::{OnlineBeaconClient, OnlineBlobProvider};
 use std::sync::Arc;

--- a/crates/mpt/src/list_walker.rs
+++ b/crates/mpt/src/list_walker.rs
@@ -77,7 +77,7 @@ where
 
     /// Takes the inner list of the [OrderedListWalker], returning it and setting the inner list to
     /// [None].
-    pub const fn take_inner(&mut self) -> Option<VecDeque<(Bytes, Bytes)>> {
+    pub fn take_inner(&mut self) -> Option<VecDeque<(Bytes, Bytes)>> {
         self.inner.take()
     }
 

--- a/crates/proof-sdk/proof/src/boot.rs
+++ b/crates/proof-sdk/proof/src/boot.rs
@@ -71,19 +71,16 @@ impl BootInfo {
             .get_exact(PreimageKey::new_local(L1_HEAD_KEY.to()), l1_head.as_mut())
             .await
             .map_err(OracleProviderError::Preimage)?;
-
         let mut l2_output_root: B256 = B256::ZERO;
         oracle
             .get_exact(PreimageKey::new_local(L2_OUTPUT_ROOT_KEY.to()), l2_output_root.as_mut())
             .await
             .map_err(OracleProviderError::Preimage)?;
-
         let mut l2_claim: B256 = B256::ZERO;
         oracle
             .get_exact(PreimageKey::new_local(L2_CLAIM_KEY.to()), l2_claim.as_mut())
             .await
             .map_err(OracleProviderError::Preimage)?;
-
         let l2_claim_block = u64::from_be_bytes(
             oracle
                 .get(PreimageKey::new_local(L2_CLAIM_BLOCK_NUMBER_KEY.to()))
@@ -102,7 +99,6 @@ impl BootInfo {
                 .try_into()
                 .map_err(OracleProviderError::SliceConversion)?,
         );
-
         // Attempt to load the rollup config from the chain ID. If there is no config for the chain,
         // fall back to loading the config from the preimage oracle.
         let rollup_config = if let Some(config) = ROLLUP_CONFIGS.get(&chain_id) {


### PR DESCRIPTION
The modules defined in `main.rs` are not accessible outside the crate because `main.rs` is the binary entry point, not a library file. By default, code in `main.rs` is only available within the binary itself.

To make the CLI types (e.g. `HostCli`) available externally (e.g. in https://github.com/succinctlabs/op-succinct), they need to be:

- Defined in `lib.rs` (or a module exported by lib.rs).
- Marked with pub visibility.

Once I included exposed the modules in `lib.rs`, modules within `cli`, `single`, etc., need to import types from `kona-host` with `crate::`.
