### PR TITLE
feat: fill eip 7702 tx env with auth list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,15 +2070,15 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",

--- a/crates/executor/src/executor/env.rs
+++ b/crates/executor/src/executor/env.rs
@@ -10,8 +10,8 @@ use maili_genesis::RollupConfig;
 use op_alloy_consensus::OpTxEnvelope;
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use revm::primitives::{
-    BlobExcessGasAndPrice, BlockEnv, CfgEnv, CfgEnvWithHandlerCfg, OptimismFields, SpecId,
-    TransactTo, TxEnv,
+    AuthorizationList, BlobExcessGasAndPrice, BlockEnv, CfgEnv, CfgEnvWithHandlerCfg,
+    OptimismFields, SpecId, TransactTo, TxEnv,
 };
 
 impl<P, H> StatelessL2BlockExecutor<'_, P, H>
@@ -205,6 +205,30 @@ where
                 env.access_list = tx.access_list.to_vec();
                 env.blob_hashes.clear();
                 env.max_fee_per_blob_gas.take();
+                env.optimism = OptimismFields {
+                    source_hash: None,
+                    mint: None,
+                    is_system_transaction: Some(false),
+                    enveloped_tx: Some(encoded_transaction.to_vec().into()),
+                };
+                Ok(env)
+            }
+            OpTxEnvelope::Eip7702(signed_tx) => {
+                let tx = signed_tx.tx();
+                env.caller = signed_tx.recover_signer().map_err(ExecutorError::SignatureError)?;
+                env.gas_limit = tx.gas_limit;
+                env.gas_price = U256::from(tx.max_fee_per_gas);
+                env.gas_priority_fee = Some(U256::from(tx.max_priority_fee_per_gas));
+                env.transact_to = TransactTo::Call(tx.to);
+                env.value = tx.value;
+                env.data = tx.input.clone();
+                env.chain_id = Some(tx.chain_id);
+                env.nonce = Some(tx.nonce);
+                env.access_list = tx.access_list.to_vec();
+                env.blob_hashes.clear();
+                env.max_fee_per_blob_gas.take();
+                env.authorization_list =
+                    Some(AuthorizationList::Signed(tx.authorization_list.to_vec()));
                 env.optimism = OptimismFields {
                     source_hash: None,
                     mint: None,

--- a/crates/executor/src/executor/mod.rs
+++ b/crates/executor/src/executor/mod.rs
@@ -184,6 +184,11 @@ where
                 return Err(ExecutorError::BlockGasLimitExceeded);
             }
 
+            // Prevent EIP-7702 transactions pre-isthmus hardfork.
+            if !is_isthmus && matches!(transaction, OpTxEnvelope::Eip7702(_)) {
+                return Err(ExecutorError::UnsupportedTransactionType(transaction.tx_type() as u8));
+            }
+
             // Modify the transaction environment with the current transaction.
             evm = evm
                 .modify()


### PR DESCRIPTION
Fills tx env for EIP 7702 transactions using the same format as EIP 1559, but with authorization list added.

Fixes #948 

TODO: do we need a switch for Isthmus here? Or is it OK to be active all the time - guessing the batcher shouldn't include 7702 txs until Isthmus is active?