### PR TITLE
chore(deps): Bump Maili -> `0.2.3`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1305,6 +1305,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2916,9 +2936,9 @@ dependencies = [
 
 [[package]]
 name = "maili-genesis"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7eee1b92b09c03f03a49bd92866c037bd2e29e4ffb328e08e635dbd115ad189"
+checksum = "5362c943f8746e56f39cbb14568be3e709e6355ad460ad79dd752241d001215d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2934,9 +2954,9 @@ dependencies = [
 
 [[package]]
 name = "maili-protocol"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339f90e890957709cee357b42496c3437fa76e29cc036fa94b7aaa26508bc793"
+checksum = "837893c0f84c6760348ef21e351a897849dfc30603183632c560bcea32a2dcd9"
 dependencies = [
  "alloc-no-stdlib",
  "alloy-consensus",
@@ -2960,14 +2980,13 @@ dependencies = [
 
 [[package]]
 name = "maili-registry"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7557be6ff8199a5076b9681681a1c67b5d4b12c6b6ab65f5ae938608edbdd524"
+checksum = "3e88d54e608b9b2ba9bb1969ef7ffb524fd6a1286b3b380d321832d968d7792e"
 dependencies = [
  "alloy-primitives",
  "lazy_static",
  "maili-genesis",
- "maili-superchain",
  "serde",
  "serde_json",
  "toml",
@@ -2975,9 +2994,9 @@ dependencies = [
 
 [[package]]
 name = "maili-rpc"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea06103d9213bc22800a8bb0dcde5c336cf34b4a391fdf939d1158c9940dd25"
+checksum = "2380b1566c658a26bb2ef5e7930f6fc60ef9d94e4544af615db7b4bc419049d6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -2988,24 +3007,13 @@ dependencies = [
 
 [[package]]
 name = "maili-serde"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa5c844aeae91d2859472d851347004709ef2f9cc86bc6b77e750e51f81309c9"
+checksum = "d11c7501c4db3a2e31942d893f9a2c867896273b003630d25f309446ef4d7474"
 dependencies = [
  "alloy-primitives",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "maili-superchain"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6014c188de26ea06743c22f63a0385baa63cb8864a3cf5b623df47c62c907a46"
-dependencies = [
- "alloy-primitives",
- "maili-genesis",
- "serde",
 ]
 
 [[package]]
@@ -3264,9 +3272,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "oorandom"
@@ -3408,28 +3416,30 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.12"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
+checksum = "c9fde3d0718baf5bc92f577d652001da0f8d54cd03a7974e118d04fc888dc23d"
 dependencies = [
  "arrayvec",
  "bitvec",
  "byte-slice-cast",
+ "const_format",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
+ "rustversion",
  "serde",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.12"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
+checksum = "581c837bb6b9541ce7faa9377c20616e4fb7650f6b0f68bc93c827ee504fb7b3"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3778,7 +3788,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.0",
- "zerocopy 0.8.16",
+ "zerocopy 0.8.17",
 ]
 
 [[package]]
@@ -3817,7 +3827,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
 dependencies = [
  "getrandom 0.3.1",
- "zerocopy 0.8.16",
+ "zerocopy 0.8.17",
 ]
 
 [[package]]
@@ -5675,11 +5685,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b8c07a70861ce02bad1607b5753ecb2501f67847b9f9ada7c160fff0ec6300c"
+checksum = "aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713"
 dependencies = [
- "zerocopy-derive 0.8.16",
+ "zerocopy-derive 0.8.17",
 ]
 
 [[package]]
@@ -5695,9 +5705,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5226bc9a9a9836e7428936cde76bb6b22feea1a8bfdbc0d241136e4d13417e25"
+checksum = "06718a168365cad3d5ff0bb133aad346959a2074bd4a85c121255a11304a8626"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,10 +79,10 @@ kona-preimage = { path = "crates/proof-sdk/preimage", version = "0.2.1", default
 kona-std-fpvm-proc = { path = "crates/proof-sdk/std-fpvm-proc", version = "0.1.2", default-features = false }
 
 # Maili
-maili-rpc = { version = "0.2.1", default-features = false }
-maili-genesis = { version = "0.2.1", default-features = false }
-maili-protocol = { version = "0.2.1", default-features = false }
-maili-registry = { version = "0.2.1", default-features = false }
+maili-rpc = { version = "0.2.3", default-features = false }
+maili-genesis = { version = "0.2.3", default-features = false }
+maili-protocol = { version = "0.2.3", default-features = false }
+maili-registry = { version = "0.2.3", default-features = false }
 
 # Alloy
 alloy-rlp = { version = "0.3.11", default-features = false }


### PR DESCRIPTION
### Description

Bumps `maili` dependencies to `0.2.3`.