### PR TITLE
fix(std-fpvm): Allow non-const fn with mut ref

### DIFF
--- a/crates/proof/std-fpvm/src/channel.rs
+++ b/crates/proof/std-fpvm/src/channel.rs
@@ -69,6 +69,7 @@ struct ReadFuture<'a> {
 
 impl<'a> ReadFuture<'a> {
     /// Create a new [ReadFuture] from a channel and a buffer.
+    #[allow(clippy::missing_const_for_fn)]
     fn new(channel: FileChannel, buf: &'a mut [u8]) -> Self {
         Self { channel, buf: RefCell::new(buf), read: 0 }
     }

--- a/justfile
+++ b/justfile
@@ -69,7 +69,6 @@ lint-native: fmt-native-check lint-docs
 lint-cannon:
   docker run \
     --rm \
-    --platform linux/amd64 \
     -v `pwd`/:/workdir \
     -w="/workdir" \
     ghcr.io/op-rs/kona/cannon-builder:main cargo clippy -p kona-std-fpvm --all-features -Zbuild-std=core,alloc -- -D warnings
@@ -78,7 +77,6 @@ lint-cannon:
 lint-asterisc:
   docker run \
     --rm \
-    --platform linux/amd64 \
     -v `pwd`/:/workdir \
     -w="/workdir" \
     ghcr.io/op-rs/kona/asterisc-builder:main cargo clippy -p kona-std-fpvm --all-features -Zbuild-std=core,alloc -- -D warnings
@@ -102,7 +100,6 @@ build-native *args='':
 build-cannon *args='':
   docker run \
     --rm \
-    --platform linux/amd64 \
     -v `pwd`/:/workdir \
     -w="/workdir" \
     ghcr.io/op-rs/kona/cannon-builder:main cargo build --workspace -Zbuild-std=core,alloc $@ --exclude kona-host --exclude kona-providers-alloy --exclude kona-net
@@ -111,7 +108,6 @@ build-cannon *args='':
 build-asterisc *args='':
   docker run \
     --rm \
-    --platform linux/amd64 \
     -v `pwd`/:/workdir \
     -w="/workdir" \
     ghcr.io/op-rs/kona/asterisc-builder:main cargo build --workspace -Zbuild-std=core,alloc $@ --exclude kona-host --exclude kona-providers-alloy --exclude kona-net


### PR DESCRIPTION
## Overview

Fixes the lint routine for the `cannon-builder` image. These images use the nightly toolchain, rather than the MSRV, to build.

Also loosens the requirements for the build images' platforms, since they're now distributed as cross-platform builds. Rejoice, Apple laptop users :D 