### PR TITLE
feat(host): Proactive hints

### DIFF
--- a/bin/host/src/backend/online.rs
+++ b/bin/host/src/backend/online.rs
@@ -7,15 +7,16 @@ use kona_preimage::{
     errors::{PreimageOracleError, PreimageOracleResult},
     HintRouter, PreimageFetcher, PreimageKey,
 };
-use std::{hash::Hash, str::FromStr, sync::Arc};
+use kona_proof::{errors::HintParsingError, Hint};
+use std::{collections::HashSet, hash::Hash, str::FromStr, sync::Arc};
 use tokio::sync::RwLock;
-use tracing::{error, trace, warn};
+use tracing::{debug, error, trace};
 
 /// The [OnlineHostBackendCfg] trait is used to define the type configuration for the
 /// [OnlineHostBackend].
 pub trait OnlineHostBackendCfg {
     /// The hint type describing the range of hints that can be received.
-    type Hint: FromStr + Hash + Eq + PartialEq + Send + Sync;
+    type HintType: FromStr<Err = HintParsingError> + Hash + Eq + PartialEq + Clone + Send + Sync;
 
     /// The providers that are used to fetch data in response to hints.
     type Providers: Send + Sync;
@@ -30,7 +31,7 @@ pub trait HintHandler {
 
     /// Fetches data in response to a hint.
     async fn fetch_hint(
-        hint: <Self::Cfg as OnlineHostBackendCfg>::Hint,
+        hint: Hint<<Self::Cfg as OnlineHostBackendCfg>::HintType>,
         cfg: &Self::Cfg,
         providers: &<Self::Cfg as OnlineHostBackendCfg>::Providers,
         kv: SharedKeyValueStore,
@@ -53,8 +54,10 @@ where
     kv: SharedKeyValueStore,
     /// The providers that are used to fetch data in response to hints.
     providers: C::Providers,
+    /// Hints that should be immediately executed by the host.
+    proactive_hints: HashSet<C::HintType>,
     /// The last hint that was received.
-    last_hint: Arc<RwLock<Option<String>>>,
+    last_hint: Arc<RwLock<Option<Hint<C::HintType>>>>,
     /// Phantom marker for the [HintHandler].
     _hint_handler: std::marker::PhantomData<H>,
 }
@@ -71,9 +74,16 @@ where
             cfg,
             kv,
             providers,
+            proactive_hints: HashSet::default(),
             last_hint: Arc::new(RwLock::new(None)),
             _hint_handler: std::marker::PhantomData,
         }
+    }
+
+    /// Adds a new proactive hint to the [OnlineHostBackend].
+    pub fn with_proactive_hint(mut self, hint_type: C::HintType) -> Self {
+        self.proactive_hints.insert(hint_type);
+        self
     }
 }
 
@@ -86,8 +96,19 @@ where
     /// Set the last hint to be received.
     async fn route_hint(&self, hint: String) -> PreimageOracleResult<()> {
         trace!(target: "host-backend", "Received hint: {hint}");
-        let mut hint_lock = self.last_hint.write().await;
-        hint_lock.replace(hint);
+
+        let parsed_hint =
+            hint.parse::<Hint<C::HintType>>().map_err(|_| PreimageOracleError::KeyNotFound)?;
+        if self.proactive_hints.contains(&parsed_hint.ty) {
+            debug!(target: "host-backend", "Proactive hint received; Immediately fetching {hint}");
+            H::fetch_hint(parsed_hint, &self.cfg, &self.providers, self.kv.clone())
+                .await
+                .map_err(|e| PreimageOracleError::Other(e.to_string()))?;
+        } else {
+            let mut hint_lock = self.last_hint.write().await;
+            hint_lock.replace(parsed_hint);
+        }
+
         Ok(())
     }
 }
