### PR TITLE
fix(executor): Withdrawals root

### DIFF
--- a/crates/executor/src/db/mod.rs
+++ b/crates/executor/src/db/mod.rs
@@ -174,10 +174,14 @@ where
     /// - `Ok(Some(TrieAccount))`: The [TrieAccount] of the account.
     /// - `Ok(None)`: If the account does not exist in the trie.
     /// - `Err(_)`: If the account could not be fetched.
-    pub fn get_trie_account(&mut self, address: &Address) -> TrieDBResult<Option<TrieAccount>> {
+    pub fn get_trie_account(
+        &mut self,
+        address: &Address,
+        block_number: u64,
+    ) -> TrieDBResult<Option<TrieAccount>> {
         // Send a hint to the host to fetch the account proof.
         self.hinter
-            .hint_account_proof(*address, self.parent_block_header.number)
+            .hint_account_proof(*address, block_number)
             .map_err(|e| TrieDBError::Provider(e.to_string()))?;
 
         // Fetch the account from the trie.
@@ -302,7 +306,9 @@ where
 
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         // Fetch the account from the trie.
-        let Some(trie_account) = self.get_trie_account(&address)? else {
+        let Some(trie_account) =
+            self.get_trie_account(&address, self.parent_block_header.number)?
+        else {
             // If the account does not exist in the trie, return `Ok(None)`.
             return Ok(None);
         };


### PR DESCRIPTION
## Overview

Fixes the withdrawals root feature of Isthmus. It's not currently enabled, but there was also a logic flaw where it fetched the L2ToL1MessagePasser's storage root for the parent block, not the current block.