### PR TITLE
chore(ci): Bump `codecov-action` to v5

### DIFF
--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -50,7 +50,7 @@ jobs:
           just action-tests
           cargo llvm-cov report --lcov --output-path actions_cov.lcov
       - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/client_host.yaml
+++ b/.github/workflows/client_host.yaml
@@ -81,7 +81,7 @@ jobs:
 
           cargo llvm-cov report --lcov --output-path client_host_cov.lcov
       - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/rust_ci.yaml
+++ b/.github/workflows/rust_ci.yaml
@@ -176,7 +176,7 @@ jobs:
       - name: Record Rust version
         run: echo "RUST=$(rustc --version)" >> "$GITHUB_ENV"
       - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Overview

Bumps the `codecov-action` to v5, which contains a fix for tokenless uploads in forks.