### PR TITLE
fix: fix type annotations

### DIFF
--- a/bin/host/src/interop/handler.rs
+++ b/bin/host/src/interop/handler.rs
@@ -297,7 +297,7 @@ impl HintHandler for InteropHintHandler {
 
                 ensure!(hint.data.len() == 40, "Invalid hint data length");
 
-                let hash: B256 = hint.data[..32].as_ref().try_into()?;
+                let hash: B256 = B256::from_slice(&hint.data[0..32]);
                 let chain_id = u64::from_be_bytes(hint.data[32..40].try_into()?);
                 let l2_provider = providers.l2(&chain_id)?;
 


### PR DESCRIPTION
# Issue
The original code attempted to convert a byte slice to B256 using:

```rust
let hash: B256 = hint.data[..32].as_ref().try_into()?;
```
However, this resulted in the following error due to missing type inference when I ran `cargo clippy --all-features --all-targets -- -D warnings -A incomplete-features` in [op-succinct](https://github.com/succinctlabs/op-succinct) repo:

```
error[E0282]: type annotations needed
   --> /Users/fakedev9999/.cargo/git/checkouts/kona-eb08956031b8bea7/cef9b87/bin/host/src/interop/handler.rs:300:50
    |
300 |                 let hash: B256 = hint.data[..32].as_ref().try_into()?;
    |                                                  ^^^^^^   -------- type must be known at this point
    |
help: try using a fully qualified path to specify the expected types
    |
300 |                 let hash: B256 = <[u8] as AsRef<T>>::as_ref(&hint.data[..32]).try_into()?;
    |                                  ++++++++++++++++++++++++++++               ~

For more information about this error, try `rustc --explain E0282`.
error: could not compile `kona-host` (lib) due to 1 previous error
```

# Fix
Replaced the failing conversion with:

```rust
let hash: B256 = B256::from_slice(&hint.data[0..32]);
```

This explicitly converts the first 32 bytes of hint.data into B256, resolving the type inference issue and making the conversion unambiguous.

# Impact
No functional changes beyond resolving the compilation issue
