### PR TITLE
chore(book): RFC and Archives Section

### DIFF
--- a/.github/workflows/book.yaml
+++ b/.github/workflows/book.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup mdbook
         run: |
           cargo install --version 0.4.40 mdbook
-          cargo install mdbook-mermaid mdbook-template
+          cargo install mdbook-mermaid mdbook-template mdbook-alerts
       - name: Build book
         working-directory: ./book
         run: mdbook build

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,8 +1,9 @@
 # Summary
 
 - [Introduction](./intro.md)
-- [Proposals](./proposals/intro.md)
-  - [Monorepo](./proposals/monorepo.md)
+- [RFC](./rfc/intro.md)
+  - [Monorepo](./rfc/monorepo.md)
+- [Archives](./archives/intro.md)
 - [Fault Proof Program Development](./fpp-dev/intro.md)
   - [Environment](./fpp-dev/env.md)
     - [Supported Targets](./fpp-dev/targets.md)

--- a/book/src/archives/intro.md
+++ b/book/src/archives/intro.md
@@ -1,0 +1,3 @@
+# Archived Documents
+
+These are archived documents that have been implemented or are no longer relevant.

--- a/book/src/rfc/intro.md
+++ b/book/src/rfc/intro.md
@@ -1,0 +1,8 @@
+# Request For Comment [RFC]
+
+Documents in this section are in the request-for-comment stage.
+
+To comment on these documents, [open an issue in the kona repository](https://github.com/op-rs/kona/issues/new)
+and provide detail on the changes you're requesting.
+
+Once the document has been reviewed, they will be moved to the [archives](../archives/intro.md).

--- a/book/src/rfc/monorepo.md
+++ b/book/src/rfc/monorepo.md
@@ -1,7 +1,7 @@
-# Monorepo Project Proposal
+# [RFC] Monorepo Project
 
-This is a proposal to merge multiple external repositories into
-`kona` to create a rust monorepo for Optimism.
+This is an RFC (request for comment) to merge multiple external
+repositories into `kona` to create a rust monorepo for Optimism.
 
 ## Provenance
 


### PR DESCRIPTION
### Description

Moves the monorepo doc to the new RFC section.

Also introduces a new archives section that will be used to
hold documents like RFC documents once they are implemented
or otherwise no longer living.