### PR TITLE
feat(proof-interop): Support multiple `RollupConfigs` in boot routine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2662,6 +2662,7 @@ dependencies = [
  "async-trait",
  "op-alloy-consensus",
  "rand 0.9.0",
+ "serde",
  "thiserror 2.0.11",
  "tokio",
  "tracing",

--- a/bin/client/src/interop/transition.rs
+++ b/bin/client/src/interop/transition.rs
@@ -52,14 +52,8 @@ where
     let safe_head_hash = fetch_l2_safe_head_hash(oracle.as_ref(), &boot.agreed_pre_state).await?;
 
     // Determine the active L2 chain ID and the fetch rollup configuration.
-    let active_l2_chain_id = boot
-        .agreed_pre_state
-        .active_l2_chain_id()
-        .ok_or(FaultProofProgramError::StateTransitionFailed)?;
     let rollup_config = boot
-        .rollup_configs
-        .get(&active_l2_chain_id)
-        .cloned()
+        .active_rollup_config()
         .map(Arc::new)
         .ok_or(FaultProofProgramError::StateTransitionFailed)?;
 

--- a/bin/client/src/single.rs
+++ b/bin/client/src/single.rs
@@ -55,18 +55,13 @@ where
     ////////////////////////////////////////////////////////////////
 
     let oracle = Arc::new(CachingOracle::new(ORACLE_LRU_SIZE, oracle_client, hint_client));
-    let boot = match BootInfo::load(oracle.as_ref()).await {
-        Ok(boot) => Arc::new(boot),
-        Err(e) => {
-            error!(target: "client", "Failed to load boot info: {:?}", e);
-            return Err(e.into());
-        }
-    };
-    let safe_head_hash = fetch_safe_head_hash(oracle.as_ref(), boot.as_ref()).await?;
+    let boot = BootInfo::load(oracle.as_ref()).await?;
+    let rollup_config = Arc::new(boot.rollup_config);
+    let safe_head_hash = fetch_safe_head_hash(oracle.as_ref(), boot.agreed_l2_output_root).await?;
 
     let mut l1_provider = OracleL1ChainProvider::new(boot.l1_head, oracle.clone());
     let mut l2_provider =
-        OracleL2ChainProvider::new(safe_head_hash, boot.rollup_config.clone(), oracle.clone());
+        OracleL2ChainProvider::new(safe_head_hash, rollup_config.clone(), oracle.clone());
     let beacon = OracleBlobProvider::new(oracle.clone());
 
     // Fetch the safe head's block header.
@@ -105,26 +100,32 @@ where
 
     // Create a new derivation driver with the given boot information and oracle.
     let cursor =
-        new_pipeline_cursor(&boot.rollup_config, safe_head, &mut l1_provider, &mut l2_provider)
+        new_pipeline_cursor(rollup_config.as_ref(), safe_head, &mut l1_provider, &mut l2_provider)
             .await?;
     l2_provider.set_cursor(cursor.clone());
 
-    let cfg = Arc::new(boot.rollup_config.clone());
     let pipeline = OraclePipeline::new(
-        cfg.clone(),
+        rollup_config.clone(),
         cursor.clone(),
         oracle.clone(),
         beacon,
         l1_provider.clone(),
         l2_provider.clone(),
     );
-    let executor = KonaExecutor::new(&cfg, l2_provider.clone(), l2_provider, handle_register, None);
+    let executor = KonaExecutor::new(
+        rollup_config.as_ref(),
+        l2_provider.clone(),
+        l2_provider,
+        handle_register,
+        None,
+    );
     let mut driver = Driver::new(cursor, executor, pipeline);
 
     // Run the derivation pipeline until we are able to produce the output root of the claimed
     // L2 block.
-    let (safe_head, output_root) =
-        driver.advance_to_target(&boot.rollup_config, Some(boot.claimed_l2_block_number)).await?;
+    let (safe_head, output_root) = driver
+        .advance_to_target(rollup_config.as_ref(), Some(boot.claimed_l2_block_number))
+        .await?;
 
     ////////////////////////////////////////////////////////////////
     //                          EPILOGUE                          //
@@ -154,7 +155,7 @@ where
 /// [BootInfo].
 pub async fn fetch_safe_head_hash<O>(
     caching_oracle: &O,
-    boot_info: &BootInfo,
+    agreed_l2_output_root: B256,
 ) -> Result<B256, OracleProviderError>
 where
     O: CommsClient,
@@ -163,7 +164,7 @@ where
     HintType::StartingL2Output
         .get_exact_preimage(
             caching_oracle,
-            boot_info.agreed_l2_output_root,
+            agreed_l2_output_root,
             PreimageKeyType::Keccak256,
             &mut output_preimage,
         )

--- a/bin/host/src/interop/fetcher.rs
+++ b/bin/host/src/interop/fetcher.rs
@@ -687,7 +687,7 @@ where
                         let mut l1_provider = OracleL1ChainProvider::new(l1_head, oracle.clone());
                         let mut l2_provider = OracleL2ChainProvider::new(
                             agreed_block_hash,
-                            rollup_config.as_ref().clone(),
+                            rollup_config.clone(),
                             oracle.clone(),
                         );
                         let beacon = OracleBlobProvider::new(oracle.clone());

--- a/bin/host/src/interop/local_kv.rs
+++ b/bin/host/src/interop/local_kv.rs
@@ -7,9 +7,10 @@ use anyhow::Result;
 use kona_host::KeyValueStore;
 use kona_preimage::PreimageKey;
 use kona_proof_interop::boot::{
-    L1_HEAD_KEY, L2_AGREED_PRE_STATE_KEY, L2_CHAIN_ID_KEY, L2_CLAIMED_POST_STATE_KEY,
-    L2_CLAIMED_TIMESTAMP_KEY, L2_ROLLUP_CONFIG_KEY,
+    L1_HEAD_KEY, L2_AGREED_PRE_STATE_KEY, L2_CLAIMED_POST_STATE_KEY, L2_CLAIMED_TIMESTAMP_KEY,
+    L2_ROLLUP_CONFIG_KEY,
 };
+use maili_registry::HashMap;
 
 /// The default chain ID to use if none is provided.
 pub(crate) const DEFAULT_CHAIN_ID: u64 = 0xbeef_babe;
@@ -37,14 +38,11 @@ impl KeyValueStore for LocalKeyValueStore {
             }
             L2_CLAIMED_POST_STATE_KEY => Some(self.cfg.claimed_l2_post_state.to_vec()),
             L2_CLAIMED_TIMESTAMP_KEY => Some(self.cfg.claimed_l2_timestamp.to_be_bytes().to_vec()),
-            L2_CHAIN_ID_KEY => Some(self.cfg.active_l2_chain_id().ok()?.to_be_bytes().to_vec()),
             L2_ROLLUP_CONFIG_KEY => {
                 let rollup_configs = self.cfg.read_rollup_configs().ok()?;
-                let active_rollup_config = rollup_configs
-                    .get(&self.cfg.active_l2_chain_id().ok()?)
-                    .cloned()
-                    .unwrap_or_default();
-                let serialized = serde_json::to_vec(&active_rollup_config).ok()?;
+                let serialized =
+                    serde_json::to_vec(&rollup_configs.into_iter().collect::<HashMap<_, _>>())
+                        .ok()?;
                 Some(serialized)
             }
             _ => None,

--- a/bin/host/src/interop/local_kv.rs
+++ b/bin/host/src/interop/local_kv.rs
@@ -10,7 +10,6 @@ use kona_proof_interop::boot::{
     L1_HEAD_KEY, L2_AGREED_PRE_STATE_KEY, L2_CLAIMED_POST_STATE_KEY, L2_CLAIMED_TIMESTAMP_KEY,
     L2_ROLLUP_CONFIG_KEY,
 };
-use maili_registry::HashMap;
 
 /// The default chain ID to use if none is provided.
 pub(crate) const DEFAULT_CHAIN_ID: u64 = 0xbeef_babe;
@@ -40,10 +39,7 @@ impl KeyValueStore for LocalKeyValueStore {
             L2_CLAIMED_TIMESTAMP_KEY => Some(self.cfg.claimed_l2_timestamp.to_be_bytes().to_vec()),
             L2_ROLLUP_CONFIG_KEY => {
                 let rollup_configs = self.cfg.read_rollup_configs().ok()?;
-                let serialized =
-                    serde_json::to_vec(&rollup_configs.into_iter().collect::<HashMap<_, _>>())
-                        .ok()?;
-                Some(serialized)
+                serde_json::to_vec(&rollup_configs).ok()
             }
             _ => None,
         }

--- a/crates/interop/Cargo.toml
+++ b/crates/interop/Cargo.toml
@@ -27,6 +27,9 @@ op-alloy-consensus.workspace = true
 # Arbitrary
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 
+# Serde
+serde = { workspace = true, optional = true }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
 alloy-primitives = { workspace = true, features = ["rlp", "arbitrary"] }
@@ -35,3 +38,4 @@ rand.workspace = true
 
 [features]
 arbitrary = ["dep:arbitrary", "alloy-primitives/arbitrary"]
+serde = ["dep:serde", "alloy-primitives/serde"]

--- a/crates/interop/src/super_root.rs
+++ b/crates/interop/src/super_root.rs
@@ -13,6 +13,7 @@ use alloy_rlp::{Buf, BufMut};
 /// The [SuperRoot] is the snapshot of the superchain at a given timestamp.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(any(feature = "arbitrary", test), derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SuperRoot {
     /// The timestamp of the superchain snapshot, in seconds.
     pub timestamp: u64,
@@ -89,6 +90,7 @@ impl SuperRoot {
 /// A wrapper around an output root hash with the chain ID it belongs to.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(any(feature = "arbitrary", test), derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OutputRootWithChain {
     /// The chain ID of the output root.
     pub chain_id: u64,

--- a/crates/proof-sdk/proof-interop/Cargo.toml
+++ b/crates/proof-sdk/proof-interop/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 # Workspace
 kona-preimage.workspace = true
-kona-interop.workspace = true
+kona-interop = { workspace = true, features = ["serde"] }
 kona-proof.workspace = true
 kona-mpt.workspace = true
 

--- a/crates/proof-sdk/proof-interop/src/boot.rs
+++ b/crates/proof-sdk/proof-interop/src/boot.rs
@@ -127,6 +127,12 @@ impl BootInfo {
             claimed_l2_timestamp: l2_claim_block,
         })
     }
