### PR TITLE
fix(client): Interop transition rules

### DIFF
--- a/bin/client/src/single.rs
+++ b/bin/client/src/single.rs
@@ -123,7 +123,7 @@ where
 
     // Run the derivation pipeline until we are able to produce the output root of the claimed
     // L2 block.
-    let (number, _, output_root) =
+    let (safe_head, output_root) =
         driver.advance_to_target(&boot.rollup_config, Some(boot.claimed_l2_block_number)).await?;
 
     ////////////////////////////////////////////////////////////////
@@ -134,7 +134,7 @@ where
         error!(
             target: "client",
             "Failed to validate L2 block #{number} with output root {output_root}",
-            number = number,
+            number = safe_head.block_info.number,
             output_root = output_root
         );
         return Err(FaultProofProgramError::InvalidClaim(output_root, boot.claimed_l2_output_root));
@@ -143,7 +143,7 @@ where
     info!(
         target: "client",
         "Successfully validated L2 block #{number} with output root {output_root}",
-        number = number,
+        number = safe_head.block_info.number,
         output_root = output_root
     );
 

--- a/crates/driver/src/core.rs
+++ b/crates/driver/src/core.rs
@@ -73,7 +73,7 @@ where
         &mut self,
         cfg: &RollupConfig,
         mut target: Option<u64>,
-    ) -> DriverResult<(u64, B256, B256), E::Error> {
+    ) -> DriverResult<(L2BlockInfo, B256), E::Error> {
         loop {
             // Check if we have reached the target block number.
             let pipeline_cursor = self.cursor.read();
@@ -81,11 +81,7 @@ where
             if let Some(tb) = target {
                 if tip_cursor.l2_safe_head.block_info.number >= tb {
                     info!(target: "client", "Derivation complete, reached L2 safe head.");
-                    return Ok((
-                        tip_cursor.l2_safe_head.block_info.number,
-                        tip_cursor.l2_safe_head.block_info.hash,
-                        tip_cursor.l2_safe_head_output_root,
-                    ));
+                    return Ok((tip_cursor.l2_safe_head, tip_cursor.l2_safe_head_output_root));
                 }
             }
 


### PR DESCRIPTION
## Overview

Small fix to the interop transition step, where:
1. No-op transitions were wrongfully rejected.
2. The validity of the claimed timestamp wasn't checked.