### PR TITLE
feat(client): support cannon mips64r2

### DIFF
--- a/.github/workflows/client_host.yaml
+++ b/.github/workflows/client_host.yaml
@@ -66,7 +66,7 @@ jobs:
         if: "contains(matrix.target, 'cannon')"
         run: |
           # TODO(pcw109550): pin cannon version which supports mips64r2 exec
-          # temporaliy pin to some recent version which does not support mips64r2 exec
+          # Temporarily pin to some recent version which does not support mips64r2 exec
           cd optimism/cannon && git checkout op-node/v1.10.2 && make cannon
           mv ./bin/cannon /usr/local/bin/
       - name: Set run environment

--- a/.github/workflows/client_host.yaml
+++ b/.github/workflows/client_host.yaml
@@ -66,7 +66,8 @@ jobs:
         if: "contains(matrix.target, 'cannon')"
         run: |
           # TODO(pcw109550): pin cannon version which supports mips64r2 exec
-          cd optimism/cannon && git checkout v1.2.0 && make cannon
+          # temporaliy pin to some recent version which does not support mips64r2 exec
+          cd optimism/cannon && git checkout op-node/v1.10.2 && make cannon
           mv ./bin/cannon /usr/local/bin/
       - name: Set run environment
         run: |

--- a/.github/workflows/client_host.yaml
+++ b/.github/workflows/client_host.yaml
@@ -36,18 +36,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Clone `asterisc` repository
-        if: "!contains(matrix.target, 'native')"
+        if: "contains(matrix.target, 'asterisc')"
         run: |
           git clone https://github.com/ethereum-optimism/asterisc.git
       - name: Setup Go toolchain
-        if: "!contains(matrix.target, 'native')"
+        if: "contains(matrix.target, 'asterisc')"
         uses: actions/setup-go@v5
         with:
           go-version: "1.21.6"
           cache-dependency-path: |
             asterisc/go.sum
       - name: Build `asterisc`
-        if: "!contains(matrix.target, 'native')"
+        if: "contains(matrix.target, 'asterisc')"
         run: |
           cd asterisc && git checkout v1.2.0 && make build-rvgo
           mv ./rvgo/bin/asterisc /usr/local/bin/

--- a/.github/workflows/client_host.yaml
+++ b/.github/workflows/client_host.yaml
@@ -11,7 +11,7 @@ jobs:
     name: ${{ matrix.target}} | ${{ matrix.name }}
     strategy:
       matrix:
-        target: ["native", "asterisc"]
+        target: ["native", "asterisc", "cannon"]
         name: ["OP Sepolia (Holocene) - Block #22012816"]
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -51,6 +51,23 @@ jobs:
         run: |
           cd asterisc && git checkout v1.2.0 && make build-rvgo
           mv ./rvgo/bin/asterisc /usr/local/bin/
+      - name: Clone monorepo for `cannon`
+        if: "contains(matrix.target, 'cannon')"
+        run: |
+          git clone https://github.com/ethereum-optimism/optimism.git
+      - name: Setup Go toolchain
+        if: "contains(matrix.target, 'cannon')"
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.21.6"
+          cache-dependency-path: |
+            optimism/go.sum
+      - name: Build `cannon`
+        if: "contains(matrix.target, 'cannon')"
+        run: |
+          # TODO(pcw109550): pin cannon version which supports mips64r2 exec
+          cd optimism/cannon && git checkout v1.2.0 && make cannon
+          mv ./bin/cannon /usr/local/bin/
       - name: Set run environment
         run: |
           if [[ ${{ contains(matrix.name, 22012816) }} == true ]]; then

--- a/bin/client/justfile
+++ b/bin/client/justfile
@@ -286,4 +286,3 @@ run-client-cannon-offline block_number l2_claim l2_output_root l2_head l1_head l
     --server \
     --data-dir ./data \
     {{verbosity}}
-  

--- a/bin/client/justfile
+++ b/bin/client/justfile
@@ -185,62 +185,62 @@ run-client-asterisc-offline block_number l2_claim l2_output_root l2_head l1_head
 
 # Run the client program on cannon with the host in detached server mode.
 run-client-cannon block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc verbosity='':
