### PR TITLE
feat(client): support cannon mips64r1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2160,7 +2160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2235,6 +2235,17 @@ name = "fastrlp"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "fastrlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -3203,7 +3214,7 @@ checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi 0.4.0",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3674,8 +3685,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libp2p"
@@ -4600,6 +4617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -5298,7 +5316,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5765,17 +5783,19 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c3cc4c2511671f327125da14133d0c5c5d137f006a1017a16f557bc85b16286"
+checksum = "825df406ec217a8116bd7b06897c6cc8f65ffefc15d030ae2c9540acc9ed50b6"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "bytes",
- "fastrlp",
+ "fastrlp 0.3.1",
+ "fastrlp 0.4.0",
  "num-bigint",
+ "num-integer",
  "num-traits",
  "parity-scale-codec",
  "primitive-types",
@@ -5855,7 +5875,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6509,7 +6529,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7221,7 +7241,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/bin/client/justfile
+++ b/bin/client/justfile
@@ -182,3 +182,107 @@ run-client-asterisc-offline block_number l2_claim l2_output_root l2_head l1_head
     --server \
     --data-dir ./data \
     {{verbosity}}
+
+# Run the client program on cannon with the host in detached server mode.
+run-client-cannon block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc verbosity='':
+  #!/usr/bin/env bash
+
+  L1_NODE_ADDRESS="{{l1_rpc}}"
+  L1_BEACON_ADDRESS="{{l1_beacon_rpc}}"
+  L2_NODE_ADDRESS="{{l2_rpc}}"
+  OP_NODE_ADDRESS="{{rollup_node_rpc}}"
+
+  HOST_BIN_PATH="./target/release/kona-host"
+  CLIENT_BIN_PATH="./target/mips64-unknown-none/release-client-lto/kona"
+  STATE_PATH="./state.bin.gz"
+
+  CLAIMED_L2_BLOCK_NUMBER={{block_number}}
+  echo "Fetching configuration for block #$CLAIMED_L2_BLOCK_NUMBER..."
+
+  # Get output root for block
+  CLAIMED_L2_OUTPUT_ROOT=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $CLAIMED_L2_BLOCK_NUMBER) | jq -r .outputRoot)
+
+  # Get the info for the previous block
+  AGREED_L2_OUTPUT_ROOT=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $((CLAIMED_L2_BLOCK_NUMBER - 1))) | jq -r .outputRoot)
+  AGREED_L2_HEAD_HASH=$(cast block --rpc-url $L2_NODE_ADDRESS $((CLAIMED_L2_BLOCK_NUMBER - 1)) --json | jq -r .hash)
+  L1_ORIGIN_NUM=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $((CLAIMED_L2_BLOCK_NUMBER - 1))) | jq -r .blockRef.l1origin.number)
+  L1_HEAD=$(cast block --rpc-url $L1_NODE_ADDRESS $((L1_ORIGIN_NUM + 30)) --json | jq -r .hash)
+  L2_CHAIN_ID=$(cast chain-id --rpc-url $L2_NODE_ADDRESS)
+
+  # Move to the workspace root
+  cd $(git rev-parse --show-toplevel)
+
+  echo "Building client program for MIPS64 target..."
+  just build-cannon --bin kona --profile release-client-lto
+
+  echo "Loading client program into Cannon state format..."
+  cannon load-elf --path=$CLIENT_BIN_PATH --type multithreaded64-3
+
+  echo "Building host program for native target..."
+  cargo build --bin kona-host --release
+
+  echo "Running cannon"
+  cannon run \
+    --info-at '%10000000' \
+    --proof-at never \
+    --input $STATE_PATH \
+    -- \
+    $HOST_BIN_PATH \
+    single \
+    --l1-head $L1_HEAD \
+    --agreed-l2-head-hash $AGREED_L2_HEAD_HASH \
+    --claimed-l2-output-root $CLAIMED_L2_OUTPUT_ROOT \
+    --agreed-l2-output-root $AGREED_L2_OUTPUT_ROOT \
+    --claimed-l2-block-number $CLAIMED_L2_BLOCK_NUMBER \
+    --l2-chain-id $L2_CHAIN_ID \
+    --l1-node-address $L1_NODE_ADDRESS \
+    --l1-beacon-address $L1_BEACON_ADDRESS \
+    --l2-node-address $L2_NODE_ADDRESS \
+    --server \
+    --data-dir ./data \
+    {{verbosity}}
+
+# Run the client program on cannon with the host program detached, in offline mode.
+run-client-cannon-offline block_number l2_claim l2_output_root l2_head l1_head l2_chain_id verbosity='':
+  #!/usr/bin/env bash
+  
+  HOST_BIN_PATH="./target/debug/kona-host"
+  CLIENT_BIN_PATH="./target/mips64-unknown-none/release-client-lto/kona"
+  STATE_PATH="./state.bin.gz"
+  
+  CLAIMED_L2_BLOCK_NUMBER={{block_number}}
+  CLAIMED_L2_OUTPUT_ROOT={{l2_claim}}
+  AGREED_L2_OUTPUT_ROOT={{l2_output_root}}
+  AGREED_L2_HEAD_HASH={{l2_head}}
+  L1_HEAD={{l1_head}}
+  L2_CHAIN_ID={{l2_chain_id}}
+  
+  # Move to the workspace root
+  cd $(git rev-parse --show-toplevel)
+
+  echo "Building client program for MIPS64 target..."
+  just build-cannon --bin kona --profile release-client-lto
+  
+  echo "Loading client program into Cannon state format..."
+  cannon load-elf --path=$CLIENT_BIN_PATH --type multithreaded64-3
+  
+  echo "Building host program for native target..."
+  cargo build --bin kona-host
+  
+  echo "Running cannon"
+  cannon run \
+    --info-at '%10000000' \
+    --proof-at never \
+    --input $STATE_PATH \
+    -- \
+    $HOST_BIN_PATH \
+    single \
+    --l1-head $L1_HEAD \
+    --agreed-l2-head-hash $AGREED_L2_HEAD_HASH \
+    --claimed-l2-output-root $CLAIMED_L2_OUTPUT_ROOT \
+    --agreed-l2-output-root $AGREED_L2_OUTPUT_ROOT \
+    --claimed-l2-block-number $CLAIMED_L2_BLOCK_NUMBER \
+    --l2-chain-id $L2_CHAIN_ID \
+    --server \
+    --data-dir ./data \
+    {{verbosity}}

--- a/docker/cannon/mips64-unknown-none.json
+++ b/docker/cannon/mips64-unknown-none.json
@@ -7,7 +7,7 @@
   "target-pointer-width": "64",
   "target-c-int-width": "32",
   "os": "none",
-  "features": "+soft-float,+mips64r2,+xgot,+noabicalls",
+  "features": "+soft-float,+mips64",
   "max-atomic-width": "64",
   "linker": "rust-lld",
   "linker-flavor": "ld.lld",


### PR DESCRIPTION
Diffs

- Update ruint dep to v1.13.1 (most recent)
- Patch cannon's build config to target mips64r1 on docker build.
- Patch justfile for testing kona on cannon.

Cannon with kona works with mips64r1 with the ruint patch in kona and DCLZ support for cannon. 

Tests
- Confirmed that local docker buildx build for cannon works
- Built kona on mips64r1
- Ran cannon(which supports DCLZ) with kona and validated offline host-client testing