### PR TITLE
fix(client): No-op sub-transitions in Superchain STF

### DIFF
--- a/bin/client/src/interop/mod.rs
+++ b/bin/client/src/interop/mod.rs
@@ -78,6 +78,12 @@ where
         }
     };
 
+    // Short-circuit the state transition if the agreed pre-state matches the claimed post-state.
+    if boot.agreed_pre_state_commitment == boot.claimed_post_state {
+        info!(target: "client_interop", "No-op transition, short-circuiting.");
+        return Ok(());
+    }
+
     // Load in the agreed pre-state from the preimage oracle in order to determine the active
     // sub-problem.
     match boot.agreed_pre_state {

--- a/bin/client/src/interop/mod.rs
+++ b/bin/client/src/interop/mod.rs
@@ -68,7 +68,7 @@ where
     let oracle = Arc::new(CachingOracle::new(ORACLE_LRU_SIZE, oracle_client, hint_client));
     let boot = match BootInfo::load(oracle.as_ref()).await {
         Ok(boot) => boot,
-        Err(BootstrapError::NoOpTransition) => {
+        Err(BootstrapError::InvalidToInvalid) => {
             info!(target: "client_interop", "No-op transition, short-circuiting.");
             return Ok(());
         }
@@ -78,20 +78,36 @@ where
         }
     };
 
-    // Short-circuit the state transition if the agreed pre-state matches the claimed post-state.
-    if boot.agreed_pre_state_commitment == boot.claimed_post_state {
-        info!(target: "client_interop", "No-op transition, short-circuiting.");
-        return Ok(());
-    }
-
     // Load in the agreed pre-state from the preimage oracle in order to determine the active
     // sub-problem.
     match boot.agreed_pre_state {
-        PreState::SuperRoot(_) => {
+        PreState::SuperRoot(ref super_root) => {
+            // If the claimed L2 block timestamp is less than the super root timestamp, the
+            // post-state muust be the agreed pre-state to accommodate trace extension.
+            if super_root.timestamp >= boot.claimed_l2_timestamp {
+                if boot.agreed_pre_state_commitment == boot.claimed_post_state {
+                    return Ok(());
+                } else {
+                    return Err(FaultProofProgramError::InvalidClaim(
+                        boot.agreed_pre_state_commitment,
+                        boot.claimed_post_state,
+                    ));
+                }
+            }
+
             // If the pre-state is a super root, the first sub-problem is always selected.
             sub_transition(oracle, handle_register, boot).await
         }
         PreState::TransitionState(ref transition_state) => {
+            // If the claimed L2 block timestamp is less than the prestate timestamp, the
+            // the claim must be invalid.
+            if transition_state.pre_state.timestamp >= boot.claimed_l2_timestamp {
+                return Err(FaultProofProgramError::InvalidClaim(
+                    boot.agreed_pre_state_commitment,
+                    boot.claimed_post_state,
+                ));
+            }
+
             // If the pre-state is a transition state, the sub-problem is selected based on the
             // current step.
             if transition_state.step < TRANSITION_STATE_MAX_STEPS {

--- a/bin/client/src/interop/transition.rs
+++ b/bin/client/src/interop/transition.rs
@@ -5,7 +5,7 @@ use crate::interop::util::fetch_l2_safe_head_hash;
 use alloc::sync::Arc;
 use alloy_consensus::Sealed;
 use alloy_primitives::B256;
-use core::{cmp::Ordering, fmt::Debug};
+use core::fmt::Debug;
 use kona_derive::errors::{PipelineError, PipelineErrorKind};
 use kona_driver::{Driver, DriverError};
 use kona_executor::{KonaHandleRegister, TrieDBProvider};
@@ -44,7 +44,7 @@ where
                 "No derivation/execution required, transition state is already saturated."
             );
 
-            return transition_and_check(boot.agreed_pre_state, None, boot.claimed_post_state, None);
+            return transition_and_check(boot.agreed_pre_state, None, boot.claimed_post_state);
         }
     }
 
@@ -70,34 +70,27 @@ where
     let safe_head = l2_provider
         .header_by_hash(safe_head_hash)
         .map(|header| Sealed::new_unchecked(header, safe_head_hash))?;
+    let disputed_l2_block_number = safe_head.number + 1;
 
-    // Translate the claimed timestamp to an L2 block number.
-    let claimed_l2_block_number = rollup_config.genesis.l2.number +
-        ((boot.claimed_l2_timestamp - rollup_config.genesis.l2_time) / rollup_config.block_time);
+    // Check if we can no-op the transition. The Superchain STF happens once every second, but chains have
+    // a variable block time, meaning there might be no transition to process. Alternatively, if the pre
+    // state is the post state, we can short-circuit the transition.
+    if safe_head.timestamp + rollup_config.block_time > boot.agreed_pre_state.timestamp() + 1 {
+        info!(
+            target: "interop_client",
+            "No-op transition, short-circuiting."
+        );
 
-    // If the claimed L2 block number is less than the safe head of the L2 chain, the claim is
-    // invalid.
-    match claimed_l2_block_number.cmp(&safe_head.number) {
-        Ordering::Less => {
-            error!(
-                target: "interop_client",
-                "Claimed L2 block number {claimed} is less than the safe head {safe}",
-                claimed = claimed_l2_block_number,
-                safe = safe_head.number
-            );
-            return Err(FaultProofProgramError::InvalidClaim(
-                boot.agreed_pre_state_commitment,
-                boot.claimed_post_state,
-            ));
-        }
-        Ordering::Equal => {
-            info!(
-                target: "interop_client",
-                "Claimed L2 block is already safe."
-            );
-            return Ok(());
-        }
-        _ => { /* Continue */ }
+        let active_root = boot
+            .agreed_pre_state
+            .active_l2_output_root()
+            .ok_or(FaultProofProgramError::StateTransitionFailed)?;
+        let optimistic_block = OptimisticBlock::new(safe_head.hash(), active_root.output_root);
+        return transition_and_check(
+            boot.agreed_pre_state,
+            Some(optimistic_block),
+            boot.claimed_post_state,
+        );
     }
 
     // Create a new derivation driver with the given boot information and oracle.
@@ -125,14 +118,13 @@ where
 
     // Run the derivation pipeline until we are able to produce the output root of the claimed
     // L2 block.
-    match driver.advance_to_target(rollup_config.as_ref(), Some(claimed_l2_block_number)).await {
+    match driver.advance_to_target(rollup_config.as_ref(), Some(disputed_l2_block_number)).await {
         Ok((safe_head, output_root)) => {
             let optimistic_block = OptimisticBlock::new(safe_head.block_info.hash, output_root);
             transition_and_check(
                 boot.agreed_pre_state,
                 Some(optimistic_block),
                 boot.claimed_post_state,
-                Some((boot.claimed_l2_timestamp, safe_head.block_info.timestamp)),
             )?;
 
             info!(
@@ -173,7 +165,6 @@ fn transition_and_check(
     pre_state: PreState,
     optimistic_block: Option<OptimisticBlock>,
     expected_post_state: B256,
-    timestamps: Option<(u64, u64)>,
 ) -> Result<(), FaultProofProgramError> {
     let did_append = optimistic_block.is_some();
     let post_state = pre_state
@@ -188,7 +179,7 @@ fn transition_and_check(
         );
     }
 
-    if post_state_commitment != expected_post_state || timestamps.is_some_and(|(a, b)| a != b) {
+    if post_state_commitment != expected_post_state {
         error!(
             target: "interop_client",
             "Failed to validate progressed transition state. Expected post-state commitment: {expected}, actual: {actual}",

--- a/bin/client/src/interop/transition.rs
+++ b/bin/client/src/interop/transition.rs
@@ -72,9 +72,9 @@ where
         .map(|header| Sealed::new_unchecked(header, safe_head_hash))?;
     let disputed_l2_block_number = safe_head.number + 1;
 
-    // Check if we can no-op the transition. The Superchain STF happens once every second, but chains have
-    // a variable block time, meaning there might be no transition to process. Alternatively, if the pre
-    // state is the post state, we can short-circuit the transition.
+    // Check if we can no-op the transition. The Superchain STF happens once every second, but
+    // chains have a variable block time, meaning there might be no transition to process.
+    // Alternatively, if the pre state is the post state, we can short-circuit the transition.
     if safe_head.timestamp + rollup_config.block_time > boot.agreed_pre_state.timestamp() + 1 {
         info!(
             target: "interop_client",

--- a/bin/client/src/interop/transition.rs
+++ b/bin/client/src/interop/transition.rs
@@ -74,7 +74,6 @@ where
 
     // Check if we can no-op the transition. The Superchain STF happens once every second, but
     // chains have a variable block time, meaning there might be no transition to process.
-    // Alternatively, if the pre state is the post state, we can short-circuit the transition.
     if safe_head.timestamp + rollup_config.block_time > boot.agreed_pre_state.timestamp() + 1 {
         info!(
             target: "interop_client",

--- a/bin/client/src/interop/util.rs
+++ b/bin/client/src/interop/util.rs
@@ -16,20 +16,9 @@ where
     O: CommsClient,
 {
     // Fetch the output root of the safe head block for the current L2 chain.
-    let rich_output = match pre {
-        PreState::SuperRoot(super_root) => {
-            super_root.output_roots.first().ok_or(OracleProviderError::Preimage(
-                PreimageOracleError::Other("No output roots in super root".to_string()),
-            ))?
-        }
-        PreState::TransitionState(transition_state) => {
-            transition_state.pre_state.output_roots.get(transition_state.step as usize).ok_or(
-                OracleProviderError::Preimage(PreimageOracleError::Other(
-                    "No output roots in transition state's pending progress".to_string(),
-                )),
-            )?
-        }
-    };
+    let rich_output = pre
+        .active_l2_output_root()
+        .ok_or(PreimageOracleError::Other("Missing active L2 output root".to_string()))?;
 
     fetch_output_block_hash(caching_oracle, rich_output.output_root, rich_output.chain_id).await
 }

--- a/crates/proof-sdk/proof-interop/src/boot.rs
+++ b/crates/proof-sdk/proof-interop/src/boot.rs
@@ -97,7 +97,7 @@ impl BootInfo {
             );
 
             if l2_post == INVALID_TRANSITION_HASH {
-                return Err(BootstrapError::NoOpTransition);
+                return Err(BootstrapError::InvalidToInvalid);
             } else {
                 return Err(BootstrapError::InvalidPostState(l2_post));
             }
@@ -160,7 +160,7 @@ pub enum BootstrapError {
     InvalidPostState(B256),
     /// The pre-state is invalid and the post-state claim is also invalid.
     #[error("No-op state transition detected; both pre and post states are `INVALID`.")]
-    NoOpTransition,
+    InvalidToInvalid,
 }
 
 /// Reads the raw pre-state from the preimage oracle.

--- a/crates/proof-sdk/proof-interop/src/pre_state.rs
+++ b/crates/proof-sdk/proof-interop/src/pre_state.rs
@@ -48,9 +48,9 @@ impl PreState {
         }
     }
 
-    /// Returns the active L2 output root hash of the [PreState]. This is the output root that represents
-    /// the pre-state of the chain that is to be committed to in the next transition step, or [None] if
-    /// the [PreState] has already been fully saturated.
+    /// Returns the active L2 output root hash of the [PreState]. This is the output root that
+    /// represents the pre-state of the chain that is to be committed to in the next transition
+    /// step, or [None] if the [PreState] has already been fully saturated.
     pub fn active_l2_output_root(&self) -> Option<&OutputRootWithChain> {
         match self {
             PreState::SuperRoot(super_root) => super_root.output_roots.first(),
@@ -79,8 +79,8 @@ impl PreState {
                 // If the transition state's pending progress contains the same number of states as
                 // the pre-state's output roots already, then we can either no-op
                 // the transition or finalize it.
-                if transition_state.pending_progress.len()
-                    == transition_state.pre_state.output_roots.len()
+                if transition_state.pending_progress.len() ==
+                    transition_state.pre_state.output_roots.len()
                 {
                     if transition_state.step == TRANSITION_STATE_MAX_STEPS {
                         let super_root = SuperRoot::new(
@@ -178,10 +178,10 @@ impl TransitionState {
 
     /// Returns the RLP payload length of the [TransitionState].
     pub fn payload_length(&self) -> usize {
-        Header { list: false, payload_length: self.pre_state.encoded_length() }.length()
-            + self.pre_state.encoded_length()
-            + self.pending_progress.length()
-            + self.step.length()
+        Header { list: false, payload_length: self.pre_state.encoded_length() }.length() +
+            self.pre_state.encoded_length() +
+            self.pending_progress.length() +
+            self.step.length()
     }
 }
 

--- a/crates/proof-sdk/proof-interop/src/pre_state.rs
+++ b/crates/proof-sdk/proof-interop/src/pre_state.rs
@@ -41,7 +41,7 @@ impl PreState {
     }
 
     /// Returns the timestamp of the [PreState].
-    pub fn timestamp(&self) -> u64 {
+    pub const fn timestamp(&self) -> u64 {
         match self {
             Self::SuperRoot(super_root) => super_root.timestamp,
             Self::TransitionState(transition_state) => transition_state.pre_state.timestamp,
@@ -53,8 +53,8 @@ impl PreState {
     /// step, or [None] if the [PreState] has already been fully saturated.
     pub fn active_l2_output_root(&self) -> Option<&OutputRootWithChain> {
         match self {
-            PreState::SuperRoot(super_root) => super_root.output_roots.first(),
-            PreState::TransitionState(transition_state) => {
+            Self::SuperRoot(super_root) => super_root.output_roots.first(),
+            Self::TransitionState(transition_state) => {
                 transition_state.pre_state.output_roots.get(transition_state.step as usize)
             }
         }


### PR DESCRIPTION
## Overview

Fixes the logic for no-op'ing sub-transitions within the Superchain STF. The superchain STF happens once every second, regardless of if each individual chain within
the dependency set has actually progressed. In this case, we need to be able to short-circuit sub-problem #1.