### PR TITLE
chore: Utilities Directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3624,6 +3624,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kona-serde"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+ "toml",
+]
+
+[[package]]
 name = "kona-std-fpvm"
 version = "0.1.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ members = [
   "bin/*",
   "crates/proof/*",
   "crates/protocol/*",
-  "crates/services/*"
+  "crates/services/*",
+  "crates/utilities/*"
 ]
 default-members = ["bin/host", "bin/client"]
 
@@ -80,6 +81,9 @@ kona-std-fpvm = { path = "crates/proof/std-fpvm", version = "0.1.2", default-fea
 kona-preimage = { path = "crates/proof/preimage", version = "0.2.1", default-features = false }
 kona-std-fpvm-proc = { path = "crates/proof/std-fpvm-proc", version = "0.1.2", default-features = false }
 kona-proof-interop = { path = "crates/proof/proof-interop", version = "0.1.1", default-features = false }
+
+# Workspace Utilities
+kona-serde = { path = "crates/utilities/serde", version = "0.1.0", default-features = false }
 
 # Maili
 maili-rpc = { version = "0.2.8", default-features = false }
@@ -153,6 +157,7 @@ criterion = "0.5.1"
 # Serialization
 rkyv = "0.8.10"
 serde = { version = "1.0.217", default-features = false }
+toml = { version = "0.8.19", default-features = false }
 serde_json = { version = "1.0.138", default-features = false }
 
 # Ethereum

--- a/crates/utilities/serde/Cargo.toml
+++ b/crates/utilities/serde/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "kona-serde"
+version = "0.1.0"
+description = "Serde related helpers for kona"
+
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+alloy-primitives = { workspace = true, features = ["serde"] }
+serde.workspace = true
+serde_json = { workspace = true, features = ["alloc"] }
+
+[dev-dependencies]
+toml = { workspace = true, features = ["parse"] }
+
+[features]
+default = ["std"]
+std = [
+	"serde/std",
+	"serde_json/std",
+	"alloy-primitives/serde",
+	"alloy-primitives/std"
+]

--- a/crates/utilities/serde/README.md
+++ b/crates/utilities/serde/README.md
@@ -1,0 +1,65 @@
+## `kona-serde`
+
+<a href="https://github.com/op-rs/kona/actions/workflows/ci.yml"><img src="https://github.com/op-rs/kona/actions/workflows/ci.yml/badge.svg?label=ci" alt="CI"></a>
+<a href="https://crates.io/crates/kona-serde"><img src="https://img.shields.io/crates/v/kona-serde.svg" alt="kona-serde crate"></a>
+<a href="https://github.com/op-rs/kona/blob/main/LICENSE-MIT"><img src="https://img.shields.io/badge/License-MIT-d1d1f6.svg?label=license&labelColor=2a2f35" alt="MIT License"></a>
+<a href="https://github.com/op-rs/kona/blob/main/LICENSE-APACHE"><img src="https://img.shields.io/badge/License-APACHE-d1d1f6.svg?label=license&labelColor=2a2f35" alt="Apache License"></a>
+<a href="https://op-rs.github.io/kona"><img src="https://img.shields.io/badge/Book-854a15?logo=mdBook&labelColor=2a2f35" alt="Book"></a>
+
+Serde related helpers for kona.
+
+### Graceful Serialization
+
+This crate extends the serialization and deserialization
+functionality provided by [`alloy-serde`][alloy-serde] to
+deserialize raw number quantity values.
+
+This issue arose in `u128` toml deserialization where
+deserialization of a raw number fails.
+[This rust playground][invalid] demonstrates how toml fails to
+deserialize a native `u128` internal value.
+
+With `kona-serde`, tagging the inner `u128` field with `#[serde(with = "kona_serde::quantity")]`,
+allows the `u128` or any other type within the following constraints to be deserialized by toml properly.
+
+These are the supported native types:
+- `bool`
+- `u8`
+- `u16`
+- `u32`
+- `u64`
+- `u128`
+
+Below demonstrates the use of the `#[serde(with = "kona_serde::quantity")]` attribute.
+
+```rust
+use serde::{Serialize, Deserialize};
+
+/// My wrapper type.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MyStruct {
+    /// The inner `u128` value.
+    #[serde(with = "kona_serde::quantity")]
+    pub inner: u128,
+}
+
+// Correctly deserializes a raw value.
+let raw_toml = r#"inner = 120"#;
+let b: MyStruct = toml::from_str(raw_toml).expect("failed to deserialize toml");
+println!("{}", b.inner);
+
+// Notice that a string value is also deserialized correctly.
+let raw_toml = r#"inner = "120""#;
+let b: MyStruct = toml::from_str(raw_toml).expect("failed to deserialize toml");
+println!("{}", b.inner);
+```
+
+### Provenance
+
+This code is heavily based on the [`alloy-serde`][alloy-serde] crate.
+
+
+<!-- Hyperlinks -->
+
+[invalid]: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=d3c674d02a90c574e3f543144621418d
+[alloy-serde]: https://crates.io/crates/alloy-serde

--- a/crates/utilities/serde/maili/Cargo.toml
+++ b/crates/utilities/serde/maili/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "maili-serde"
+version = "0.2.8"
+description = "Serde related helpers for Maili"
+
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+kona-serde.workspace = true
+
+[features]
+default = ["std"]
+std = ["kona-serde/std"]

--- a/crates/utilities/serde/maili/src/lib.rs
+++ b/crates/utilities/serde/maili/src/lib.rs
@@ -1,0 +1,10 @@
+#![doc = include_str!("../../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/op-rs/kona/main/assets/square.png",
+    html_favicon_url = "https://raw.githubusercontent.com/op-rs/kona/main/assets/favicon.ico"
+)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![no_std]
+
+pub use kona_serde::*;