@@ -112,14 +133,11 @@ where
         // Use a loop to keep retrying the prefetch as long as the key is not found
         while preimage.is_none() {
             if let Some(hint) = self.last_hint.read().await.as_ref() {
-                let parsed_hint =
-                    hint.parse::<C::Hint>().map_err(|_| PreimageOracleError::KeyNotFound)?;
                 let value =
-                    H::fetch_hint(parsed_hint, &self.cfg, &self.providers, self.kv.clone()).await;
+                    H::fetch_hint(hint.clone(), &self.cfg, &self.providers, self.kv.clone()).await;
 
                 if let Err(e) = value {
                     error!(target: "host-backend", "Failed to prefetch hint: {e}");
-                    warn!(target: "host-backend", "Retrying hint fetch: {hint}");
                     continue;
                 }
 

--- a/bin/host/src/interop/cfg.rs
+++ b/bin/host/src/interop/cfg.rs
@@ -17,7 +17,6 @@ use clap::Parser;
 use kona_preimage::{
     BidirectionalChannel, Channel, HintReader, HintWriter, OracleReader, OracleServer,
 };
-use kona_proof::Hint;
 use kona_proof_interop::HintType;
 use kona_providers_alloy::{OnlineBeaconClient, OnlineBlobProvider};
 use kona_std_fpvm::{FileChannel, FileDescriptor};
@@ -136,7 +135,8 @@ impl InteropHost {
                 kv_store.clone(),
                 providers,
                 InteropHintHandler,
-            );
+            )
+            .with_proactive_hint(HintType::L2BlockData);
 
             task::spawn(
                 PreimageServer::new(
@@ -243,7 +243,7 @@ impl InteropHost {
 }
 
 impl OnlineHostBackendCfg for InteropHost {
-    type Hint = Hint<HintType>;
+    type HintType = HintType;
     type Providers = InteropProviders;
 }
 

--- a/bin/host/src/interop/handler.rs
+++ b/bin/host/src/interop/handler.rs
@@ -27,7 +27,7 @@ use kona_proof::{
     l1::{OracleBlobProvider, OracleL1ChainProvider, OraclePipeline},
     l2::OracleL2ChainProvider,
     sync::new_pipeline_cursor,
-    CachingOracle,
+    CachingOracle, Hint,
 };
 use kona_proof_interop::{HintType, PreState};
 use maili_protocol::BlockInfo;
@@ -44,7 +44,7 @@ impl HintHandler for InteropHintHandler {
     type Cfg = InteropHost;
 
     async fn fetch_hint(
-        hint: <Self::Cfg as OnlineHostBackendCfg>::Hint,
+        hint: Hint<<Self::Cfg as OnlineHostBackendCfg>::HintType>,
         cfg: &Self::Cfg,
         providers: &<Self::Cfg as OnlineHostBackendCfg>::Providers,
         kv: SharedKeyValueStore,

--- a/bin/host/src/single/cfg.rs
+++ b/bin/host/src/single/cfg.rs
@@ -14,7 +14,7 @@ use clap::Parser;
 use kona_preimage::{
     BidirectionalChannel, Channel, HintReader, HintWriter, OracleReader, OracleServer,
 };
-use kona_proof::{Hint, HintType};
+use kona_proof::HintType;
 use kona_providers_alloy::{OnlineBeaconClient, OnlineBlobProvider};
 use kona_std_fpvm::{FileChannel, FileDescriptor};
 use maili_genesis::RollupConfig;
@@ -239,7 +239,7 @@ impl SingleChainHost {
 }
 
 impl OnlineHostBackendCfg for SingleChainHost {
-    type Hint = Hint<HintType>;
+    type HintType = HintType;
     type Providers = SingleChainProviders;
 }
 

--- a/bin/host/src/single/handler.rs
+++ b/bin/host/src/single/handler.rs
@@ -16,7 +16,7 @@ use alloy_rpc_types::{debug::ExecutionWitness, Block, BlockTransactionsKind};
 use anyhow::{anyhow, ensure, Result};
 use async_trait::async_trait;
 use kona_preimage::{PreimageKey, PreimageKeyType};
-use kona_proof::HintType;
+use kona_proof::{Hint, HintType};
 use maili_protocol::BlockInfo;
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use std::collections::HashMap;
@@ -30,7 +30,7 @@ impl HintHandler for SingleChainHintHandler {
     type Cfg = SingleChainHost;
 
     async fn fetch_hint(
-        hint: <Self::Cfg as OnlineHostBackendCfg>::Hint,
+        hint: Hint<<Self::Cfg as OnlineHostBackendCfg>::HintType>,
         cfg: &Self::Cfg,
         providers: &<Self::Cfg as OnlineHostBackendCfg>::Providers,
         kv: SharedKeyValueStore,


### PR DESCRIPTION
## Overview

Adds a feature to the `OnlineHostBackend` that allows for "proactive hints," which fetch data from the remote sources and populate the key-value store immediately rather than upon the next request for a preimage.

With this, the interop host sets the `L2BlockData` hint to a proactive hint in order to ensure that the host fetches the optimistic block data without another hint interrupting it.