### PR TITLE
chore(client): Remove Hardcoded Precompile Addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9901,3 +9901,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "revm"
+version = "20.0.0-alpha.1"
+source = "git+https://github.com/bluealloy/revm?branch=main#1967753677ab6f394a5b77f9432ebb734488d927"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,9 @@ panic = "abort"
 codegen-units = 1
 lto = "fat"
 
+[patch.crates-io]
+revm = { git = "https://github.com/bluealloy/revm", branch = "main" }
+
 [workspace.dependencies]
 # Workspace Binaries
 kona-host = { path = "bin/host", version = "0.1.0", default-features = false }

--- a/bin/client/src/precompiles/bls12_g1_add.rs
+++ b/bin/client/src/precompiles/bls12_g1_add.rs
@@ -8,16 +8,19 @@
 
 use crate::precompiles::utils::precompile_run;
 use alloc::{string::ToString, vec::Vec};
-use alloy_primitives::{address, keccak256, Address, Bytes};
+use alloy_primitives::{keccak256, Address, Bytes};
 use revm::{
-    precompile::{Error as PrecompileError, Precompile, PrecompileResult, PrecompileWithAddress},
+    precompile::{
+        bls12_381::g1_add::PRECOMPILE, Error as PrecompileError, Precompile, PrecompileResult,
+        PrecompileWithAddress,
+    },
     primitives::PrecompileOutput,
 };
 
 /// The address of the BLS12-381 g1 addition check precompile.
 ///
 /// See: <https://eips.ethereum.org/EIPS/eip-2537#constants>
-const BLS12_G1_ADD_CHECK: Address = address!("0x000000000000000000000000000000000000000b");
+const BLS12_G1_ADD_CHECK: Address = PRECOMPILE.0;
 
 /// Input length of G1 Addition operation.
 const INPUT_LENGTH: usize = 256;

--- a/bin/client/src/precompiles/bls12_g1_msm.rs
+++ b/bin/client/src/precompiles/bls12_g1_msm.rs
@@ -8,9 +8,12 @@
 
 use crate::precompiles::utils::{msm_required_gas, precompile_run};
 use alloc::{string::ToString, vec::Vec};
-use alloy_primitives::{address, keccak256, Address, Bytes};
+use alloy_primitives::{keccak256, Address, Bytes};
 use revm::{
-    precompile::{Error as PrecompileError, Precompile, PrecompileResult, PrecompileWithAddress},
+    precompile::{
+        bls12_381::g1_msm::PRECOMPILE, Error as PrecompileError, Precompile, PrecompileResult,
+        PrecompileWithAddress,
+    },
     primitives::PrecompileOutput,
 };
 
@@ -22,7 +25,7 @@ const BLS12_MAX_G1_MSM_SIZE_ISTHMUS: usize = 513760;
 /// The address of the BLS12-381 g1 msm check precompile.
 ///
 /// See: <https://eips.ethereum.org/EIPS/eip-2537#constants>
-const BLS12_G1_MSM_CHECK: Address = address!("0x000000000000000000000000000000000000000c");
+const BLS12_G1_MSM_CHECK: Address = PRECOMPILE.0;
 
 /// Input length of g1 msm operation.
 const INPUT_LENGTH: usize = 160;

--- a/bin/client/src/precompiles/bls12_g2_add.rs
+++ b/bin/client/src/precompiles/bls12_g2_add.rs
@@ -8,16 +8,19 @@
 
 use crate::precompiles::utils::precompile_run;
 use alloc::{string::ToString, vec::Vec};
-use alloy_primitives::{address, keccak256, Address, Bytes};
+use alloy_primitives::{keccak256, Address, Bytes};
 use revm::{
-    precompile::{Error as PrecompileError, Precompile, PrecompileResult, PrecompileWithAddress},
+    precompile::{
+        bls12_381::g2_add::PRECOMPILE, Error as PrecompileError, Precompile, PrecompileResult,
+        PrecompileWithAddress,
+    },
     primitives::PrecompileOutput,
 };
 
 /// The address of the BLS12-381 g2 addition check precompile.
 ///
 /// See: <https://eips.ethereum.org/EIPS/eip-2537#constants>
-const BLS12_G2_ADD_CHECK: Address = address!("0x000000000000000000000000000000000000000d");
+const BLS12_G2_ADD_CHECK: Address = PRECOMPILE.0;
 
 /// Input length of g2 addition operation.
 const INPUT_LENGTH: usize = 512;

--- a/bin/client/src/precompiles/bls12_g2_msm.rs
+++ b/bin/client/src/precompiles/bls12_g2_msm.rs
@@ -8,9 +8,12 @@
 
 use crate::precompiles::utils::{msm_required_gas, precompile_run};
 use alloc::{string::ToString, vec::Vec};