+
+    /// Returns the [RollupConfig] corresponding to the [PreState::active_l2_chain_id].
+    pub fn active_rollup_config(&self) -> Option<RollupConfig> {
+        let active_l2_chain_id = self.agreed_pre_state.active_l2_chain_id()?;
+        self.rollup_configs.get(&active_l2_chain_id).cloned()
+    }
 }
 
 /// Reads the raw pre-state from the preimage oracle.

--- a/crates/proof-sdk/proof-interop/src/boot.rs
+++ b/crates/proof-sdk/proof-interop/src/boot.rs
@@ -1,11 +1,17 @@
 //! This module contains the prologue phase of the client program, pulling in the boot information
 //! through the `PreimageOracle` ABI as local keys.
 
-use alloy_primitives::{B256, U256};
-use kona_preimage::{PreimageKey, PreimageOracleClient};
+use crate::{HintType, PreState};
+use alloc::{string::ToString, vec::Vec};
+use alloy_primitives::{Bytes, B256, U256};
+use alloy_rlp::Decodable;
+use kona_preimage::{
+    errors::PreimageOracleError, CommsClient, HintWriterClient, PreimageKey, PreimageKeyType,
+    PreimageOracleClient,
+};
 use kona_proof::errors::OracleProviderError;
 use maili_genesis::RollupConfig;