-    #!/usr/bin/env bash
+  #!/usr/bin/env bash
 
-    L1_NODE_ADDRESS="{{l1_rpc}}"
-    L1_BEACON_ADDRESS="{{l1_beacon_rpc}}"
-    L2_NODE_ADDRESS="{{l2_rpc}}"
-    OP_NODE_ADDRESS="{{rollup_node_rpc}}"
+  L1_NODE_ADDRESS="{{l1_rpc}}"
+  L1_BEACON_ADDRESS="{{l1_beacon_rpc}}"
+  L2_NODE_ADDRESS="{{l2_rpc}}"
+  OP_NODE_ADDRESS="{{rollup_node_rpc}}"
 
-    HOST_BIN_PATH="./target/release/kona-host"
-    CLIENT_BIN_PATH="./target/mips64-unknown-none/release-client-lto/kona"
-    STATE_PATH="./state.bin.gz"
+  HOST_BIN_PATH="./target/release/kona-host"
+  CLIENT_BIN_PATH="./target/mips64-unknown-none/release-client-lto/kona"
+  STATE_PATH="./state.bin.gz"
 
-    CLAIMED_L2_BLOCK_NUMBER={{block_number}}
-    echo "Fetching configuration for block #$CLAIMED_L2_BLOCK_NUMBER..."
+  CLAIMED_L2_BLOCK_NUMBER={{block_number}}
+  echo "Fetching configuration for block #$CLAIMED_L2_BLOCK_NUMBER..."
 
-    # Get output root for block
-    CLAIMED_L2_OUTPUT_ROOT=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $CLAIMED_L2_BLOCK_NUMBER) | jq -r .outputRoot)
+  # Get output root for block
+  CLAIMED_L2_OUTPUT_ROOT=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $CLAIMED_L2_BLOCK_NUMBER) | jq -r .outputRoot)
 
-    # Get the info for the previous block
-    AGREED_L2_OUTPUT_ROOT=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $((CLAIMED_L2_BLOCK_NUMBER - 1))) | jq -r .outputRoot)
-    AGREED_L2_HEAD_HASH=$(cast block --rpc-url $L2_NODE_ADDRESS $((CLAIMED_L2_BLOCK_NUMBER - 1)) --json | jq -r .hash)
-    L1_ORIGIN_NUM=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $((CLAIMED_L2_BLOCK_NUMBER - 1))) | jq -r .blockRef.l1origin.number)
-    L1_HEAD=$(cast block --rpc-url $L1_NODE_ADDRESS $((L1_ORIGIN_NUM + 30)) --json | jq -r .hash)
-    L2_CHAIN_ID=$(cast chain-id --rpc-url $L2_NODE_ADDRESS)
+  # Get the info for the previous block
+  AGREED_L2_OUTPUT_ROOT=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $((CLAIMED_L2_BLOCK_NUMBER - 1))) | jq -r .outputRoot)
+  AGREED_L2_HEAD_HASH=$(cast block --rpc-url $L2_NODE_ADDRESS $((CLAIMED_L2_BLOCK_NUMBER - 1)) --json | jq -r .hash)
+  L1_ORIGIN_NUM=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $((CLAIMED_L2_BLOCK_NUMBER - 1))) | jq -r .blockRef.l1origin.number)
+  L1_HEAD=$(cast block --rpc-url $L1_NODE_ADDRESS $((L1_ORIGIN_NUM + 30)) --json | jq -r .hash)
+  L2_CHAIN_ID=$(cast chain-id --rpc-url $L2_NODE_ADDRESS)
 
-    # Move to the workspace root
-    cd $(git rev-parse --show-toplevel)
+  # Move to the workspace root
+  cd $(git rev-parse --show-toplevel)
 
-    echo "Building client program for MIPS64 target..."
-    just build-cannon --bin kona --profile release-client-lto
+  echo "Building client program for MIPS64 target..."
+  just build-cannon --bin kona --profile release-client-lto
 
-    echo "Loading client program into Cannon state format..."
-    cannon load-elf --path=$CLIENT_BIN_PATH --type multithreaded64-3
+  echo "Loading client program into Cannon state format..."
+  cannon load-elf --path=$CLIENT_BIN_PATH --type multithreaded64-3
 
