### PR TITLE
feat(proof-sdk): Cleanup `Hint` API

### DIFF
--- a/bin/client/src/interop/util.rs
+++ b/bin/client/src/interop/util.rs
@@ -30,13 +30,13 @@ where
         }
     };
 
-    caching_oracle
-        .write(&HintType::L2OutputRoot.encode_with(&[
+    HintType::L2OutputRoot
+        .with_data(&[
             rich_output.output_root.as_slice(),
             rich_output.chain_id.to_be_bytes().as_slice(),
-        ]))
-        .await
-        .map_err(OracleProviderError::Preimage)?;
+        ])
+        .send(caching_oracle)
+        .await?;
     let output_preimage = caching_oracle
         .get(PreimageKey::new(*rich_output.output_root, PreimageKeyType::Keccak256))
         .await

--- a/bin/client/src/precompiles/bls12.rs
+++ b/bin/client/src/precompiles/bls12.rs
@@ -10,8 +10,7 @@ use crate::{HINT_WRITER, ORACLE_READER};
 use alloc::{string::ToString, vec::Vec};
 use alloy_primitives::{address, keccak256, Address, Bytes};
 use kona_preimage::{
-    errors::PreimageOracleError, HintWriterClient, PreimageKey, PreimageKeyType,
-    PreimageOracleClient,
+    errors::PreimageOracleError, PreimageKey, PreimageKeyType, PreimageOracleClient,
 };
 use kona_proof::{errors::OracleProviderError, HintType};
 use revm::{
@@ -57,10 +56,7 @@ fn fpvm_bls12_pairing(input: &Bytes, gas_limit: u64) -> PrecompileResult {
     let result_data = kona_proof::block_on(async move {
         // Write the hint for the ecrecover precompile run.
         let hint_data = &[BLS12_PAIRING_CHECK.as_ref(), input.as_ref()];
-        HINT_WRITER
-            .write(&HintType::L1Precompile.encode_with(hint_data))
-            .await
-            .map_err(OracleProviderError::Preimage)?;
+        HintType::L1Precompile.with_data(hint_data).send(&HINT_WRITER).await?;
 
         // Construct the key hash for the ecrecover precompile run.
         let raw_key_data = hint_data.iter().copied().flatten().copied().collect::<Vec<u8>>();

--- a/bin/client/src/precompiles/bn128_pair.rs
+++ b/bin/client/src/precompiles/bn128_pair.rs
@@ -4,8 +4,7 @@ use crate::{HINT_WRITER, ORACLE_READER};
 use alloc::{string::ToString, vec::Vec};
 use alloy_primitives::{keccak256, Address, Bytes};
 use kona_preimage::{
-    errors::PreimageOracleError, HintWriterClient, PreimageKey, PreimageKeyType,
-    PreimageOracleClient,
+    errors::PreimageOracleError, PreimageKey, PreimageKeyType, PreimageOracleClient,
 };
 use kona_proof::{errors::OracleProviderError, HintType};
 use revm::{
@@ -41,10 +40,7 @@ fn fpvm_ecpairing(input: &Bytes, gas_limit: u64) -> PrecompileResult {
     let result_data = kona_proof::block_on(async move {
         // Write the hint for the ecrecover precompile run.
         let hint_data = &[ECPAIRING_ADDRESS.as_ref(), input.as_ref()];
-        HINT_WRITER
-            .write(&HintType::L1Precompile.encode_with(hint_data))
-            .await
-            .map_err(OracleProviderError::Preimage)?;
+        HintType::L1Precompile.with_data(hint_data).send(&HINT_WRITER).await?;
 
         // Construct the key hash for the ecrecover precompile run.
         let raw_key_data = hint_data.iter().copied().flatten().copied().collect::<Vec<u8>>();

--- a/bin/client/src/precompiles/ecrecover.rs
+++ b/bin/client/src/precompiles/ecrecover.rs
@@ -4,8 +4,7 @@ use crate::{HINT_WRITER, ORACLE_READER};
 use alloc::{string::ToString, vec::Vec};
 use alloy_primitives::{keccak256, Address, Bytes};
 use kona_preimage::{
-    errors::PreimageOracleError, HintWriterClient, PreimageKey, PreimageKeyType,
-    PreimageOracleClient,
+    errors::PreimageOracleError, PreimageKey, PreimageKeyType, PreimageOracleClient,
 };
 use kona_proof::{errors::OracleProviderError, HintType};
 use revm::{
@@ -29,10 +28,7 @@ fn fpvm_ecrecover(input: &Bytes, gas_limit: u64) -> PrecompileResult {
     let result_data = kona_proof::block_on(async move {
         // Write the hint for the ecrecover precompile run.
         let hint_data = &[ECRECOVER_ADDRESS.as_ref(), input.as_ref()];
-        HINT_WRITER
-            .write(&HintType::L1Precompile.encode_with(hint_data))
-            .await
-            .map_err(OracleProviderError::Preimage)?;
+        HintType::L1Precompile.with_data(hint_data).send(&HINT_WRITER).await?;
 
         // Construct the key hash for the ecrecover precompile run.
         let raw_key_data = hint_data.iter().copied().flatten().copied().collect::<Vec<u8>>();

--- a/bin/client/src/precompiles/kzg_point_eval.rs
+++ b/bin/client/src/precompiles/kzg_point_eval.rs
@@ -4,8 +4,7 @@ use crate::{HINT_WRITER, ORACLE_READER};
 use alloc::{string::ToString, vec::Vec};
 use alloy_primitives::{keccak256, Address, Bytes};
 use kona_preimage::{
-    errors::PreimageOracleError, HintWriterClient, PreimageKey, PreimageKeyType,
-    PreimageOracleClient,
+    errors::PreimageOracleError, PreimageKey, PreimageKeyType, PreimageOracleClient,
 };
 use kona_proof::{errors::OracleProviderError, HintType};
 use revm::{
@@ -33,10 +32,7 @@ fn fpvm_kzg_point_eval(input: &Bytes, gas_limit: u64) -> PrecompileResult {
     let result_data = kona_proof::block_on(async move {
         // Write the hint for the ecrecover precompile run.
         let hint_data = &[POINT_EVAL_ADDRESS.as_ref(), input.as_ref()];
-        HINT_WRITER
-            .write(&HintType::L1Precompile.encode_with(hint_data))
-            .await
-            .map_err(OracleProviderError::Preimage)?;
+        HintType::L1Precompile.with_data(hint_data).send(&HINT_WRITER).await?;
 
         // Construct the key hash for the ecrecover precompile run.
         let raw_key_data = hint_data.iter().copied().flatten().copied().collect::<Vec<u8>>();

--- a/crates/proof-sdk/proof-interop/src/boot.rs
+++ b/crates/proof-sdk/proof-interop/src/boot.rs
@@ -143,10 +143,10 @@ pub(crate) async fn read_raw_pre_state<O>(
 where
     O: CommsClient,
 {
-    caching_oracle
-        .write(&HintType::AgreedPreState.encode_with(&[agreed_pre_state_commitment.as_ref()]))
-        .await
-        .map_err(OracleProviderError::Preimage)?;
+    HintType::AgreedPreState
+        .with_data(&[agreed_pre_state_commitment.as_ref()])
+        .send(caching_oracle)
+        .await?;
     let pre = caching_oracle
         .get(PreimageKey::new(*agreed_pre_state_commitment, PreimageKeyType::Keccak256))
         .await

--- a/crates/proof-sdk/proof-interop/src/hint.rs
+++ b/crates/proof-sdk/proof-interop/src/hint.rs
@@ -1,12 +1,8 @@
 //! This module contains the [HintType] enum.
 
-use alloc::{
-    string::{String, ToString},
-    vec::Vec,
-};
-use alloy_primitives::hex;
+use alloc::{string::ToString, vec::Vec};
 use core::{fmt::Display, str::FromStr};
-use kona_proof::errors::HintParsingError;
+use kona_proof::{errors::HintParsingError, Hint};
 
 /// The [HintType] enum is used to specify the type of hint that was received.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -46,10 +42,15 @@ pub enum HintType {
 }
 
 impl HintType {
-    /// Encodes the hint type as a string.
-    pub fn encode_with(&self, data: &[&[u8]]) -> String {
-        let concatenated = hex::encode(data.iter().copied().flatten().copied().collect::<Vec<_>>());
-        alloc::format!("{} {}", self, concatenated)
+    /// Creates a new [Hint] from `self` and the specified data. The data passed will be
+    /// concatenated into a single byte array before being stored in the resulting [Hint].
+    pub fn with_data(self, data: &[&[u8]]) -> Hint<Self> {
+        let total_len = data.iter().map(|d| d.len()).sum();
+        let hint_data = data.iter().fold(Vec::with_capacity(total_len), |mut acc, d| {
+            acc.extend_from_slice(d);
+            acc
+        });
+        Hint::new(self, hint_data)
     }
 }
 

--- a/crates/proof-sdk/proof/src/hint.rs
+++ b/crates/proof-sdk/proof/src/hint.rs
@@ -34,7 +34,7 @@ where
         (self.ty, self.data)
     }
 
-    /// Sends the hint to the passed [CommsClient].
+    /// Sends the hint to the passed [HintWriterClient].
     pub async fn send<T: HintWriterClient>(&self, comms: &T) -> Result<(), OracleProviderError> {
         comms.write(&self.encode()).await.map_err(OracleProviderError::Preimage)
     }
@@ -100,7 +100,7 @@ pub enum HintType {
 }
 
 impl HintType {
-    /// Creates a new [Hint] from [self] and the specified data. The data passed will be
+    /// Creates a new [Hint] from `self` and the specified data. The data passed will be
     /// concatenated into a single byte array before being stored in the resulting [Hint].
     pub fn with_data(self, data: &[&[u8]]) -> Hint<Self> {
         let total_len = data.iter().map(|d| d.len()).sum();

--- a/crates/proof-sdk/proof/src/hint.rs
+++ b/crates/proof-sdk/proof/src/hint.rs
@@ -5,9 +5,9 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use alloy_primitives::{hex, Bytes, B256};
+use alloy_primitives::{hex, Bytes};
 use core::{fmt::Display, str::FromStr};
-use kona_preimage::{CommsClient, PreimageKey, PreimageKeyType};
+use kona_preimage::HintWriterClient;
 
 /// A [Hint] is parsed in the format `<hint_type> <hint_data>`, where `<hint_type>` is a string that
 /// represents the type of hint, and `<hint_data>` is the data associated with the hint (bytes
@@ -15,15 +15,33 @@ use kona_preimage::{CommsClient, PreimageKey, PreimageKeyType};
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Hint<HT> {
     /// The type of hint.
-    pub hint_type: HT,
+    pub ty: HT,
     /// The data associated with the hint.
-    pub hint_data: Bytes,
+    pub data: Bytes,
 }
 
-impl<HT> Hint<HT> {
+impl<HT> Hint<HT>
+where
+    HT: Display,
+{
+    /// Creates a new [Hint] with the specified type and data.
+    pub fn new<T: Into<Bytes>>(ty: HT, data: T) -> Self {
+        Self { ty, data: data.into() }
+    }
+
     /// Splits the [Hint] into its components.
     pub fn split(self) -> (HT, Bytes) {
-        (self.hint_type, self.hint_data)
+        (self.ty, self.data)
+    }
+
+    /// Sends the hint to the passed [CommsClient].
+    pub async fn send<T: HintWriterClient>(&self, comms: &T) -> Result<(), OracleProviderError> {
+        comms.write(&self.encode()).await.map_err(OracleProviderError::Preimage)
+    }
+
+    /// Encodes the hint as a string.
+    pub fn encode(&self) -> String {
+        alloc::format!("{} {}", self.ty, self.data)
     }
 }
 
@@ -44,7 +62,7 @@ where
         let hint_data =
             hex::decode(parts.remove(0)).map_err(|e| HintParsingError(e.to_string()))?.into();
 
-        Ok(Self { hint_type, hint_data })
+        Ok(Self { ty: hint_type, data: hint_data })
     }
 }
 
@@ -82,45 +100,15 @@ pub enum HintType {
 }
 
 impl HintType {
-    /// Encodes the hint type as a string.
-    pub fn encode_with(&self, data: &[&[u8]]) -> String {
-        let concatenated = hex::encode(data.iter().copied().flatten().copied().collect::<Vec<_>>());
-        alloc::format!("{} {}", self, concatenated)
-    }
-
-    /// Retrieves a preimage through an oracle
-    pub async fn get_preimage<T: CommsClient>(
-        &self,
-        oracle: &T,
-        image: B256,
-        preimage_key_type: PreimageKeyType,
-    ) -> Result<Vec<u8>, OracleProviderError> {
-        oracle
-            .write(&self.encode_with(&[image.as_ref()]))
-            .await
-            .map_err(OracleProviderError::Preimage)?;
-        oracle
-            .get(PreimageKey::new(*image, preimage_key_type))
-            .await
-            .map_err(OracleProviderError::Preimage)
-    }
-
-    /// Retrieves a preimage through an oracle
-    pub async fn get_exact_preimage<T: CommsClient>(
-        &self,
-        oracle: &T,
-        image: B256,
-        preimage_key_type: PreimageKeyType,
-        buf: &mut [u8],
-    ) -> Result<(), OracleProviderError> {
-        oracle
-            .write(&self.encode_with(&[image.as_ref()]))
-            .await
-            .map_err(OracleProviderError::Preimage)?;
-        oracle
-            .get_exact(PreimageKey::new(*image, preimage_key_type), buf)
-            .await
-            .map_err(OracleProviderError::Preimage)
+    /// Creates a new [Hint] from [self] and the specified data. The data passed will be
+    /// concatenated into a single byte array before being stored in the resulting [Hint].
+    pub fn with_data(self, data: &[&[u8]]) -> Hint<Self> {
+        let total_len = data.iter().map(|d| d.len()).sum();
+        let hint_data = data.iter().fold(Vec::with_capacity(total_len), |mut acc, d| {
+            acc.extend_from_slice(d);
+            acc
+        });
+        Hint::new(self, hint_data)
     }
 }
 

--- a/crates/proof-sdk/proof/src/l1/blob_provider.rs
+++ b/crates/proof-sdk/proof/src/l1/blob_provider.rs
@@ -42,10 +42,7 @@ impl<T: CommsClient> OracleBlobProvider<T> {
         blob_req_meta[40..48].copy_from_slice(block_ref.timestamp.to_be_bytes().as_ref());
 
         // Send a hint for the blob commitment and field elements.
-        self.oracle
-            .write(&HintType::L1Blob.encode_with(&[blob_req_meta.as_ref()]))
-            .await
-            .map_err(OracleProviderError::Preimage)?;
+        HintType::L1Blob.with_data(&[blob_req_meta.as_ref()]).send(self.oracle.as_ref()).await?;
 
         // Fetch the blob commitment.
         let mut commitment = [0u8; 48];


### PR DESCRIPTION
## Overview

Cleans up the hint sending API to allow for a nice builder pattern, over the previous method of constructing the raw encoded hint and sending it directly to the `HintWriterClient`.

**Old**:

```rs
self.oracle
    .write(&HintType::L2AccountStorageProof.encode_with(&[
        block_number.to_be_bytes().as_ref(),
        address.as_slice(),
        slot.to_be_bytes::<32>().as_ref(),
    ]))
    .await
    .map_err(OracleProviderError::Preimage)
```

**New**:

```rs
HintType::L2AccountStorageProof
    .with_data(&[
        block_number.to_be_bytes().as_ref(),
        address.as_slice(),
        slot.to_be_bytes::<32>().as_ref(),
    ])
    .send(self.oracle.as_ref())
    .await
````