-use maili_registry::ROLLUP_CONFIGS;
+use maili_registry::{HashMap, ROLLUP_CONFIGS};
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
@@ -21,9 +27,6 @@ pub const L2_CLAIMED_POST_STATE_KEY: U256 = U256::from_be_slice(&[3]);
 /// The local key ident for the L2 claim timestamp.
 pub const L2_CLAIMED_TIMESTAMP_KEY: U256 = U256::from_be_slice(&[4]);
 
-/// The local key ident for the L2 chain ID.
-pub const L2_CHAIN_ID_KEY: U256 = U256::from_be_slice(&[5]);
-
 /// The local key ident for the L2 rollup config.
 pub const L2_ROLLUP_CONFIG_KEY: U256 = U256::from_be_slice(&[6]);
 
@@ -33,15 +36,15 @@ pub struct BootInfo {
     /// The L1 head hash containing the safe L2 chain data that may reproduce the post-state claim.
     pub l1_head: B256,
     /// The agreed upon superchain pre-state commitment.
-    pub agreed_pre_state: B256,
+    pub agreed_pre_state_commitment: B256,
+    /// The agreed upon superchain pre-state.
+    pub agreed_pre_state: PreState,
     /// The claimed (disputed) superchain post-state commitment.
     pub claimed_post_state: B256,
     /// The L2 claim timestamp.
     pub claimed_l2_timestamp: u64,
-    /// The L2 chain ID.
-    pub chain_id: u64,
     /// The rollup config for the L2 chain.
-    pub rollup_config: RollupConfig,
+    pub rollup_configs: HashMap<u64, RollupConfig>,
 }
 
 impl BootInfo {
@@ -55,7 +58,7 @@ impl BootInfo {
     /// - `Err(_)`: Failed to load the boot information.
     pub async fn load<O>(oracle: &O) -> Result<Self, OracleProviderError>
     where
-        O: PreimageOracleClient + Send,
+        O: PreimageOracleClient + HintWriterClient + Clone + Send,
     {
         let mut l1_head: B256 = B256::ZERO;
         oracle
@@ -84,25 +87,29 @@ impl BootInfo {
                 .try_into()
                 .map_err(OracleProviderError::SliceConversion)?,
         );
-        let chain_id = u64::from_be_bytes(
-            oracle
-                .get(PreimageKey::new_local(L2_CHAIN_ID_KEY.to()))
-                .await
-                .map_err(OracleProviderError::Preimage)?
-                .as_slice()
-                .try_into()
-                .map_err(OracleProviderError::SliceConversion)?,
-        );
+
+        let agreed_pre_state =
+            PreState::decode(&mut read_raw_pre_state(oracle, l2_pre).await?.as_ref())
+                .map_err(OracleProviderError::Rlp)?;
+
+        let chain_ids: Vec<_> = match agreed_pre_state {
+            PreState::SuperRoot(ref super_root) => {
+                super_root.output_roots.iter().map(|r| r.chain_id).collect()
+            }
+            PreState::TransitionState(ref transition_state) => {
+                transition_state.pre_state.output_roots.iter().map(|r| r.chain_id).collect()
+            }
+        };
 
         // Attempt to load the rollup config from the chain ID. If there is no config for the chain,
         // fall back to loading the config from the preimage oracle.
-        let rollup_config = if let Some(config) = ROLLUP_CONFIGS.get(&chain_id) {
-            config.clone()
+        let rollup_configs = if chain_ids.iter().all(|id| ROLLUP_CONFIGS.contains_key(id)) {
+            chain_ids.iter().map(|id| (*id, ROLLUP_CONFIGS[id].clone())).collect()
         } else {
             warn!(
                 target: "boot-loader",
-                "No rollup config found for chain ID {}, falling back to preimage oracle. This is insecure in production without additional validation!",
-                chain_id
+                "No rollup config found for chain IDs {:?}, falling back to preimage oracle. This is insecure in production without additional validation!",
+                chain_ids
             );
             let ser_cfg = oracle
                 .get(PreimageKey::new_local(L2_ROLLUP_CONFIG_KEY.to()))
@@ -113,11 +120,37 @@ impl BootInfo {
 
         Ok(Self {
             l1_head,
-            agreed_pre_state: l2_pre,
+            rollup_configs,
+            agreed_pre_state_commitment: l2_pre,
+            agreed_pre_state,
             claimed_post_state: l2_post,
             claimed_l2_timestamp: l2_claim_block,
-            chain_id,
-            rollup_config,
         })
     }
+}
+
+/// Reads the raw pre-state from the preimage oracle.
+pub(crate) async fn read_raw_pre_state<O>(
+    caching_oracle: &O,
+    agreed_pre_state_commitment: B256,
+) -> Result<Bytes, OracleProviderError>
+where
+    O: CommsClient,
+{
+    caching_oracle
+        .write(&HintType::AgreedPreState.encode_with(&[agreed_pre_state_commitment.as_ref()]))
+        .await
+        .map_err(OracleProviderError::Preimage)?;
+    let pre = caching_oracle
+        .get(PreimageKey::new(*agreed_pre_state_commitment, PreimageKeyType::Keccak256))
+        .await
+        .map_err(OracleProviderError::Preimage)?;
+
+    if pre.is_empty() {
+        return Err(OracleProviderError::Preimage(PreimageOracleError::Other(
+            "Invalid pre-state preimage".to_string(),
+        )));
+    }
+
+    Ok(Bytes::from(pre))
 }

--- a/crates/proof-sdk/proof/src/l2/chain_provider.rs
+++ b/crates/proof-sdk/proof/src/l2/chain_provider.rs
@@ -23,7 +23,7 @@ pub struct OracleL2ChainProvider<T: CommsClient> {
     /// The L2 safe head block hash.
     l2_head: B256,
     /// The rollup configuration.
-    rollup_config: RollupConfig,
+    rollup_config: Arc<RollupConfig>,
     /// The preimage oracle client.
     oracle: Arc<T>,
     /// The derivation pipeline cursor
@@ -32,7 +32,7 @@ pub struct OracleL2ChainProvider<T: CommsClient> {
 
 impl<T: CommsClient> OracleL2ChainProvider<T> {
     /// Creates a new [OracleL2ChainProvider] with the given boot information and oracle client.
-    pub const fn new(l2_head: B256, rollup_config: RollupConfig, oracle: Arc<T>) -> Self {
+    pub const fn new(l2_head: B256, rollup_config: Arc<RollupConfig>, oracle: Arc<T>) -> Self {
         Self { l2_head, rollup_config, oracle, cursor: None }
     }
 


### PR DESCRIPTION
## Overview

Adds support for loading multiple `RollupConfig`s into the client program during the boot routine.

closes https://github.com/op-rs/kona/issues/985