-    echo "Building host program for native target..."
-    cargo build --bin kona-host --release
+  echo "Building host program for native target..."
+  cargo build --bin kona-host --release
 
-    echo "Running cannon"
-    cannon run \
-      --info-at '%10000000' \
-      --proof-at never \
-      --input $STATE_PATH \
-      -- \
-      $HOST_BIN_PATH \
-      single \
-      --l1-head $L1_HEAD \
-      --agreed-l2-head-hash $AGREED_L2_HEAD_HASH \
-      --claimed-l2-output-root $CLAIMED_L2_OUTPUT_ROOT \
-      --agreed-l2-output-root $AGREED_L2_OUTPUT_ROOT \
-      --claimed-l2-block-number $CLAIMED_L2_BLOCK_NUMBER \
-      --l2-chain-id $L2_CHAIN_ID \
-      --l1-node-address $L1_NODE_ADDRESS \
-      --l1-beacon-address $L1_BEACON_ADDRESS \
-      --l2-node-address $L2_NODE_ADDRESS \
-      --server \
-      --data-dir ./data \
-      {{verbosity}}
+  echo "Running cannon"
+  cannon run \
+    --info-at '%10000000' \
+    --proof-at never \
+    --input $STATE_PATH \
+    -- \
+    $HOST_BIN_PATH \
+    single \
+    --l1-head $L1_HEAD \
+    --agreed-l2-head-hash $AGREED_L2_HEAD_HASH \
+    --claimed-l2-output-root $CLAIMED_L2_OUTPUT_ROOT \
+    --agreed-l2-output-root $AGREED_L2_OUTPUT_ROOT \
+    --claimed-l2-block-number $CLAIMED_L2_BLOCK_NUMBER \
+    --l2-chain-id $L2_CHAIN_ID \
+    --l1-node-address $L1_NODE_ADDRESS \
+    --l1-beacon-address $L1_BEACON_ADDRESS \
+    --l2-node-address $L2_NODE_ADDRESS \
+    --server \
+    --data-dir ./data \
+    {{verbosity}}
 
 # Run the client program on cannon with the host program detached, in offline mode.
 run-client-cannon-offline block_number l2_claim l2_output_root l2_head l1_head l2_chain_id verbosity='':

--- a/bin/client/justfile
+++ b/bin/client/justfile
@@ -182,3 +182,108 @@ run-client-asterisc-offline block_number l2_claim l2_output_root l2_head l1_head
     --server \
     --data-dir ./data \
     {{verbosity}}
