### PR TITLE
chore(workspace): Foundry Install Target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4752,7 +4752,7 @@ dependencies = [
  "parking_lot",
  "quinn",
  "rand 0.8.5",
- "ring 0.17.9",
+ "ring 0.17.10",
  "rustls",
  "socket2",
  "thiserror 1.0.69",
@@ -4824,7 +4824,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "rcgen",
- "ring 0.17.9",
+ "ring 0.17.10",
  "rustls",
  "rustls-webpki 0.101.7",
  "thiserror 1.0.69",
@@ -5022,48 +5022,6 @@ name = "lz4_flex"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
-
-[[package]]
-name = "maili-genesis"
-version = "0.2.8"
-dependencies = [
- "kona-genesis",
-]
-
-[[package]]
-name = "maili-interop"
-version = "0.2.8"
-dependencies = [
- "kona-interop",
-]
-
-[[package]]
-name = "maili-protocol"
-version = "0.2.8"
-dependencies = [
- "kona-protocol",
-]
-
-[[package]]
-name = "maili-registry"
-version = "0.2.8"
-dependencies = [
- "kona-registry",
-]
-
-[[package]]
-name = "maili-rpc"
-version = "0.2.8"
-dependencies = [
- "kona-rpc",
-]
-
-[[package]]
-name = "maili-serde"
-version = "0.2.8"
-dependencies = [
- "kona-serde",
-]
 
 [[package]]
 name = "match_cfg"
@@ -5927,9 +5885,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -6358,7 +6316,7 @@ dependencies = [
  "bytes",
  "getrandom 0.2.15",
  "rand 0.8.5",
- "ring 0.17.9",
+ "ring 0.17.10",
  "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
@@ -6536,9 +6494,9 @@ checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
 dependencies = [
  "bitflags 2.8.0",
 ]
@@ -7532,9 +7490,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.9"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75ec5e92c4d8aede845126adc388046234541629e76029599ed35a003c7ed24"
+checksum = "d34b5020fcdea098ef7d95e9f89ec15952123a4a039badd09fabebe9e963e839"
 dependencies = [
  "cc",
  "cfg-if",
@@ -7778,7 +7736,7 @@ checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "log",
  "once_cell",
- "ring 0.17.9",
+ "ring 0.17.10",
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
  "subtle",
@@ -7849,7 +7807,7 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.9",
+ "ring 0.17.10",
  "untrusted 0.9.0",
 ]
 
@@ -7859,7 +7817,7 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "ring 0.17.9",
+ "ring 0.17.10",
  "rustls-pki-types",
  "untrusted 0.9.0",
 ]
@@ -8258,7 +8216,7 @@ dependencies = [
  "chacha20poly1305",
  "curve25519-dalek",
  "rand_core 0.6.4",
- "ring 0.17.9",
+ "ring 0.17.10",
  "rustc_version 0.4.1",
  "sha2 0.10.8",
  "subtle",

--- a/Justfile
+++ b/Justfile
@@ -22,6 +22,11 @@ test *args="-E '!test(test_online)'":
 test-online:
   just test "-E 'test(test_online)'"
 
+# Installs the latest version of foundry using the monorepo
+install-foundry:
+  just monorepo
+  foundryup -i $(grep -m 1 'forge = "[^"]*"' ./monorepo/mise.toml | awk -F'"' '{print $2}')
+
 # Run action tests for the client program on the native target
 action-tests test_name='Test_ProgramAction' *args='':
   #!/bin/bash

--- a/scripts/check_no_std.sh
+++ b/scripts/check_no_std.sh
@@ -26,14 +26,6 @@ no_std_packages=(
 
   # utilities
   kona-serde
-
-  # Maili Shadows
-  maili-serde
-  maili-rpc
-  maili-genesis
-  maili-protocol
-  maili-registry
-  maili-interop
 )
 
 for package in "${no_std_packages[@]}"; do


### PR DESCRIPTION
### Description

Adds a small helper target to the `Justfile` to grab the foundry version from `mise.toml` in the monorepo and install that version using `foundryup -i`.