### PR TITLE
feat(executor): Export receipts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2551,6 +2551,7 @@ dependencies = [
  "alloy-rlp",
  "async-trait",
  "kona-derive",
+ "kona-executor",
  "maili-genesis",
  "maili-protocol",
  "maili-rpc",

--- a/crates/driver/Cargo.toml
+++ b/crates/driver/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 # Workspace
 kona-derive.workspace = true
+kona-executor.workspace = true
 
 # Maili
 maili-rpc.workspace = true

--- a/crates/driver/src/executor.rs
+++ b/crates/driver/src/executor.rs
@@ -5,6 +5,7 @@ use core::{
     error::Error,
     fmt::{Debug, Display},
 };
+use kona_executor::ExecutionArtifacts;
 
 use alloc::string::ToString;
 use alloy_consensus::{Header, Sealed};
@@ -30,7 +31,7 @@ pub trait Executor {
     async fn execute_payload(
         &mut self,
         attributes: OpPayloadAttributes,
-    ) -> Result<Header, Self::Error>;
+    ) -> Result<ExecutionArtifacts, Self::Error>;
 
     /// Computes the output root.
     /// Expected to be called after the payload has been executed.

--- a/crates/executor/src/constants.rs
+++ b/crates/executor/src/constants.rs
@@ -1,6 +1,6 @@
 //! Protocol constants for the executor.
 
-use alloy_primitives::{address, Address};
+use alloy_primitives::{address, b256, Address, B256};
 
 /// The address of the fee recipient.
 pub(crate) const FEE_RECIPIENT: Address = address!("4200000000000000000000000000000000000011");
@@ -9,7 +9,11 @@ pub(crate) const FEE_RECIPIENT: Address = address!("4200000000000000000000000000
 pub(crate) const L2_TO_L1_BRIDGE: Address = address!("4200000000000000000000000000000000000016");
 
 /// The current version of the output root format.
-pub(crate) const OUTPUT_ROOT_VERSION: u8 = 0;
+pub(crate) const OUTPUT_ROOT_VERSION: u8 = 0x00;
 
 /// The version byte for the Holocene extra data.
 pub(crate) const HOLOCENE_EXTRA_DATA_VERSION: u8 = 0x00;
+
+/// Empty SHA-256 hash.
+pub(crate) const SHA256_EMPTY: B256 =
+    b256!("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470");

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -16,7 +16,10 @@ mod errors;
 pub use errors::{ExecutorError, ExecutorResult, TrieDBError, TrieDBResult};
 
 mod executor;
-pub use executor::{KonaHandleRegister, StatelessL2BlockExecutor, StatelessL2BlockExecutorBuilder};
+pub use executor::{
+    ExecutionArtifacts, KonaHandleRegister, StatelessL2BlockExecutor,
+    StatelessL2BlockExecutorBuilder,
+};
 
 mod db;
 pub use db::{NoopTrieDBProvider, TrieAccount, TrieDB, TrieDBProvider};

--- a/crates/executor/src/test_utils.rs
+++ b/crates/executor/src/test_utils.rs
@@ -147,11 +147,12 @@ impl ExecutorTestFixtureCreator {
         let mut executor = StatelessL2BlockExecutor::builder(rollup_config, self, NoopTrieHinter)
             .with_parent_header(parent_header)
             .build();
-        let produced_header =
+        let exec_artifacts =
             executor.execute_payload(payload_attrs).expect("Failed to execute block").clone();
 
         assert_eq!(
-            produced_header, executing_header.inner,
+            exec_artifacts.block_header.inner(),
+            &executing_header.inner,
             "Produced header does not match the expected header"
         );
         fs::write(fixture_path.as_path(), serde_json::to_vec(&fixture).unwrap()).await.unwrap();
@@ -338,10 +339,10 @@ pub(crate) async fn run_test_fixture(fixture_path: PathBuf) {
             .with_parent_header(fixture.parent_header.seal_slow())
             .build();
 
-    let produced_header = executor.execute_payload(fixture.executing_payload).unwrap();
+    let exec_artifacts = executor.execute_payload(fixture.executing_payload).unwrap();
 
     assert_eq!(
-        produced_header.hash_slow(),
+        exec_artifacts.block_header.hash(),
         fixture.expected_block_hash,
         "Produced header does not match the expected header"
     );

--- a/crates/proof-sdk/proof/src/executor.rs
+++ b/crates/proof-sdk/proof/src/executor.rs
@@ -5,7 +5,9 @@ use alloy_consensus::{Header, Sealed};
 use alloy_primitives::B256;
 use async_trait::async_trait;
 use kona_driver::Executor;
-use kona_executor::{KonaHandleRegister, StatelessL2BlockExecutor, TrieDBProvider};
+use kona_executor::{
+    ExecutionArtifacts, KonaHandleRegister, StatelessL2BlockExecutor, TrieDBProvider,
+};
 use kona_mpt::TrieHinter;
 use maili_genesis::RollupConfig;
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
@@ -82,14 +84,11 @@ where
     async fn execute_payload(
         &mut self,
         attributes: OpPayloadAttributes,
-    ) -> Result<Header, Self::Error> {
-        self.inner
-            .as_mut()
-            .map_or_else(
-                || Err(kona_executor::ExecutorError::MissingExecutor),
-                |e| e.execute_payload(attributes),
-            )
-            .cloned()
+    ) -> Result<ExecutionArtifacts, Self::Error> {
+        self.inner.as_mut().map_or_else(
+            || Err(kona_executor::ExecutorError::MissingExecutor),
+            |e| e.execute_payload(attributes),
+        )
     }
 
     /// Computes the output root.


### PR DESCRIPTION
## Overview

Exports the receipts from the executor in a bundled executor result with the header. This will allow the interop proof program to re-execute optimistic blocks and store the receipts root preimages out of band.