### PR TITLE
chore(genesis): Rename HardForkConfiguration

### DIFF
--- a/crates/external/net/src/gossip/config.rs
+++ b/crates/external/net/src/gossip/config.rs
@@ -1,4 +1,4 @@
-//! Gossipsub Configuration
+//! Gossipsub Config
 
 use lazy_static::lazy_static;
 use libp2p::gossipsub::{Config, ConfigBuilder, ConfigBuilderError, Message, MessageId};

--- a/crates/protocol/genesis/src/chain/config.rs
+++ b/crates/protocol/genesis/src/chain/config.rs
@@ -6,8 +6,8 @@ use alloy_primitives::Address;
 
 use crate::{
     base_fee_params, base_fee_params_canyon, rollup::DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW,
-    AddressList, AltDAConfig, BaseFeeConfig, ChainGenesis, HardForkConfiguration, Roles,
-    RollupConfig, SuperchainLevel, GRANITE_CHANNEL_TIMEOUT,
+    AddressList, AltDAConfig, BaseFeeConfig, ChainGenesis, HardForkConfig, Roles, RollupConfig,
+    SuperchainLevel, GRANITE_CHANNEL_TIMEOUT,
 };
 
 /// Defines core blockchain settings per block.
@@ -86,9 +86,9 @@ pub struct ChainConfig {
     /// Gas paying token metadata. Not consumed by downstream OPStack components.
     #[cfg_attr(feature = "serde", serde(rename = "GasPayingToken", alias = "gas_paying_token"))]
     pub gas_paying_token: Option<Address>,
-    /// Hardfork Configuration. These values may override the superchain-wide defaults.
-    #[cfg_attr(feature = "serde", serde(alias = "hardforks"))]
-    pub hardfork_configuration: HardForkConfiguration,
+    /// Hardfork Config. These values may override the superchain-wide defaults.
+    #[cfg_attr(feature = "serde", serde(rename = "hardfork_configuration", alias = "hardforks"))]
+    pub hardfork_config: HardForkConfig,
     /// Optimism configuration
     #[cfg_attr(feature = "serde", serde(rename = "optimism"))]
     pub optimism: Option<BaseFeeConfig>,
@@ -140,14 +140,14 @@ impl ChainConfig {
             max_sequencer_drift: self.max_sequencer_drift,
             canyon_base_fee_params: self.canyon_base_fee_params(),
             regolith_time: Some(0),
-            canyon_time: self.hardfork_configuration.canyon_time,
-            delta_time: self.hardfork_configuration.delta_time,
-            ecotone_time: self.hardfork_configuration.ecotone_time,
-            fjord_time: self.hardfork_configuration.fjord_time,
-            granite_time: self.hardfork_configuration.granite_time,
-            holocene_time: self.hardfork_configuration.holocene_time,
-            isthmus_time: self.hardfork_configuration.isthmus_time,
-            interop_time: self.hardfork_configuration.interop_time,
+            canyon_time: self.hardfork_config.canyon_time,
+            delta_time: self.hardfork_config.delta_time,
+            ecotone_time: self.hardfork_config.ecotone_time,
+            fjord_time: self.hardfork_config.fjord_time,
+            granite_time: self.hardfork_config.granite_time,
+            holocene_time: self.hardfork_config.holocene_time,
+            isthmus_time: self.hardfork_config.isthmus_time,
+            interop_time: self.hardfork_config.interop_time,
             batch_inbox_address: self.batch_inbox_addr,
             deposit_contract_address: self
                 .addresses

--- a/crates/protocol/genesis/src/chain/hardfork.rs
+++ b/crates/protocol/genesis/src/chain/hardfork.rs
@@ -7,7 +7,7 @@
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
-pub struct HardForkConfiguration {
+pub struct HardForkConfig {
     /// Canyon hardfork activation time
     pub canyon_time: Option<u64>,
     /// Delta hardfork activation time

--- a/crates/protocol/genesis/src/chain/mod.rs
+++ b/crates/protocol/genesis/src/chain/mod.rs
@@ -22,7 +22,7 @@ mod altda;
 pub use altda::AltDAConfig;
 
 mod hardfork;
-pub use hardfork::HardForkConfiguration;
+pub use hardfork::HardForkConfig;
 
 mod roles;
 pub use roles::Roles;

--- a/crates/protocol/genesis/src/lib.rs
+++ b/crates/protocol/genesis/src/lib.rs
@@ -43,9 +43,13 @@ pub use system::{
     CONFIG_UPDATE_TOPIC,
 };
 
+/// An alias for the hardfork configuration.
+#[deprecated(note = "Use `HardForkConfig` instead")]
+pub type HardForkConfiguration = HardForkConfig;
+
 mod chain;
 pub use chain::{
-    AddressList, AltDAConfig, ChainConfig, HardForkConfiguration, Roles, BASE_MAINNET_CHAIN_ID,
+    AddressList, AltDAConfig, ChainConfig, HardForkConfig, Roles, BASE_MAINNET_CHAIN_ID,
     BASE_SEPOLIA_CHAIN_ID, OP_MAINNET_CHAIN_ID, OP_SEPOLIA_CHAIN_ID,
 };
 

--- a/crates/protocol/genesis/src/params.rs
+++ b/crates/protocol/genesis/src/params.rs
@@ -113,7 +113,7 @@ pub const OP_MAINNET_BASE_FEE_CONFIG: BaseFeeConfig = BaseFeeConfig {
     eip1559_denominator_canyon: OP_MAINNET_EIP1559_BASE_FEE_MAX_CHANGE_DENOMINATOR_CANYON,
 };
 
-/// Optimism Base Fee Configuration
+/// Optimism Base Fee Config
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/protocol/genesis/src/rollup.rs
+++ b/crates/protocol/genesis/src/rollup.rs
@@ -4,8 +4,7 @@ use alloy_eips::eip1559::BaseFeeParams;
 use alloy_primitives::Address;
 
 use crate::{
-    base_fee_params, base_fee_params_canyon, ChainGenesis, HardForkConfiguration,
-    OP_MAINNET_CHAIN_ID,
+    base_fee_params, base_fee_params_canyon, ChainGenesis, HardForkConfig, OP_MAINNET_CHAIN_ID,
 };
 
 /// The max rlp bytes per channel for the Bedrock hardfork.
@@ -330,9 +329,9 @@ impl RollupConfig {
         }
     }
 
-    /// Returns the [HardForkConfiguration] using [RollupConfig] timestamps.
-    pub const fn hardfork_config(&self) -> HardForkConfiguration {
-        HardForkConfiguration {
+    /// Returns the [HardForkConfig] using [RollupConfig] timestamps.
+    pub const fn hardfork_config(&self) -> HardForkConfig {
+        HardForkConfig {
             canyon_time: self.canyon_time,
             delta_time: self.delta_time,
             ecotone_time: self.ecotone_time,

--- a/crates/protocol/genesis/src/superchain/chain.rs
+++ b/crates/protocol/genesis/src/superchain/chain.rs
@@ -20,7 +20,7 @@ pub struct Superchain {
 #[cfg(feature = "serde")]
 mod tests {
     use super::*;
-    use crate::{HardForkConfiguration, SuperchainConfig, SuperchainL1Info};
+    use crate::{HardForkConfig, SuperchainConfig, SuperchainL1Info};
     use alloc::{string::ToString, vec};
 
     #[test]
@@ -87,7 +87,7 @@ mod tests {
                     public_rpc: "https://mainnet.rpc".to_string(),
                     explorer: "https://mainnet.explorer".to_string(),
                 },
-                hardforks: HardForkConfiguration {
+                hardforks: HardForkConfig {
                     canyon_time: Some(1699981200),
                     delta_time: Some(1703203200),
                     ecotone_time: Some(1708534800),

--- a/crates/protocol/genesis/src/superchain/chains.rs
+++ b/crates/protocol/genesis/src/superchain/chains.rs
@@ -18,7 +18,7 @@ pub struct Superchains {
 #[cfg(feature = "serde")]
 mod tests {
     use super::*;
-    use crate::{HardForkConfiguration, SuperchainConfig, SuperchainL1Info};
+    use crate::{HardForkConfig, SuperchainConfig, SuperchainL1Info};
     use alloc::{string::ToString, vec};
 
     #[test]
@@ -94,7 +94,7 @@ mod tests {
                         public_rpc: "https://mainnet.rpc".to_string(),
                         explorer: "https://mainnet.explorer".to_string(),
                     },
-                    hardforks: HardForkConfiguration {
+                    hardforks: HardForkConfig {
                         canyon_time: Some(1699981200),
                         delta_time: Some(1703203200),
                         ecotone_time: Some(1708534800),

--- a/crates/protocol/genesis/src/superchain/config.rs
+++ b/crates/protocol/genesis/src/superchain/config.rs
@@ -1,6 +1,6 @@
 //! Contains the `SuperchainConfig` type.
 
-use crate::{HardForkConfiguration, SuperchainL1Info};
+use crate::{HardForkConfig, SuperchainL1Info};
 use alloc::string::String;
 use alloy_primitives::Address;
 
@@ -14,7 +14,7 @@ pub struct SuperchainConfig {
     /// Superchain L1 anchor information
     pub l1: SuperchainL1Info,
     /// Default hardforks timestamps.
-    pub hardforks: HardForkConfiguration,
+    pub hardforks: HardForkConfig,
     /// Optional addresses for the superchain-wide default protocol versions contract.
     #[cfg_attr(feature = "serde", serde(alias = "protocolVersionsAddr"))]
     pub protocol_versions_addr: Option<Address>,
@@ -30,7 +30,7 @@ pub struct SuperchainConfig {
 #[cfg(feature = "serde")]
 mod tests {
     use super::*;
-    use crate::{HardForkConfiguration, SuperchainL1Info};
+    use crate::{HardForkConfig, SuperchainL1Info};
     use alloc::string::ToString;
 
     #[test]
@@ -87,7 +87,7 @@ mod tests {
                 public_rpc: "https://mainnet.rpc".to_string(),
                 explorer: "https://mainnet.explorer".to_string(),
             },
-            hardforks: HardForkConfiguration {
+            hardforks: HardForkConfig {
                 canyon_time: Some(1699981200),
                 delta_time: Some(1703203200),
                 ecotone_time: Some(1708534800),

--- a/crates/protocol/protocol/src/compression/config.rs
+++ b/crates/protocol/protocol/src/compression/config.rs
@@ -2,7 +2,7 @@
 
 use crate::{CompressionAlgo, CompressorType};
 
-/// Configuration for the compressor itself.
+/// Config for the compressor itself.
 #[derive(Debug, Clone)]
 pub struct Config {
     /// TargetOutputSize is the target size that the compressed data should reach.

--- a/crates/protocol/registry/src/superchain.rs
+++ b/crates/protocol/registry/src/superchain.rs
@@ -80,7 +80,7 @@ mod tests {
             governed_by_optimism: false,
             superchain_time: Some(0),
             batch_inbox_addr: address!("ff00000000000000000000000000000000008453"),
-            hardfork_configuration: crate::test_utils::BASE_MAINNET_CONFIG.hardfork_config(),
+            hardfork_config: crate::test_utils::BASE_MAINNET_CONFIG.hardfork_config(),
             block_time: 2,
             seq_window_size: 3600,
             max_sequencer_drift: 600,

--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,8 @@ ignore = [
     "RUSTSEC-2024-0384",
     # Can be removed once reth version is updated
     "RUSTSEC-2024-0370",
+    # Ring is unmaintained - used in upstream libs
+    "RUSTSEC-2025-0007",
 ]
 
 [licenses]

--- a/release.toml
+++ b/release.toml
@@ -1,4 +1,4 @@
-# Configuration file for [`cargo-release`](https://github.com/crate-ci/cargo-release)
+# Config file for [`cargo-release`](https://github.com/crate-ci/cargo-release)
 # See: https://github.com/crate-ci/cargo-release/blob/master/docs/reference.md
 
 allow-branch = ["main"]


### PR DESCRIPTION
### Description

Been wanting to do this for a while.

We've been inconsistently naming configuration types across our codebase.
Some have the suffix "Configuration" while others have "Config".

This PR renames `HardForkConfiguration` type to `HardForkConfig` and
deprecated a new `HardForkConfiguration` alias to improve devx.

I don't see a need to spell out the full "configuration" blurb when most
everywhere just uses "config" to denote a configuration, but open to discussion.