### PR TITLE
feat(ci): Remove support for features after MSRV

### DIFF
--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -18,6 +18,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
+          toolchain: 1.81
       - uses: taiki-e/install-action@cargo-llvm-cov
       - name: Clone monorepo
         run: just monorepo

--- a/.github/workflows/book.yaml
+++ b/.github/workflows/book.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.81
       - name: Setup mdbook
         run: |
           cargo install --version 0.4.40 mdbook

--- a/.github/workflows/client_host.yaml
+++ b/.github/workflows/client_host.yaml
@@ -24,6 +24,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
+          toolchain: 1.81
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/.github/workflows/monorepo_pin_update.yaml
+++ b/.github/workflows/monorepo_pin_update.yaml
@@ -17,6 +17,8 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
       - uses: taiki-e/install-action@just
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.81
       - name: Update Monorepo Commit
         run: just update-monorepo
       - name: Create Pull Request

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,8 @@ jobs:
           submodules: true
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.81
       - name: Commit Cargo.lock
         run: |
           git config --local user.email "action@github.com"

--- a/.github/workflows/rust_ci.yaml
+++ b/.github/workflows/rust_ci.yaml
@@ -19,6 +19,8 @@ jobs:
       - uses: taiki-e/install-action@just
       - name: Install Rust stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.81
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -70,6 +72,8 @@ jobs:
       - uses: taiki-e/install-action@just
       - name: Install Rust stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.81
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -94,6 +98,8 @@ jobs:
       - uses: taiki-e/install-action@just
       - name: Install Rust stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.81
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -120,6 +126,8 @@ jobs:
       - uses: taiki-e/install-action@just
       - name: Install Rust stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.81
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -138,6 +146,8 @@ jobs:
       - uses: taiki-e/install-action@just
       - name: Install Rust stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.81
       - uses: taiki-e/install-action@cargo-hack
       - uses: Swatinem/rust-cache@v2
         with:
@@ -154,6 +164,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
+          toolchain: 1.81
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "rust-analyzer.rustfmt.extraArgs": [
-        "+nightly"
-    ]
-}

--- a/bin/host/src/single/cfg.rs
+++ b/bin/host/src/single/cfg.rs
@@ -124,7 +124,7 @@ impl SingleChainHost {
     }
 
     /// Starts the preimage server, communicating with the client over the provided channels.
-    async fn start_server<C>(&self, hint: C, preimage: C) -> Result<JoinHandle<Result<()>>>
+    pub async fn start_server<C>(&self, hint: C, preimage: C) -> Result<JoinHandle<Result<()>>>
     where
         C: Channel + Send + Sync + 'static,
     {

--- a/crates/derive/src/attributes/stateful.rs
+++ b/crates/derive/src/attributes/stateful.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::unnecessary_map_or)]
 //! The [`AttributesBuilder`] and it's default implementation.
 
 use crate::{

--- a/crates/derive/src/stages/batch/batch_validator.rs
+++ b/crates/derive/src/stages/batch/batch_validator.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::unnecessary_map_or)]
 //! Contains the [BatchValidator] stage.
 
 use super::NextBatchProvider;

--- a/crates/derive/src/test_utils/frame_queue.rs
+++ b/crates/derive/src/test_utils/frame_queue.rs
@@ -31,7 +31,7 @@ impl TestFrameQueueProvider {
     }
 
     /// Sets the origin for the [MockFrameQueueProvider].
-    pub const fn set_origin(&mut self, origin: BlockInfo) {
+    pub fn set_origin(&mut self, origin: BlockInfo) {
         self.origin = Some(origin);
     }
 }

--- a/crates/interop/src/super_root.rs
+++ b/crates/interop/src/super_root.rs
@@ -125,7 +125,7 @@ mod test {
             ],
         );
 
-        assert!(super_root.output_roots.is_sorted_by_key(|r| r.chain_id));
+        assert!(super_root.output_roots.windows(2).all(|w| w[0].chain_id <= w[1].chain_id));
     }
 
     #[test]

--- a/crates/mpt/src/list_walker.rs
+++ b/crates/mpt/src/list_walker.rs
@@ -77,7 +77,7 @@ where
 
     /// Takes the inner list of the [OrderedListWalker], returning it and setting the inner list to
     /// [None].
-    pub const fn take_inner(&mut self) -> Option<VecDeque<(Bytes, Bytes)>> {
+    pub fn take_inner(&mut self) -> Option<VecDeque<(Bytes, Bytes)>> {
         self.inner.take()
     }
 

--- a/crates/mpt/src/list_walker.rs
+++ b/crates/mpt/src/list_walker.rs
@@ -75,6 +75,7 @@ where
         Ok(())
     }
 
