### PR TITLE
fix(workspace): Exclude Maili Shadows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5024,48 +5024,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
 
 [[package]]
-name = "maili-genesis"
-version = "0.2.8"
-dependencies = [
- "kona-genesis",
-]
-
-[[package]]
-name = "maili-interop"
-version = "0.2.8"
-dependencies = [
- "kona-interop",
-]
-
-[[package]]
-name = "maili-protocol"
-version = "0.2.8"
-dependencies = [
- "kona-protocol",
-]
-
-[[package]]
-name = "maili-registry"
-version = "0.2.8"
-dependencies = [
- "kona-registry",
-]
-
-[[package]]
-name = "maili-rpc"
-version = "0.2.8"
-dependencies = [
- "kona-rpc",
-]
-
-[[package]]
-name = "maili-serde"
-version = "0.2.8"
-dependencies = [
- "kona-serde",
-]
-
-[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,16 @@ homepage = "https://github.com/op-rs/kona"
 repository = "https://github.com/op-rs/kona"
 keywords = ["ethereum", "optimism", "crypto"]
 categories = ["cryptography", "cryptography::cryptocurrencies"]
-exclude = ["**/target"]
+exclude = [
+  "**/target",
+  # Maili shadow crates must be explicitly excluded for `cargo metadata` to work
+  "crates/external/rpc/maili",
+  "crates/protocol/protocol/maili",
+  "crates/protocol/interop/maili",
+  "crates/protocol/registry/maili",
+  "crates/protocol/genesis/maili",
+  "crates/utilities/serde/maili",
+]
 
 [workspace]
 members = [

--- a/crates/protocol/protocol/src/errors.rs
+++ b/crates/protocol/protocol/src/errors.rs
@@ -22,6 +22,6 @@ pub enum OpBlockConversionError {
     #[error("Empty transactions in payload. Block hash: {0}")]
     EmptyTransactions(B256),
     /// EIP-1559 parameter decoding error.
-    #[error("Failed to decode EIP-1559 parameters from header's `nonce` field.")]
+    #[error("Failed to decode EIP-1559 parameters from header's `extraData` field.")]
     Eip1559DecodeError,
 }


### PR DESCRIPTION
### Description

Releasing maili shadow crates currently fails since the `cargo metadata` command will error.

This PR explicitly excludes the maili shadows in the workspace manifest to allow releases.