### PR TITLE
fix: Exclude kona-net

### DIFF
--- a/docker/fpvm-prestates/asterisc-repro.dockerfile
+++ b/docker/fpvm-prestates/asterisc-repro.dockerfile
@@ -44,7 +44,7 @@ RUN git clone https://github.com/op-rs/kona
 # Build kona-client on the selected tag
 RUN cd kona && \
   git checkout $CLIENT_TAG && \
-  cargo build -Zbuild-std=core,alloc --workspace --bin kona --locked --profile release-client-lto --exclude kona-host --exclude kona-providers-alloy && \
+  cargo build -Zbuild-std=core,alloc --workspace --bin kona --locked --profile release-client-lto --exclude kona-host --exclude kona-providers-alloy --exclude kona-net && \
   mv ./target/riscv64imac-unknown-none-elf/release-client-lto/kona /kona-client-elf
 
 ################################################################


### PR DESCRIPTION
### Description

Excludes `kona-net` so the asterisc builder works