### PR TITLE
chore(book): Devdocs subdirectory

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -12,7 +12,7 @@ command = "mdbook-mermaid"
 [preprocessor.template]
 
 [output.html]
-build-dir = "book"
+build-dir = "kona"
 default-theme = "ferra"
 preferred-dark-theme = "ferra"
 git-repository-url = "https://github.com/op-rs/kona"


### PR DESCRIPTION
## Overview

Defines the build directory as `kona` to deploy to the `kona` subdir in [`devdocs`](https://github.com/ethereum-optimism/devdocs)