+    #[allow(clippy::missing_const_for_fn)]
     /// Takes the inner list of the [OrderedListWalker], returning it and setting the inner list to
     /// [None].
     pub fn take_inner(&mut self) -> Option<VecDeque<(Bytes, Bytes)>> {

--- a/crates/mpt/src/list_walker.rs
+++ b/crates/mpt/src/list_walker.rs
@@ -75,7 +75,6 @@ where
         Ok(())
     }
 
-    #[allow(clippy::missing_const_for_fn)]
     /// Takes the inner list of the [OrderedListWalker], returning it and setting the inner list to
     /// [None].
     pub fn take_inner(&mut self) -> Option<VecDeque<(Bytes, Bytes)>> {

--- a/crates/proof-sdk/proof-interop/src/consolidation.rs
+++ b/crates/proof-sdk/proof-interop/src/consolidation.rs
@@ -40,7 +40,7 @@ where
     C: CommsClient + Send + Sync,
 {
     /// Creates a new [SuperchainConsolidator] with the given providers and [Header]s.
-    pub const fn new(
+    pub fn new(
         boot_info: &'a mut BootInfo,
         interop_provider: OracleInteropProvider<C>,
         l2_providers: HashMap<u64, OracleL2ChainProvider<C>>,

--- a/crates/proof-sdk/proof/src/l2/chain_provider.rs
+++ b/crates/proof-sdk/proof/src/l2/chain_provider.rs
@@ -39,7 +39,7 @@ impl<T: CommsClient> OracleL2ChainProvider<T> {
     }
 
     /// Sets the L2 chain ID to use for the provider's hints.
-    pub const fn set_chain_id(&mut self, chain_id: Option<u64>) {
+    pub fn set_chain_id(&mut self, chain_id: Option<u64>) {
         self.chain_id = chain_id;
     }
 

--- a/crates/proof-sdk/std-fpvm/src/channel.rs
+++ b/crates/proof-sdk/std-fpvm/src/channel.rs
@@ -69,7 +69,7 @@ struct ReadFuture<'a> {
 
 impl<'a> ReadFuture<'a> {
     /// Create a new [ReadFuture] from a channel and a buffer.
-    const fn new(channel: FileChannel, buf: &'a mut [u8]) -> Self {
+    fn new(channel: FileChannel, buf: &'a mut [u8]) -> Self {
         Self { channel, buf: RefCell::new(buf), read: 0 }
     }
 }

--- a/justfile
+++ b/justfile
@@ -63,7 +63,7 @@ fmt-native-check:
 
 # Lint the workspace
 lint-native: fmt-native-check lint-docs
-  cargo +nightly clippy --workspace --all --all-features --all-targets -- -D warnings
+  cargo clippy --workspace --all --all-features --all-targets -- -D warnings
 
 # Lint the workspace (mips arch). Currently, only the `kona-std-fpvm` crate is linted for the `cannon` target, as it is the only crate with architecture-specific code.
 lint-cannon:

--- a/justfile
+++ b/justfile
@@ -55,11 +55,11 @@ hack:
 
 # Fixes the formatting of the workspace
 fmt-native-fix:
-  cargo fmt --all
+  cargo +nightly fmt --all
 
 # Check the formatting of the workspace
 fmt-native-check:
-  cargo fmt --all -- --check
+  cargo +nightly fmt --all -- --check
 
 # Lint the workspace
 lint-native: fmt-native-check lint-docs

--- a/justfile
+++ b/justfile
@@ -55,15 +55,15 @@ hack:
 
 # Fixes the formatting of the workspace
 fmt-native-fix:
-  cargo +nightly fmt --all
+  cargo fmt --all
 
 # Check the formatting of the workspace
 fmt-native-check:
-  cargo +nightly fmt --all -- --check
+  cargo fmt --all -- --check
 
 # Lint the workspace
 lint-native: fmt-native-check lint-docs
-  cargo +nightly clippy --workspace --all --all-features --all-targets -- -D warnings
+  cargo clippy --workspace --all --all-features --all-targets -- -D warnings
 
 # Lint the workspace (mips arch). Currently, only the `kona-std-fpvm` crate is linted for the `cannon` target, as it is the only crate with architecture-specific code.
 lint-cannon:
@@ -72,7 +72,7 @@ lint-cannon:
     --platform linux/amd64 \
     -v `pwd`/:/workdir \
     -w="/workdir" \
-    ghcr.io/op-rs/kona/cannon-builder:main cargo +nightly clippy -p kona-std-fpvm --all-features -Zbuild-std=core,alloc -- -D warnings
+    ghcr.io/op-rs/kona/cannon-builder:main cargo clippy -p kona-std-fpvm --all-features -Zbuild-std=core,alloc -- -D warnings
 
 # Lint the workspace (risc-v arch). Currently, only the `kona-std-fpvm` crate is linted for the `asterisc` target, as it is the only crate with architecture-specific code.
 lint-asterisc:
@@ -81,7 +81,7 @@ lint-asterisc:
     --platform linux/amd64 \
     -v `pwd`/:/workdir \
     -w="/workdir" \
-    ghcr.io/op-rs/kona/asterisc-builder:main cargo +nightly clippy -p kona-std-fpvm --all-features -Zbuild-std=core,alloc -- -D warnings
+    ghcr.io/op-rs/kona/asterisc-builder:main cargo clippy -p kona-std-fpvm --all-features -Zbuild-std=core,alloc -- -D warnings
 
 # Lint the Rust documentation
 lint-docs:

--- a/justfile
+++ b/justfile
@@ -63,7 +63,7 @@ fmt-native-check:
 
 # Lint the workspace
 lint-native: fmt-native-check lint-docs
-  cargo clippy --workspace --all --all-features --all-targets -- -D warnings
+  cargo +nightly clippy --workspace --all --all-features --all-targets -- -D warnings
 
 # Lint the workspace (mips arch). Currently, only the `kona-std-fpvm` crate is linted for the `cannon` target, as it is the only crate with architecture-specific code.
 lint-cannon:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.81"


### PR DESCRIPTION
## Motivation
Currently in `kona`, the CI runs with the latest stable toolchain.

This allows for features stabilized after the latest MSRV (e.g. https://github.com/rust-lang/rust/pull/129195) to be used, which causes crates such as OP Succinct to fail to compile. This is because SP1's Rust toolchain (as well as other zkVM Rust toolchains) are not always up to date with the latest stable Rust toolchain, though they're above the MSRV in `kona`, which is currently set to 1.81.

## Solution

- Update CI to use the MSRV toolchain (1.81).
- Add a `rust-toolchain.toml` file, which ensures during local development that the MSRV toolchain is used.
- Update functions to reflect the fact that `const_mut_refs` is not stabilized.
- Set `clippy` in `justfile` to use stable, instead of nightly. `fmt` should still use nightly for features enabled in `rustfmt.toml`.
- Remove #![allow(clippy::unnecessary_map_or)], which does not exist in the `clippy` toolchain for `1.81`

### Misc
- Expose `start_server`, which is nice for OP Succinct. Happy to separate this into a different PR.

## Context

SP1's current supported Rust toolchain is 1.82, and the `const_mut_refs` feature was stabilized in 1.83.

```shell
[sp1]  error[E0658]: mutable references are not allowed in constant functions
[sp1]    --> /home/ubuntu/.cargo/git/checkouts/kona-eb08956031b8bea7/2e37ea5/crates/mpt/src/list_walker.rs:80:29
[sp1]     |
[sp1]  80 |     pub const fn take_inner(&mut self) -> Option<VecDeque<(Bytes, Bytes)>> {
[sp1]     |                             ^^^^^^^^^
[sp1]     |
[sp1]     = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
[sp1]     = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
[sp1]  
[sp1]  error[E0658]: mutable references are not allowed in constant functions
[sp1]    --> /home/ubuntu/.cargo/git/checkouts/kona-eb08956031b8bea7/2e37ea5/crates/mpt/src/list_walker.rs:81:9
[sp1]     |
[sp1]  81 |         self.inner.take()
[sp1]     |         ^^^^^^^^^^
[sp1]     |
[sp1]     = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
[sp1]     = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
[sp1]  
[sp1]  error: `core::option::Option::<T>::take` is not yet stable as a const fn
[sp1]    --> /home/ubuntu/.cargo/git/checkouts/kona-eb08956031b8bea7/2e37ea5/crates/mpt/src/list_walker.rs:81:9
[sp1]     |
[sp1]  81 |         self.inner.take()
[sp1]     |         ^^^^^^^^^^^^^^^^^
[sp1]     |
[sp1]     = help: add `#![feature(const_option)]` to the crate attributes to enable
```