--- a/crates/utilities/serde/src/lib.rs
+++ b/crates/utilities/serde/src/lib.rs
@@ -1,0 +1,12 @@
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/op-rs/kona/main/assets/square.png",
+    html_favicon_url = "https://raw.githubusercontent.com/op-rs/kona/main/assets/favicon.ico"
+)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![no_std]
+
+extern crate alloc;
+
+pub mod quantity;

--- a/crates/utilities/serde/src/quantity.rs
+++ b/crates/utilities/serde/src/quantity.rs
@@ -1,0 +1,83 @@
+//! Kona quantity serialization and deserialization helpers.
+
+use alloc::string::ToString;
+use core::str::FromStr;
+use private::ConvertRuint;
+use serde::{self, de, Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Value;
+
+/// Serializes a primitive number as a "quantity" hex string.
+pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    T: ConvertRuint,
+    S: Serializer,
+{
+    value.into_ruint().serialize(serializer)
+}
+
+/// Deserializes a primitive number from a "quantity" hex string or raw number.
+pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: ConvertRuint,
+    D: Deserializer<'de>,
+{
+    use serde::de::Error;
+    match Value::deserialize(deserializer)? {
+        Value::String(s) => T::Ruint::from_str(&s)
+            .map_err(|_| D::Error::custom("failed to deserialize str"))
+            .map(T::from_ruint),
+        Value::Number(num) => T::Ruint::from_str(&num.to_string())
+            .map_err(|_| de::Error::custom("failed to deserialize number"))
+            .map(T::from_ruint),
+        _ => Err(de::Error::custom("only string and number types are supported")),
+    }
+}
+
+/// Private implementation details of the [`quantity`](self) module.
+#[allow(unnameable_types)]
+mod private {
+    use core::str::FromStr;
+
+    #[doc(hidden)]
+    pub trait ConvertRuint: Copy + Sized {
+        type Ruint: Copy
+            + serde::Serialize
+            + serde::de::DeserializeOwned
+            + TryFrom<Self>
+            + TryInto<Self>
+            + FromStr;
+
+        #[inline]
+        fn into_ruint(self) -> Self::Ruint {
+            // We have to use `Try*` traits because `From` is not implemented by ruint types.
+            // They shouldn't ever error.
+            self.try_into().ok().unwrap()
+        }
+
+        #[inline]
+        fn from_ruint(ruint: Self::Ruint) -> Self {
+            // We have to use `Try*` traits because `From` is not implemented by ruint types.
+            // They shouldn't ever error.
+            ruint.try_into().ok().unwrap()
+        }
+    }
+
+    macro_rules! impl_from_ruint {
+        ($($primitive:ty = $ruint:ty),* $(,)?) => {
+            $(
+                impl ConvertRuint for $primitive {
+                    type Ruint = $ruint;
+                }
+            )*
+        };
+    }
+
+    impl_from_ruint! {
+        bool = alloy_primitives::ruint::aliases::U1,
+        u8   = alloy_primitives::U8,
+        u16  = alloy_primitives::U16,
+        u32  = alloy_primitives::U32,
+        u64  = alloy_primitives::U64,
+        u128 = alloy_primitives::U128,
+    }
+}

--- a/docker/fpvm-prestates/asterisc-repro.dockerfile
+++ b/docker/fpvm-prestates/asterisc-repro.dockerfile
@@ -44,7 +44,7 @@ RUN git clone https://github.com/op-rs/kona
 # Build kona-client on the selected tag
 RUN cd kona && \
   git checkout $CLIENT_TAG && \
-  cargo build -Zbuild-std=core,alloc --workspace --bin kona --locked --profile release-client-lto --exclude kona-host --exclude kona-providers-alloy && \
+  cargo build -Zbuild-std=core,alloc --workspace --bin kona --locked --profile release-client-lto --exclude kona-host --exclude kona-providers-alloy --exclude kona-net --exclude kona-serde --exclude maili-serde && \
   mv ./target/riscv64imac-unknown-none-elf/release-client-lto/kona /kona-client-elf
 
 ################################################################

--- a/justfile
+++ b/justfile
@@ -105,7 +105,7 @@ build-cannon *args='':
     --platform linux/amd64 \
     -v `pwd`/:/workdir \
     -w="/workdir" \
-    ghcr.io/op-rs/kona/cannon-builder:main cargo build --workspace -Zbuild-std=core,alloc $@ --exclude kona-host --exclude kona-providers-alloy --exclude kona-net
+    ghcr.io/op-rs/kona/cannon-builder:main cargo build --workspace -Zbuild-std=core,alloc $@ --exclude kona-host --exclude kona-providers-alloy --exclude kona-net --exclude kona-serde --exclude maili-serde
 
 # Build for the `asterisc` target. Any crates that require the stdlib are excluded from the build for this target.
 build-asterisc *args='':
@@ -114,7 +114,7 @@ build-asterisc *args='':
     --platform linux/amd64 \
     -v `pwd`/:/workdir \
     -w="/workdir" \
-    ghcr.io/op-rs/kona/asterisc-builder:main cargo build --workspace -Zbuild-std=core,alloc $@ --exclude kona-host --exclude kona-providers-alloy --exclude kona-net
+    ghcr.io/op-rs/kona/asterisc-builder:main cargo build --workspace -Zbuild-std=core,alloc $@ --exclude kona-host --exclude kona-providers-alloy --exclude kona-net --exclude kona-serde --exclude maili-serde
 
 # Clones and checks out the monorepo at the commit present in `.monorepo`
 monorepo:


### PR DESCRIPTION
### Description

Ports `maili-serde` to `kona` with the `maili-serde` shadow crate beneath `kona-serde`.