### PR TITLE
feat(proof-sdk): Optional L2 chain ID in L2-specific hints

### DIFF
--- a/bin/client/src/interop/transition.rs
+++ b/bin/client/src/interop/transition.rs
@@ -63,6 +63,9 @@ where
         OracleL2ChainProvider::new(safe_head_hash, rollup_config.clone(), oracle.clone());
     let beacon = OracleBlobProvider::new(oracle.clone());
 
+    // Set the active L2 chain ID for the L2 provider.
+    l2_provider.set_chain_id(boot.agreed_pre_state.active_l2_chain_id());
+
     // Fetch the safe head's block header.
     let safe_head = l2_provider
         .header_by_hash(safe_head_hash)

--- a/bin/host/src/interop/cfg.rs
+++ b/bin/host/src/interop/cfg.rs
@@ -180,32 +180,6 @@ impl InteropHost {
             self.data_dir.is_some()
     }
 
-    /// Returns the active L2 chain ID based on the agreed L2 pre-state.
-    pub fn active_l2_chain_id(&self) -> Result<u64> {
-        let pre_state = match PreState::decode(&mut self.agreed_l2_pre_state.as_ref()) {
-            Ok(pre_state) => pre_state,
-            // If the pre-state is invalid, return a dummy chain ID.
-            Err(_) => return Ok(0),
-        };
-
-        match pre_state {
-            PreState::SuperRoot(super_root) => Ok(super_root
-                .output_roots
-                .first()
-                .ok_or(anyhow!("output roots are empty"))?
-                .chain_id),
-            PreState::TransitionState(transition_state) => Ok(transition_state
-                .pre_state
-                .output_roots
-                .get(
-                    (transition_state.step as usize)
-                        .min(transition_state.pre_state.output_roots.len() - 1),
-                )
-                .ok_or(anyhow!("no output root found"))?
-                .chain_id),
-        }
-    }
-
     /// Reads the [RollupConfig]s from the file system and returns a map of L2 chain ID ->
     /// [RollupConfig]s.
     pub fn read_rollup_configs(&self) -> Result<HashMap<u64, RollupConfig>> {

--- a/bin/host/src/interop/cfg.rs
+++ b/bin/host/src/interop/cfg.rs
@@ -12,14 +12,13 @@ use crate::{
 };
 use alloy_primitives::{Bytes, B256};
 use alloy_provider::{Provider, RootProvider};
-use alloy_rlp::Decodable;
 use anyhow::{anyhow, Result};
 use clap::Parser;
 use kona_preimage::{
     BidirectionalChannel, Channel, HintReader, HintWriter, OracleReader, OracleServer,
 };
 use kona_proof::Hint;
-use kona_proof_interop::{HintType, PreState};
+use kona_proof_interop::HintType;
 use kona_providers_alloy::{OnlineBeaconClient, OnlineBlobProvider};
 use kona_std_fpvm::{FileChannel, FileDescriptor};
 use maili_genesis::RollupConfig;
@@ -39,8 +38,7 @@ pub struct InteropHost {
     /// L1 chain.
     #[clap(long, value_parser = parse_b256, env)]
     pub l1_head: B256,
-    /// Agreed [PreState] to start from. Can be a [PreState::SuperRoot] or
-    /// [PreState::TransitionState].
+    /// Agreed [PreState] to start from.
     ///
     /// [PreState]: kona_proof_interop::PreState
     #[clap(long, visible_alias = "l2-pre-state", value_parser = parse_bytes, env)]

--- a/bin/host/src/interop/handler.rs
+++ b/bin/host/src/interop/handler.rs
@@ -233,14 +233,10 @@ impl HintHandler for InteropHintHandler {
                 kv_lock.set(PreimageKey::new_keccak256(*output_root).into(), raw_output.into())?;
             }
             HintType::L2BlockHeader => {
-                ensure!(hint.data.len() >= 32 && hint.data.len() <= 40, "Invalid hint data length");
+                ensure!(hint.data.len() == 40, "Invalid hint data length");
 
                 let hash: B256 = hint.data.as_ref()[..32].try_into()?;
-                let chain_id = if hint.data.len() == 40 {
-                    u64::from_be_bytes(hint.data[32..40].try_into()?)
-                } else {
-                    cfg.active_l2_chain_id()?
-                };
+                let chain_id = u64::from_be_bytes(hint.data[32..40].try_into()?);
 
                 let raw_header: Bytes =
                     providers.l2(&chain_id)?.client().request("debug_getRawHeader", [hash]).await?;
@@ -249,14 +245,10 @@ impl HintHandler for InteropHintHandler {
                 kv_lock.set(PreimageKey::new_keccak256(*hash).into(), raw_header.into())?;
             }
             HintType::L2Transactions => {
-                ensure!(hint.data.len() >= 32 && hint.data.len() <= 40, "Invalid hint data length");
+                ensure!(hint.data.len() == 40, "Invalid hint data length");
 
                 let hash: B256 = hint.data.as_ref()[..32].try_into()?;
-                let chain_id = if hint.data.len() == 40 {
-                    u64::from_be_bytes(hint.data[32..40].try_into()?)
-                } else {
-                    cfg.active_l2_chain_id()?
-                };
+                let chain_id = u64::from_be_bytes(hint.data[32..40].try_into()?);
 
                 let Block { transactions, .. } = providers
                     .l2(&chain_id)?
@@ -271,14 +263,10 @@ impl HintHandler for InteropHintHandler {
                 store_ordered_trie(kv.as_ref(), encoded_transactions.as_slice()).await?;
             }
             HintType::L2Receipts => {
-                ensure!(hint.data.len() >= 32 && hint.data.len() <= 40, "Invalid hint data length");
+                ensure!(hint.data.len() == 40, "Invalid hint data length");
 
                 let hash: B256 = hint.data.as_ref()[..32].try_into()?;
-                let chain_id = if hint.data.len() == 40 {
-                    u64::from_be_bytes(hint.data[32..40].try_into()?)
-                } else {
-                    cfg.active_l2_chain_id()?
-                };
+                let chain_id = u64::from_be_bytes(hint.data[32..40].try_into()?);
 
                 let raw_receipts: Vec<Bytes> = providers
                     .l2(&chain_id)?
@@ -292,14 +280,10 @@ impl HintHandler for InteropHintHandler {
                 // geth hashdb scheme code hash key prefix
                 const CODE_PREFIX: u8 = b'c';
 
-                ensure!(hint.data.len() >= 32 && hint.data.len() <= 40, "Invalid hint data length");
+                ensure!(hint.data.len() == 40, "Invalid hint data length");
 
                 let hash: B256 = hint.data[..32].as_ref().try_into()?;
-                let chain_id = if hint.data.len() == 40 {
-                    u64::from_be_bytes(hint.data[32..40].try_into()?)
-                } else {
-                    cfg.active_l2_chain_id()?
-                };
+                let chain_id = u64::from_be_bytes(hint.data[32..40].try_into()?);
                 let l2_provider = providers.l2(&chain_id)?;
 
                 // Attempt to fetch the code from the L2 chain provider.
@@ -324,14 +308,10 @@ impl HintHandler for InteropHintHandler {
                 kv_lock.set(PreimageKey::new_keccak256(*hash).into(), code.into())?;
             }
             HintType::L2StateNode => {
-                ensure!(hint.data.len() >= 32 && hint.data.len() <= 40, "Invalid hint data length");
+                ensure!(hint.data.len() == 40, "Invalid hint data length");
 
                 let hash: B256 = hint.data.as_ref().try_into()?;
-                let chain_id = if hint.data.len() == 40 {
-                    u64::from_be_bytes(hint.data[32..40].try_into()?)
-                } else {
-                    cfg.active_l2_chain_id()?
-                };
+                let chain_id = u64::from_be_bytes(hint.data[32..40].try_into()?);
 
                 // Fetch the preimage from the L2 chain provider.
                 let preimage: Bytes =
@@ -341,18 +321,11 @@ impl HintHandler for InteropHintHandler {
                 kv_write_lock.set(PreimageKey::new_keccak256(*hash).into(), preimage.into())?;
             }
             HintType::L2AccountProof => {
-                ensure!(
-                    hint.data.len() >= 8 + 20 && hint.data.len() <= 8 + 20 + 8,
-                    "Invalid hint data length"
-                );
+                ensure!(hint.data.len() == 8 + 20 + 8, "Invalid hint data length");
 
                 let block_number = u64::from_be_bytes(hint.data.as_ref()[..8].try_into()?);
                 let address = Address::from_slice(&hint.data.as_ref()[8..28]);
-                let chain_id = if hint.data.len() == 8 + 20 + 8 {
-                    u64::from_be_bytes(hint.data[28..].try_into()?)
-                } else {
-                    cfg.active_l2_chain_id()?
-                };
+                let chain_id = u64::from_be_bytes(hint.data[28..].try_into()?);
 
                 let proof_response = providers
                     .l2(&chain_id)?
@@ -370,19 +343,12 @@ impl HintHandler for InteropHintHandler {
                 })?;
             }
             HintType::L2AccountStorageProof => {
-                ensure!(
-                    hint.data.len() >= 8 + 20 + 32 && hint.data.len() <= 8 + 20 + 32 + 8,
-                    "Invalid hint data length"
-                );
+                ensure!(hint.data.len() == 8 + 20 + 32 + 8, "Invalid hint data length");
 
                 let block_number = u64::from_be_bytes(hint.data.as_ref()[..8].try_into()?);
                 let address = Address::from_slice(&hint.data.as_ref()[8..28]);
                 let slot = B256::from_slice(&hint.data.as_ref()[28..]);
-                let chain_id = if hint.data.len() == 8 + 20 + 32 + 8 {
-                    u64::from_be_bytes(hint.data[60..].try_into()?)
-                } else {
-                    cfg.active_l2_chain_id()?
-                };
+                let chain_id = u64::from_be_bytes(hint.data[60..].try_into()?);
 
                 let mut proof_response = providers
                     .l2(&chain_id)?

--- a/crates/proof-sdk/proof/src/hint.rs
+++ b/crates/proof-sdk/proof/src/hint.rs
@@ -34,6 +34,20 @@ where
         (self.ty, self.data)
     }
 
+    /// Appends more data to [Hint::data].
+    pub fn with_data<T: AsRef<[u8]>>(self, data: T) -> Self {
+        // No-op if the data is empty.
+        if data.as_ref().is_empty() {
+            return self;
+        }
+
+        let mut hint_data = Vec::with_capacity(self.data.len() + data.as_ref().len());
+        hint_data[..self.data.len()].copy_from_slice(self.data.as_ref());
+        hint_data[self.data.len()..].copy_from_slice(data.as_ref());
+
+        Self { data: hint_data.into(), ..self }
+    }
+
     /// Sends the hint to the passed [HintWriterClient].
     pub async fn send<T: HintWriterClient>(&self, comms: &T) -> Result<(), OracleProviderError> {
         comms.write(&self.encode()).await.map_err(OracleProviderError::Preimage)

--- a/crates/proof-sdk/proof/src/l2/chain_provider.rs
+++ b/crates/proof-sdk/proof/src/l2/chain_provider.rs
@@ -39,7 +39,7 @@ impl<T: CommsClient> OracleL2ChainProvider<T> {
     }
 
     /// Sets the L2 chain ID to use for the provider's hints.
-    pub fn set_chain_id(&mut self, chain_id: Option<u64>) {
+    pub const fn set_chain_id(&mut self, chain_id: Option<u64>) {
         self.chain_id = chain_id;
     }
 

--- a/crates/proof-sdk/proof/src/l2/chain_provider.rs
+++ b/crates/proof-sdk/proof/src/l2/chain_provider.rs
@@ -28,12 +28,19 @@ pub struct OracleL2ChainProvider<T: CommsClient> {
     oracle: Arc<T>,
     /// The derivation pipeline cursor
     cursor: Option<Arc<RwLock<PipelineCursor>>>,
+    /// The L2 chain ID to use for the provider's hints.
+    chain_id: Option<u64>,
 }
 
 impl<T: CommsClient> OracleL2ChainProvider<T> {
     /// Creates a new [OracleL2ChainProvider] with the given boot information and oracle client.
     pub const fn new(l2_head: B256, rollup_config: Arc<RollupConfig>, oracle: Arc<T>) -> Self {
-        Self { l2_head, rollup_config, oracle, cursor: None }
+        Self { l2_head, rollup_config, oracle, cursor: None, chain_id: None }
+    }
+
+    /// Sets the L2 chain ID to use for the provider's hints.
+    pub fn set_chain_id(&mut self, chain_id: Option<u64>) {
+        self.chain_id = chain_id;
     }
 
     /// Updates the derivation pipeline cursor
@@ -93,6 +100,7 @@ impl<T: CommsClient + Send + Sync> BatchValidationProvider for OracleL2ChainProv
         // Fetch the transactions in the block.
         HintType::L2Transactions
             .with_data(&[header_hash.as_ref()])
+            .with_data(self.chain_id.map_or_else(Vec::new, |id| id.to_be_bytes().to_vec()))
             .send(self.oracle.as_ref())
             .await?;
         let trie_walker = OrderedListWalker::try_new_hydrated(transactions_root, self)
@@ -165,7 +173,11 @@ impl<T: CommsClient> TrieDBProvider for OracleL2ChainProvider<T> {
     fn bytecode_by_hash(&self, hash: B256) -> Result<Bytes, OracleProviderError> {
         // Fetch the bytecode preimage from the caching oracle.
         crate::block_on(async move {
-            HintType::L2Code.with_data(&[hash.as_slice()]).send(self.oracle.as_ref()).await?;
+            HintType::L2Code
+                .with_data(&[hash.as_slice()])
+                .with_data(self.chain_id.map_or_else(Vec::new, |id| id.to_be_bytes().to_vec()))
+                .send(self.oracle.as_ref())
+                .await?;
             self.oracle
                 .get(PreimageKey::new_keccak256(*hash))
                 .await
@@ -179,6 +191,7 @@ impl<T: CommsClient> TrieDBProvider for OracleL2ChainProvider<T> {
         crate::block_on(async move {
             HintType::L2BlockHeader
                 .with_data(&[hash.as_slice()])
+                .with_data(self.chain_id.map_or_else(Vec::new, |id| id.to_be_bytes().to_vec()))
                 .send(self.oracle.as_ref())
                 .await?;
             let header_bytes = self.oracle.get(PreimageKey::new_keccak256(*hash)).await?;
@@ -193,7 +206,11 @@ impl<T: CommsClient> TrieHinter for OracleL2ChainProvider<T> {
 
     fn hint_trie_node(&self, hash: B256) -> Result<(), Self::Error> {
         crate::block_on(async move {
-            HintType::L2StateNode.with_data(&[hash.as_slice()]).send(self.oracle.as_ref()).await
+            HintType::L2StateNode
+                .with_data(&[hash.as_slice()])
+                .with_data(self.chain_id.map_or_else(Vec::new, |id| id.to_be_bytes().to_vec()))
+                .send(self.oracle.as_ref())
+                .await
         })
     }
 
@@ -201,6 +218,7 @@ impl<T: CommsClient> TrieHinter for OracleL2ChainProvider<T> {
         crate::block_on(async move {
             HintType::L2AccountProof
                 .with_data(&[block_number.to_be_bytes().as_ref(), address.as_slice()])
+                .with_data(self.chain_id.map_or_else(Vec::new, |id| id.to_be_bytes().to_vec()))
                 .send(self.oracle.as_ref())
                 .await
         })
@@ -219,6 +237,7 @@ impl<T: CommsClient> TrieHinter for OracleL2ChainProvider<T> {
                     address.as_slice(),
                     slot.to_be_bytes::<32>().as_ref(),
                 ])
+                .with_data(self.chain_id.map_or_else(Vec::new, |id| id.to_be_bytes().to_vec()))
                 .send(self.oracle.as_ref())
                 .await
         })


### PR DESCRIPTION
## Overview

Adds support for the client program optionally sending an L2 chain ID with hints to specify which L2 provider to use.

closes https://github.com/op-rs/kona/issues/987