-use alloy_primitives::{address, keccak256, Address, Bytes};
+use alloy_primitives::{keccak256, Address, Bytes};
 use revm::{
-    precompile::{Error as PrecompileError, Precompile, PrecompileResult, PrecompileWithAddress},
+    precompile::{
+        bls12_381::g2_msm::PRECOMPILE, Error as PrecompileError, Precompile, PrecompileResult,
+        PrecompileWithAddress,
+    },
     primitives::PrecompileOutput,
 };
 
@@ -22,7 +25,7 @@ const BLS12_MAX_G2_MSM_SIZE_ISTHMUS: usize = 488448;
 /// The address of the BLS12-381 g2 msm check precompile.
 ///
 /// See: <https://eips.ethereum.org/EIPS/eip-2537#constants>
-const BLS12_G2_MSM_CHECK: Address = address!("0x000000000000000000000000000000000000000e");
+const BLS12_G2_MSM_CHECK: Address = PRECOMPILE.0;
 
 /// Input length of g2 msm operation.
 const INPUT_LENGTH: usize = 288;

--- a/bin/client/src/precompiles/bls12_map_fp.rs
+++ b/bin/client/src/precompiles/bls12_map_fp.rs
@@ -8,16 +8,19 @@
 
 use crate::precompiles::utils::precompile_run;
 use alloc::{string::ToString, vec::Vec};
-use alloy_primitives::{address, keccak256, Address, Bytes};
+use alloy_primitives::{keccak256, Address, Bytes};
 use revm::{
-    precompile::{Error as PrecompileError, Precompile, PrecompileResult, PrecompileWithAddress},
+    precompile::{
+        bls12_381::map_fp_to_g1::PRECOMPILE, Error as PrecompileError, Precompile,
+        PrecompileResult, PrecompileWithAddress,
+    },
     primitives::PrecompileOutput,
 };
 
 /// The address of the BLS12-381 map fp to g1 check precompile.
 ///
 /// See: <https://eips.ethereum.org/EIPS/eip-2537#constants>
-const BLS12_MAP_FP_CHECK: Address = address!("0x0000000000000000000000000000000000000010");
+const BLS12_MAP_FP_CHECK: Address = PRECOMPILE.0;
 
 /// Base gas fee for the BLS12-381 map fp to g1 operation.
 const MAP_FP_BASE_FEE: u64 = 5500;

--- a/bin/client/src/precompiles/bls12_map_fp2.rs
+++ b/bin/client/src/precompiles/bls12_map_fp2.rs
@@ -8,16 +8,19 @@
 
 use crate::precompiles::utils::precompile_run;
 use alloc::{string::ToString, vec::Vec};
-use alloy_primitives::{address, keccak256, Address, Bytes};
+use alloy_primitives::{keccak256, Address, Bytes};
 use revm::{
-    precompile::{Error as PrecompileError, Precompile, PrecompileResult, PrecompileWithAddress},
+    precompile::{
+        bls12_381::map_fp2_to_g2::PRECOMPILE, Error as PrecompileError, Precompile,
+        PrecompileResult, PrecompileWithAddress,
+    },
     primitives::PrecompileOutput,
 };
 
 /// The address of the BLS12-381 map fp2 to g2 check precompile.
 ///
 /// See: <https://eips.ethereum.org/EIPS/eip-2537#constants>
-const BLS12_MAP_FP2_CHECK: Address = address!("0x0000000000000000000000000000000000000011");
+const BLS12_MAP_FP2_CHECK: Address = PRECOMPILE.0;
 
 /// Base gas fee for the BLS12-381 map fp2 to g2 operation.
 const MAP_FP2_BASE_FEE: u64 = 23800;

--- a/bin/client/src/precompiles/bls12_pairing.rs
+++ b/bin/client/src/precompiles/bls12_pairing.rs
@@ -8,9 +8,12 @@
 
 use crate::precompiles::utils::precompile_run;
 use alloc::{string::ToString, vec::Vec};
-use alloy_primitives::{address, keccak256, Address, Bytes};
+use alloy_primitives::{keccak256, Address, Bytes};
 use revm::{
-    precompile::{Error as PrecompileError, Precompile, PrecompileResult, PrecompileWithAddress},
+    precompile::{
+        bls12_381::pairing::PRECOMPILE, Error as PrecompileError, Precompile, PrecompileResult,
+        PrecompileWithAddress,
+    },
     primitives::PrecompileOutput,
 };
 
@@ -18,7 +21,7 @@ use revm::{
 const BLS12_MAX_PAIRING_SIZE_ISTHMUS: usize = 235_008;
 
 /// The address of the BLS12-381 pairing check precompile.
-const BLS12_PAIRING_CHECK: Address = address!("0x000000000000000000000000000000000000000f");
+const BLS12_PAIRING_CHECK: Address = PRECOMPILE.0;
 
 /// Input length of pairing operation.
 const INPUT_LENGTH: usize = 384;


### PR DESCRIPTION
### Description

Updates `kona-client` precompiles to use the addresses defined in `revm-precompiles`.

Reduces the chance that precompile addresses are incorrectly input.