+
+# Run the client program on cannon with the host in detached server mode.
+run-client-cannon block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc verbosity='':
+    #!/usr/bin/env bash
+
+    L1_NODE_ADDRESS="{{l1_rpc}}"
+    L1_BEACON_ADDRESS="{{l1_beacon_rpc}}"
+    L2_NODE_ADDRESS="{{l2_rpc}}"
+    OP_NODE_ADDRESS="{{rollup_node_rpc}}"
+
+    HOST_BIN_PATH="./target/release/kona-host"
+    CLIENT_BIN_PATH="./target/mips64-unknown-none/release-client-lto/kona"
+    STATE_PATH="./state.bin.gz"
+
+    CLAIMED_L2_BLOCK_NUMBER={{block_number}}
+    echo "Fetching configuration for block #$CLAIMED_L2_BLOCK_NUMBER..."
+
+    # Get output root for block
+    CLAIMED_L2_OUTPUT_ROOT=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $CLAIMED_L2_BLOCK_NUMBER) | jq -r .outputRoot)
+
+    # Get the info for the previous block
+    AGREED_L2_OUTPUT_ROOT=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $((CLAIMED_L2_BLOCK_NUMBER - 1))) | jq -r .outputRoot)
+    AGREED_L2_HEAD_HASH=$(cast block --rpc-url $L2_NODE_ADDRESS $((CLAIMED_L2_BLOCK_NUMBER - 1)) --json | jq -r .hash)
+    L1_ORIGIN_NUM=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $((CLAIMED_L2_BLOCK_NUMBER - 1))) | jq -r .blockRef.l1origin.number)
+    L1_HEAD=$(cast block --rpc-url $L1_NODE_ADDRESS $((L1_ORIGIN_NUM + 30)) --json | jq -r .hash)
+    L2_CHAIN_ID=$(cast chain-id --rpc-url $L2_NODE_ADDRESS)
+
+    # Move to the workspace root
+    cd $(git rev-parse --show-toplevel)
+
+    echo "Building client program for MIPS64 target..."
+    just build-cannon --bin kona --profile release-client-lto
+
+    echo "Loading client program into Cannon state format..."
+    cannon load-elf --path=$CLIENT_BIN_PATH --type multithreaded64-3
+
+    echo "Building host program for native target..."
+    cargo build --bin kona-host --release
+
+    echo "Running cannon"
+    cannon run \
+      --info-at '%10000000' \
+      --proof-at never \
+      --input $STATE_PATH \
+      -- \
+      $HOST_BIN_PATH \
+      single \
+      --l1-head $L1_HEAD \
+      --agreed-l2-head-hash $AGREED_L2_HEAD_HASH \
+      --claimed-l2-output-root $CLAIMED_L2_OUTPUT_ROOT \
+      --agreed-l2-output-root $AGREED_L2_OUTPUT_ROOT \
+      --claimed-l2-block-number $CLAIMED_L2_BLOCK_NUMBER \
+      --l2-chain-id $L2_CHAIN_ID \
+      --l1-node-address $L1_NODE_ADDRESS \
+      --l1-beacon-address $L1_BEACON_ADDRESS \
+      --l2-node-address $L2_NODE_ADDRESS \
+      --server \
+      --data-dir ./data \
+      {{verbosity}}
+
+# Run the client program on cannon with the host program detached, in offline mode.
+run-client-cannon-offline block_number l2_claim l2_output_root l2_head l1_head l2_chain_id verbosity='':
+  #!/usr/bin/env bash
+  
+  HOST_BIN_PATH="./target/debug/kona-host"
+  CLIENT_BIN_PATH="./target/mips64-unknown-none/release-client-lto/kona"
+  STATE_PATH="./state.bin.gz"
+  
+  CLAIMED_L2_BLOCK_NUMBER={{block_number}}
+  CLAIMED_L2_OUTPUT_ROOT={{l2_claim}}
+  AGREED_L2_OUTPUT_ROOT={{l2_output_root}}
+  AGREED_L2_HEAD_HASH={{l2_head}}
+  L1_HEAD={{l1_head}}
+  L2_CHAIN_ID={{l2_chain_id}}
+  
+  # Move to the workspace root
+  cd $(git rev-parse --show-toplevel)
+
+  echo "Building client program for MIPS64 target..."
+  just build-cannon --bin kona --profile release-client-lto
+  
+  echo "Loading client program into Cannon state format..."
+  cannon load-elf --path=$CLIENT_BIN_PATH --type multithreaded64-3
+  
+  echo "Building host program for native target..."
+  cargo build --bin kona-host
+  
+  echo "Running cannon"
+  cannon run \
+    --info-at '%10000000' \
+    --proof-at never \
+    --input $STATE_PATH \
+    -- \
+    $HOST_BIN_PATH \
+    single \
+    --l1-head $L1_HEAD \
+    --agreed-l2-head-hash $AGREED_L2_HEAD_HASH \
+    --claimed-l2-output-root $CLAIMED_L2_OUTPUT_ROOT \
+    --agreed-l2-output-root $AGREED_L2_OUTPUT_ROOT \
+    --claimed-l2-block-number $CLAIMED_L2_BLOCK_NUMBER \
+    --l2-chain-id $L2_CHAIN_ID \
+    --server \
+    --data-dir ./data \
+    {{verbosity}}
+  


### PR DESCRIPTION
Luckily we only need DCLZ support after ruint patch https://github.com/recmo/uint/pull/431 is applied. So closing below monorepo PR and plan to reopen with minimal diff only for DCLZ
- Cannon supporting minimal mips64r2: https://github.com/pcw109550/optimism/tree/pcw109550/cannon-mipsevm-full-mips64r2