### PR TITLE
feat(host): Reintroduce `L2BlockData` hint

### DIFF
--- a/bin/host/src/interop/cfg.rs
+++ b/bin/host/src/interop/cfg.rs
@@ -248,7 +248,7 @@ impl OnlineHostBackendCfg for InteropHost {
 }
 
 /// The providers required for the single chain host.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct InteropProviders {
     /// The L1 EL provider.
     pub l1: RootProvider,


### PR DESCRIPTION
## Overview

Reintroduces the `L2BlockData` hint to the interop host. This was removed temporarily during the refactor, but is now supported by the L2 chain ID in all hints feature.