### PR TITLE
chore(genesis): Flatten Hardforks in Rollup Config

### DIFF
--- a/book/src/examples/new-l1-block-info-tx-hardfork.md
+++ b/book/src/examples/new-l1-block-info-tx-hardfork.md
@@ -13,7 +13,7 @@ for a new Hardfork.
 ## Required Genesis Updates
 
 The first updates that need to be made are to [`maili-genesis`][genesis]
-types, namely the [`RollupConfig`][rc] and [`HardForkConfiguration`][hfc].
+types, namely the [`RollupConfig`][rc] and [`HardForkConfig`][hfc].
 
 First, add a timestamp field to the [`RollupConfig`][rc]. Let's use the
 hardfork name "Glacier" as an example.
@@ -46,10 +46,10 @@ accessor to call this method (let's use "Isthmus" as the prior hardfork).
     }
 ```
 
-Lastly, add the "Glacier" timestamp to the [`HardForkConfiguration`][hfc].
+Lastly, add the "Glacier" timestamp to the [`HardForkConfig`][hfc].
 
 ```rust
-pub struct HardForkConfiguration {
+pub struct HardForkConfig {
     ...
     /// Glacier hardfork activation time
     pub glacier_time: Option<u64>,
@@ -109,5 +109,5 @@ Some new error variants to the [`BlockInfoError`][bie] are needed as well.
 [info-mod]: https://github.com/op-rs/maili/blob/main/crates/protocol/src/info/mod.rs
 [genesis]: https://docs.rs/maili-genesis/latest/maili_genesis/index.html
 [rc]: https://docs.rs/maili-genesis/latest/maili_genesis/struct.RollupConfig.html
-[hfc]: https://docs.rs/maili-genesis/latest/maili_genesis/struct.HardForkConfiguration.html
+[hfc]: https://docs.rs/maili-genesis/latest/maili_genesis/struct.HardForkConfig.html
 [info-tx]: https://docs.rs/maili-protocol/latest/maili_protocol/enum.L1BlockInfoTx.html

--- a/crates/proof/executor/benches/execution.rs
+++ b/crates/proof/executor/benches/execution.rs
@@ -8,7 +8,9 @@ use alloy_rlp::Decodable;
 use alloy_rpc_types_engine::PayloadAttributes;
 use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 use kona_executor::{StatelessL2BlockExecutor, TrieDBProvider};
-use kona_genesis::{RollupConfig, OP_MAINNET_BASE_FEE_PARAMS, OP_MAINNET_BASE_FEE_PARAMS_CANYON};
+use kona_genesis::{
+    HardForkConfig, RollupConfig, OP_MAINNET_BASE_FEE_PARAMS, OP_MAINNET_BASE_FEE_PARAMS_CANYON,
+};
 use kona_mpt::{NoopTrieHinter, TrieNode, TrieProvider};
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use pprof::criterion::{Output, PProfProfiler};
@@ -82,10 +84,13 @@ fn op_mainnet_exec_bench(
     // Make a mock rollup config for OP mainnet, with Ecotone activated at timestamp = 0.
     let rollup_config = RollupConfig {
         l2_chain_id: 10,
-        regolith_time: Some(0),
-        canyon_time: Some(0),
-        delta_time: Some(0),
-        ecotone_time: Some(0),
+        hardforks: HardForkConfig {
+            regolith_time: Some(0),
+            canyon_time: Some(0),
+            delta_time: Some(0),
+            ecotone_time: Some(0),
+            ..Default::default()
+        },
         base_fee_params: OP_MAINNET_BASE_FEE_PARAMS,
         canyon_base_fee_params: OP_MAINNET_BASE_FEE_PARAMS_CANYON,
         ..Default::default()

--- a/crates/protocol/derive/src/attributes/stateful.rs
+++ b/crates/protocol/derive/src/attributes/stateful.rs
@@ -251,7 +251,7 @@ mod tests {
     use alloc::vec;
     use alloy_consensus::Header;
     use alloy_primitives::{Log, LogData, B256, U256, U64};
-    use kona_genesis::{HardForkConfiguration, SystemConfig};
+    use kona_genesis::{HardForkConfig, SystemConfig};
     use kona_protocol::{BlockInfo, DepositError};
 
     fn generate_valid_log() -> Log {
@@ -484,7 +484,7 @@ mod tests {
         let timestamp = 100;
         let cfg = Arc::new(RollupConfig {
             block_time,
-            hardforks: HardForkConfiguration { canyon_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { canyon_time: Some(0), ..Default::default() },
             ..Default::default()
         });
         let l2_number = 1;
@@ -534,7 +534,7 @@ mod tests {
         let timestamp = 100;
         let cfg = Arc::new(RollupConfig {
             block_time,
-            hardforks: HardForkConfiguration { ecotone_time: Some(102), ..Default::default() },
+            hardforks: HardForkConfig { ecotone_time: Some(102), ..Default::default() },
             ..Default::default()
         });
         let l2_number = 1;
@@ -585,7 +585,7 @@ mod tests {
         let timestamp = 100;
         let cfg = Arc::new(RollupConfig {
             block_time,
-            hardforks: HardForkConfiguration { fjord_time: Some(102), ..Default::default() },
+            hardforks: HardForkConfig { fjord_time: Some(102), ..Default::default() },
             ..Default::default()
         });
         let l2_number = 1;

--- a/crates/protocol/derive/src/attributes/stateful.rs
+++ b/crates/protocol/derive/src/attributes/stateful.rs
@@ -251,7 +251,7 @@ mod tests {
     use alloc::vec;
     use alloy_consensus::Header;
     use alloy_primitives::{Log, LogData, B256, U256, U64};
-    use kona_genesis::SystemConfig;
+    use kona_genesis::{HardForkConfiguration, SystemConfig};
     use kona_protocol::{BlockInfo, DepositError};
 
     fn generate_valid_log() -> Log {
@@ -482,7 +482,11 @@ mod tests {
     async fn test_prepare_payload_with_canyon() {
         let block_time = 10;
         let timestamp = 100;
-        let cfg = Arc::new(RollupConfig { block_time, canyon_time: Some(0), ..Default::default() });
+        let cfg = Arc::new(RollupConfig {
+            block_time,
+            hardforks: HardForkConfiguration { canyon_time: Some(0), ..Default::default() },
+            ..Default::default()
+        });
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
         fetcher.insert(l2_number, SystemConfig::default());
@@ -528,8 +532,11 @@ mod tests {
     async fn test_prepare_payload_with_ecotone() {
         let block_time = 2;
         let timestamp = 100;
-        let cfg =
-            Arc::new(RollupConfig { block_time, ecotone_time: Some(102), ..Default::default() });
+        let cfg = Arc::new(RollupConfig {
+            block_time,
+            hardforks: HardForkConfiguration { ecotone_time: Some(102), ..Default::default() },
+            ..Default::default()
+        });
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
         fetcher.insert(l2_number, SystemConfig::default());
@@ -576,8 +583,11 @@ mod tests {
     async fn test_prepare_payload_with_fjord() {
         let block_time = 2;
         let timestamp = 100;
-        let cfg =
-            Arc::new(RollupConfig { block_time, fjord_time: Some(102), ..Default::default() });
+        let cfg = Arc::new(RollupConfig {
+            block_time,
+            hardforks: HardForkConfiguration { fjord_time: Some(102), ..Default::default() },
+            ..Default::default()
+        });
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
         fetcher.insert(l2_number, SystemConfig::default());

--- a/crates/protocol/derive/src/sources/ethereum.rs
+++ b/crates/protocol/derive/src/sources/ethereum.rs
@@ -87,7 +87,7 @@ mod tests {
     use alloy_consensus::TxEnvelope;
     use alloy_eips::eip2718::Decodable2718;
     use alloy_primitives::{address, Address};
-    use kona_genesis::{HardForkConfiguration, RollupConfig, SystemConfig};
+    use kona_genesis::{HardForkConfig, RollupConfig, SystemConfig};
     use kona_protocol::BlockInfo;
 
     fn default_test_blob_source() -> BlobSource<TestChainProvider, TestBlobProvider> {
@@ -126,7 +126,7 @@ mod tests {
         blob.data.push(BlobData { data: None, calldata: Some(Bytes::default()) });
         let calldata = CalldataSource::new(chain.clone(), Address::ZERO, Address::ZERO);
         let cfg = RollupConfig {
-            hardforks: HardForkConfiguration { ecotone_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { ecotone_time: Some(0), ..Default::default() },
             ..Default::default()
         };
 

--- a/crates/protocol/derive/src/sources/ethereum.rs
+++ b/crates/protocol/derive/src/sources/ethereum.rs
@@ -38,7 +38,7 @@ where
         calldata_source: CalldataSource<C>,
         cfg: &RollupConfig,
     ) -> Self {
-        Self { ecotone_timestamp: cfg.ecotone_time, blob_source, calldata_source }
+        Self { ecotone_timestamp: cfg.hardforks.ecotone_time, blob_source, calldata_source }
     }
 
     /// Instantiates a new [EthereumDataSource] from parts.
@@ -46,7 +46,7 @@ where
         let signer =
             cfg.genesis.system_config.as_ref().map(|sc| sc.batcher_address).unwrap_or_default();
         Self {
-            ecotone_timestamp: cfg.ecotone_time,
+            ecotone_timestamp: cfg.hardforks.ecotone_time,
             blob_source: BlobSource::new(provider.clone(), blobs, cfg.batch_inbox_address, signer),
             calldata_source: CalldataSource::new(provider, cfg.batch_inbox_address, signer),
         }

--- a/crates/protocol/derive/src/sources/ethereum.rs
+++ b/crates/protocol/derive/src/sources/ethereum.rs
@@ -87,7 +87,7 @@ mod tests {
     use alloy_consensus::TxEnvelope;
     use alloy_eips::eip2718::Decodable2718;
     use alloy_primitives::{address, Address};
-    use kona_genesis::{RollupConfig, SystemConfig};
+    use kona_genesis::{HardForkConfiguration, RollupConfig, SystemConfig};
     use kona_protocol::BlockInfo;
 
     fn default_test_blob_source() -> BlobSource<TestChainProvider, TestBlobProvider> {
@@ -125,7 +125,10 @@ mod tests {
         blob.open = true;
         blob.data.push(BlobData { data: None, calldata: Some(Bytes::default()) });
         let calldata = CalldataSource::new(chain.clone(), Address::ZERO, Address::ZERO);
-        let cfg = RollupConfig { ecotone_time: Some(0), ..Default::default() };
+        let cfg = RollupConfig {
+            hardforks: HardForkConfiguration { ecotone_time: Some(0), ..Default::default() },
+            ..Default::default()
+        };
 
         // Should successfully retrieve a blob batch from the block
         let mut data_source = EthereumDataSource::new(blob, calldata, &cfg);

--- a/crates/protocol/derive/src/stages/batch/batch_provider.rs
+++ b/crates/protocol/derive/src/stages/batch/batch_provider.rs
@@ -182,14 +182,17 @@ mod test {
         types::ResetSignal,
     };
     use alloc::{sync::Arc, vec};
-    use kona_genesis::RollupConfig;
+    use kona_genesis::{HardForkConfiguration, RollupConfig};
     use kona_protocol::BlockInfo;
 
     #[test]
     fn test_batch_provider_validator_active() {
         let provider = TestNextBatchProvider::new(vec![]);
         let l2_provider = TestL2ChainProvider::default();
-        let cfg = Arc::new(RollupConfig { holocene_time: Some(0), ..Default::default() });
+        let cfg = Arc::new(RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        });
         let mut batch_provider = BatchProvider::new(cfg, provider, l2_provider);
 
         assert!(batch_provider.attempt_update().is_ok());
@@ -215,7 +218,10 @@ mod test {
     fn test_batch_provider_transition_stage() {
         let provider = TestNextBatchProvider::new(vec![]);
         let l2_provider = TestL2ChainProvider::default();
-        let cfg = Arc::new(RollupConfig { holocene_time: Some(2), ..Default::default() });
+        let cfg = Arc::new(RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(12), ..Default::default() },
+            ..Default::default()
+        });
         let mut batch_provider = BatchProvider::new(cfg, provider, l2_provider);
 
         batch_provider.attempt_update().unwrap();
@@ -238,7 +244,10 @@ mod test {
     fn test_batch_provider_transition_stage_backwards() {
         let provider = TestNextBatchProvider::new(vec![]);
         let l2_provider = TestL2ChainProvider::default();
-        let cfg = Arc::new(RollupConfig { holocene_time: Some(2), ..Default::default() });
+        let cfg = Arc::new(RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(2), ..Default::default() },
+            ..Default::default()
+        });
         let mut batch_provider = BatchProvider::new(cfg, provider, l2_provider);
 
         batch_provider.attempt_update().unwrap();
@@ -285,7 +294,10 @@ mod test {
     async fn test_batch_provider_reset_validator() {
         let provider = TestNextBatchProvider::new(vec![]);
         let l2_provider = TestL2ChainProvider::default();
-        let cfg = Arc::new(RollupConfig { holocene_time: Some(0), ..Default::default() });
+        let cfg = Arc::new(RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        });
         let mut batch_provider = BatchProvider::new(cfg, provider, l2_provider);
 
         // Reset the batch provider.

--- a/crates/protocol/derive/src/stages/batch/batch_provider.rs
+++ b/crates/protocol/derive/src/stages/batch/batch_provider.rs
@@ -219,7 +219,7 @@ mod test {
         let provider = TestNextBatchProvider::new(vec![]);
         let l2_provider = TestL2ChainProvider::default();
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(12), ..Default::default() },
+            hardforks: HardForkConfiguration { holocene_time: Some(2), ..Default::default() },
             ..Default::default()
         });
         let mut batch_provider = BatchProvider::new(cfg, provider, l2_provider);

--- a/crates/protocol/derive/src/stages/batch/batch_provider.rs
+++ b/crates/protocol/derive/src/stages/batch/batch_provider.rs
@@ -182,7 +182,7 @@ mod test {
         types::ResetSignal,
     };
     use alloc::{sync::Arc, vec};
-    use kona_genesis::{HardForkConfiguration, RollupConfig};
+    use kona_genesis::{HardForkConfig, RollupConfig};
     use kona_protocol::BlockInfo;
 
     #[test]
@@ -190,7 +190,7 @@ mod test {
         let provider = TestNextBatchProvider::new(vec![]);
         let l2_provider = TestL2ChainProvider::default();
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         });
         let mut batch_provider = BatchProvider::new(cfg, provider, l2_provider);
@@ -219,7 +219,7 @@ mod test {
         let provider = TestNextBatchProvider::new(vec![]);
         let l2_provider = TestL2ChainProvider::default();
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(2), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(2), ..Default::default() },
             ..Default::default()
         });
         let mut batch_provider = BatchProvider::new(cfg, provider, l2_provider);
@@ -245,7 +245,7 @@ mod test {
         let provider = TestNextBatchProvider::new(vec![]);
         let l2_provider = TestL2ChainProvider::default();
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(2), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(2), ..Default::default() },
             ..Default::default()
         });
         let mut batch_provider = BatchProvider::new(cfg, provider, l2_provider);
@@ -295,7 +295,7 @@ mod test {
         let provider = TestNextBatchProvider::new(vec![]);
         let l2_provider = TestL2ChainProvider::default();
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         });
         let mut batch_provider = BatchProvider::new(cfg, provider, l2_provider);

--- a/crates/protocol/derive/src/stages/batch/batch_queue.rs
+++ b/crates/protocol/derive/src/stages/batch/batch_queue.rs
@@ -468,7 +468,7 @@ mod tests {
     use alloy_eips::{eip2718::Decodable2718, BlockNumHash};
     use alloy_primitives::{address, b256, Address, Bytes, TxKind, B256, U256};
     use alloy_rlp::{BytesMut, Encodable};
-    use kona_genesis::{ChainGenesis, HardForkConfiguration, MAX_RLP_BYTES_PER_CHANNEL_FJORD};
+    use kona_genesis::{ChainGenesis, HardForkConfig, MAX_RLP_BYTES_PER_CHANNEL_FJORD};
     use kona_protocol::{BatchReader, L1BlockInfoBedrock, L1BlockInfoTx};
     use op_alloy_consensus::{OpBlock, OpTxEnvelope, OpTxType, TxDeposit};
     use tracing::Level;
@@ -542,7 +542,7 @@ mod tests {
         // Construct a future single batch.
         let cfg = Arc::new(RollupConfig {
             max_sequencer_drift: 700,
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         });
         assert!(cfg.is_holocene_active(0));
@@ -579,7 +579,7 @@ mod tests {
     async fn test_holocene_add_batch_future() {
         // Construct a future single batch.
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         });
         assert!(cfg.is_holocene_active(0));
@@ -648,7 +648,7 @@ mod tests {
         // Construct a single batch with BatchValidity::Past.
         let cfg = Arc::new(RollupConfig {
             block_time: 2,
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         });
         assert!(cfg.is_holocene_active(0));
@@ -833,7 +833,7 @@ mod tests {
 
         // Construct a future single batch.
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         });
         assert!(cfg.is_holocene_active(0));
@@ -961,7 +961,7 @@ mod tests {
         let payload_block_hash =
             b256!("4444444444444444444444444444444444444444444444444444444444444444");
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfiguration { delta_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
             block_time: 100,
             max_sequencer_drift: 10000000,
             seq_window_size: 10000000,

--- a/crates/protocol/derive/src/stages/batch/batch_queue.rs
+++ b/crates/protocol/derive/src/stages/batch/batch_queue.rs
@@ -468,7 +468,7 @@ mod tests {
     use alloy_eips::{eip2718::Decodable2718, BlockNumHash};
     use alloy_primitives::{address, b256, Address, Bytes, TxKind, B256, U256};
     use alloy_rlp::{BytesMut, Encodable};
-    use kona_genesis::{ChainGenesis, MAX_RLP_BYTES_PER_CHANNEL_FJORD};
+    use kona_genesis::{ChainGenesis, HardForkConfiguration, MAX_RLP_BYTES_PER_CHANNEL_FJORD};
     use kona_protocol::{BatchReader, L1BlockInfoBedrock, L1BlockInfoTx};
     use op_alloy_consensus::{OpBlock, OpTxEnvelope, OpTxType, TxDeposit};
     use tracing::Level;
@@ -578,7 +578,10 @@ mod tests {
     #[tokio::test]
     async fn test_holocene_add_batch_future() {
         // Construct a future single batch.
-        let cfg = Arc::new(RollupConfig { holocene_time: Some(0), ..Default::default() });
+        let cfg = Arc::new(RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        });
         assert!(cfg.is_holocene_active(0));
         let batch = SingleBatch {
             parent_hash: B256::default(),
@@ -643,8 +646,11 @@ mod tests {
     #[tokio::test]
     async fn test_add_old_batch_drop_holocene() {
         // Construct a single batch with BatchValidity::Past.
-        let cfg =
-            Arc::new(RollupConfig { holocene_time: Some(0), block_time: 2, ..Default::default() });
+        let cfg = Arc::new(RollupConfig {
+            block_time: 2,
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        });
         assert!(cfg.is_holocene_active(0));
         let batch = SingleBatch {
             parent_hash: B256::default(),
@@ -826,7 +832,10 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         // Construct a future single batch.
-        let cfg = Arc::new(RollupConfig { holocene_time: Some(0), ..Default::default() });
+        let cfg = Arc::new(RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        });
         assert!(cfg.is_holocene_active(0));
         let batch = SingleBatch {
             parent_hash: B256::default(),
@@ -952,7 +961,7 @@ mod tests {
         let payload_block_hash =
             b256!("4444444444444444444444444444444444444444444444444444444444444444");
         let cfg = Arc::new(RollupConfig {
-            delta_time: Some(0),
+            hardforks: HardForkConfiguration { delta_time: Some(0), ..Default::default() },
             block_time: 100,
             max_sequencer_drift: 10000000,
             seq_window_size: 10000000,

--- a/crates/protocol/derive/src/stages/batch/batch_queue.rs
+++ b/crates/protocol/derive/src/stages/batch/batch_queue.rs
@@ -542,7 +542,7 @@ mod tests {
         // Construct a future single batch.
         let cfg = Arc::new(RollupConfig {
             max_sequencer_drift: 700,
-            holocene_time: Some(0),
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         });
         assert!(cfg.is_holocene_active(0));

--- a/crates/protocol/derive/src/stages/batch/batch_stream.rs
+++ b/crates/protocol/derive/src/stages/batch/batch_stream.rs
@@ -226,14 +226,14 @@ mod test {
     };
     use alloc::vec;
     use alloy_eips::NumHash;
-    use kona_genesis::HardForkConfiguration;
+    use kona_genesis::HardForkConfig;
     use kona_protocol::{SingleBatch, SpanBatchElement};
     use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
     #[tokio::test]
     async fn test_batch_stream_flush() {
         let config = Arc::new(RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         });
         let prev = TestBatchStreamProvider::new(vec![]);
@@ -250,7 +250,7 @@ mod test {
     #[tokio::test]
     async fn test_batch_stream_reset() {
         let config = Arc::new(RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         });
         let prev = TestBatchStreamProvider::new(vec![]);
@@ -267,7 +267,7 @@ mod test {
     #[tokio::test]
     async fn test_batch_stream_flush_channel() {
         let config = Arc::new(RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         });
         let prev = TestBatchStreamProvider::new(vec![]);
@@ -289,7 +289,7 @@ mod test {
 
         let data = vec![Ok(Batch::Single(SingleBatch::default()))];
         let config = Arc::new(RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(100), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(100), ..Default::default() },
             ..Default::default()
         });
         let prev = TestBatchStreamProvider::new(data);
@@ -321,7 +321,7 @@ mod test {
         let data = vec![Ok(Batch::Span(mock_batch.clone()))];
         let config = Arc::new(RollupConfig {
             block_time: 2,
-            hardforks: HardForkConfiguration {
+            hardforks: HardForkConfig {
                 delta_time: Some(0),
                 holocene_time: Some(0),
                 ..Default::default()
@@ -387,7 +387,7 @@ mod test {
     async fn test_single_batch_pass_through() {
         let data = vec![Ok(Batch::Single(SingleBatch::default()))];
         let config = Arc::new(RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         });
         let prev = TestBatchStreamProvider::new(data);
@@ -416,7 +416,7 @@ mod test {
         let data = vec![Ok(Batch::Span(mock_batch))];
 
         let config = Arc::new(RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         });
         let prev = TestBatchStreamProvider::new(data);

--- a/crates/protocol/derive/src/stages/batch/batch_stream.rs
+++ b/crates/protocol/derive/src/stages/batch/batch_stream.rs
@@ -226,12 +226,16 @@ mod test {
     };
     use alloc::vec;
     use alloy_eips::NumHash;
+    use kona_genesis::HardForkConfiguration;
     use kona_protocol::{SingleBatch, SpanBatchElement};
     use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
     #[tokio::test]
     async fn test_batch_stream_flush() {
-        let config = Arc::new(RollupConfig { holocene_time: Some(0), ..RollupConfig::default() });
+        let config = Arc::new(RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        });
         let prev = TestBatchStreamProvider::new(vec![]);
         let mut stream = BatchStream::new(prev, config, TestL2ChainProvider::default());
         stream.buffer.push_back(SingleBatch::default());
@@ -245,7 +249,10 @@ mod test {
 
     #[tokio::test]
     async fn test_batch_stream_reset() {
-        let config = Arc::new(RollupConfig { holocene_time: Some(0), ..RollupConfig::default() });
+        let config = Arc::new(RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        });
         let prev = TestBatchStreamProvider::new(vec![]);
         let mut stream = BatchStream::new(prev, config.clone(), TestL2ChainProvider::default());
         stream.buffer.push_back(SingleBatch::default());
@@ -259,7 +266,10 @@ mod test {
 
     #[tokio::test]
     async fn test_batch_stream_flush_channel() {
-        let config = Arc::new(RollupConfig { holocene_time: Some(0), ..RollupConfig::default() });
+        let config = Arc::new(RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        });
         let prev = TestBatchStreamProvider::new(vec![]);
         let mut stream = BatchStream::new(prev, config.clone(), TestL2ChainProvider::default());
         stream.buffer.push_back(SingleBatch::default());
@@ -278,7 +288,10 @@ mod test {
         tracing_subscriber::Registry::default().with(layer).init();
 
         let data = vec![Ok(Batch::Single(SingleBatch::default()))];
-        let config = Arc::new(RollupConfig { holocene_time: Some(100), ..RollupConfig::default() });
+        let config = Arc::new(RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(100), ..Default::default() },
+            ..Default::default()
+        });
         let prev = TestBatchStreamProvider::new(data);
         let mut stream = BatchStream::new(prev, config.clone(), TestL2ChainProvider::default());
 
@@ -307,10 +320,13 @@ mod test {
 
         let data = vec![Ok(Batch::Span(mock_batch.clone()))];
         let config = Arc::new(RollupConfig {
-            delta_time: Some(0),
-            holocene_time: Some(0),
             block_time: 2,
-            ..RollupConfig::default()
+            hardforks: HardForkConfiguration {
+                delta_time: Some(0),
+                holocene_time: Some(0),
+                ..Default::default()
+            },
+            ..Default::default()
         });
         let prev = TestBatchStreamProvider::new(data);
         let provider = TestL2ChainProvider::default();
@@ -370,7 +386,10 @@ mod test {
     #[tokio::test]
     async fn test_single_batch_pass_through() {
         let data = vec![Ok(Batch::Single(SingleBatch::default()))];
-        let config = Arc::new(RollupConfig { holocene_time: Some(0), ..RollupConfig::default() });
+        let config = Arc::new(RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        });
         let prev = TestBatchStreamProvider::new(data);
         let mut stream = BatchStream::new(prev, config.clone(), TestL2ChainProvider::default());
 
@@ -396,7 +415,10 @@ mod test {
         let mock_origins = [BlockInfo { number: 1, timestamp: 12, ..Default::default() }];
         let data = vec![Ok(Batch::Span(mock_batch))];
 
-        let config = Arc::new(RollupConfig { holocene_time: Some(0), ..RollupConfig::default() });
+        let config = Arc::new(RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        });
         let prev = TestBatchStreamProvider::new(data);
         let mut stream = BatchStream::new(prev, config.clone(), TestL2ChainProvider::default());
 

--- a/crates/protocol/derive/src/stages/batch/batch_validator.rs
+++ b/crates/protocol/derive/src/stages/batch/batch_validator.rs
@@ -319,7 +319,7 @@ mod test {
     use alloc::{sync::Arc, vec, vec::Vec};
     use alloy_eips::{BlockNumHash, NumHash};
     use alloy_primitives::B256;
-    use kona_genesis::{HardForkConfiguration, RollupConfig};
+    use kona_genesis::{HardForkConfig, RollupConfig};
     use kona_protocol::{Batch, BlockInfo, L2BlockInfo, SingleBatch, SpanBatch};
     use tracing::Level;
     use tracing_subscriber::layer::SubscriberExt;
@@ -497,7 +497,7 @@ mod test {
     #[tokio::test]
     async fn test_batch_validator_next_batch_valid() {
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             block_time: 2,
             max_sequencer_drift: 700,
             ..Default::default()

--- a/crates/protocol/derive/src/stages/batch/batch_validator.rs
+++ b/crates/protocol/derive/src/stages/batch/batch_validator.rs
@@ -319,7 +319,7 @@ mod test {
     use alloc::{sync::Arc, vec, vec::Vec};
     use alloy_eips::{BlockNumHash, NumHash};
     use alloy_primitives::B256;
-    use kona_genesis::RollupConfig;
+    use kona_genesis::{HardForkConfiguration, RollupConfig};
     use kona_protocol::{Batch, BlockInfo, L2BlockInfo, SingleBatch, SpanBatch};
     use tracing::Level;
     use tracing_subscriber::layer::SubscriberExt;
@@ -497,7 +497,7 @@ mod test {
     #[tokio::test]
     async fn test_batch_validator_next_batch_valid() {
         let cfg = Arc::new(RollupConfig {
-            holocene_time: Some(0),
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
             block_time: 2,
             max_sequencer_drift: 700,
             ..Default::default()

--- a/crates/protocol/derive/src/stages/channel/channel_assembler.rs
+++ b/crates/protocol/derive/src/stages/channel/channel_assembler.rs
@@ -192,7 +192,7 @@ mod test {
     };
     use alloc::{sync::Arc, vec};
     use kona_genesis::{
-        HardForkConfiguration, RollupConfig, MAX_RLP_BYTES_PER_CHANNEL_BEDROCK,
+        HardForkConfig, RollupConfig, MAX_RLP_BYTES_PER_CHANNEL_BEDROCK,
         MAX_RLP_BYTES_PER_CHANNEL_FJORD,
     };
     use kona_protocol::BlockInfo;
@@ -350,7 +350,7 @@ mod test {
         frames[1].data = vec![0; MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize];
         let mock = TestNextFrameProvider::new(frames.into_iter().rev().map(Ok).collect());
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfiguration { fjord_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { fjord_time: Some(0), ..Default::default() },
             ..Default::default()
         });
 

--- a/crates/protocol/derive/src/stages/channel/channel_assembler.rs
+++ b/crates/protocol/derive/src/stages/channel/channel_assembler.rs
@@ -192,7 +192,8 @@ mod test {
     };
     use alloc::{sync::Arc, vec};
     use kona_genesis::{
-        RollupConfig, MAX_RLP_BYTES_PER_CHANNEL_BEDROCK, MAX_RLP_BYTES_PER_CHANNEL_FJORD,
+        HardForkConfiguration, RollupConfig, MAX_RLP_BYTES_PER_CHANNEL_BEDROCK,
+        MAX_RLP_BYTES_PER_CHANNEL_FJORD,
     };
     use kona_protocol::BlockInfo;
     use tracing::Level;
@@ -348,7 +349,10 @@ mod test {
         ];
         frames[1].data = vec![0; MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize];
         let mock = TestNextFrameProvider::new(frames.into_iter().rev().map(Ok).collect());
-        let cfg = Arc::new(RollupConfig { fjord_time: Some(0), ..Default::default() });
+        let cfg = Arc::new(RollupConfig {
+            hardforks: HardForkConfiguration { fjord_time: Some(0), ..Default::default() },
+            ..Default::default()
+        });
 
         let mut assembler = ChannelAssembler::new(cfg, mock);
 

--- a/crates/protocol/derive/src/stages/channel/channel_bank.rs
+++ b/crates/protocol/derive/src/stages/channel/channel_bank.rs
@@ -248,7 +248,7 @@ mod tests {
         types::ResetSignal,
     };
     use alloc::{vec, vec::Vec};
-    use kona_genesis::HardForkConfiguration;
+    use kona_genesis::HardForkConfig;
     use tracing::Level;
     use tracing_subscriber::layer::SubscriberExt;
 
@@ -360,7 +360,7 @@ mod tests {
     fn test_read_channel_active() {
         let mock = TestNextFrameProvider::new(vec![]);
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfiguration { canyon_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { canyon_time: Some(0), ..Default::default() },
             ..Default::default()
         });
         let mut channel_bank = ChannelBank::new(cfg, mock);
@@ -472,7 +472,7 @@ mod tests {
         let mut frames = crate::frames!(0xFF, 0, vec![0xDD; 50], 100000);
         let mock = TestNextFrameProvider::new(vec![]);
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfiguration { fjord_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { fjord_time: Some(0), ..Default::default() },
             ..Default::default()
         });
         let mut channel_bank = ChannelBank::new(cfg, mock);

--- a/crates/protocol/derive/src/stages/channel/channel_bank.rs
+++ b/crates/protocol/derive/src/stages/channel/channel_bank.rs
@@ -248,6 +248,7 @@ mod tests {
         types::ResetSignal,
     };
     use alloc::{vec, vec::Vec};
+    use kona_genesis::HardForkConfiguration;
     use tracing::Level;
     use tracing_subscriber::layer::SubscriberExt;
 
@@ -358,7 +359,10 @@ mod tests {
     #[test]
     fn test_read_channel_active() {
         let mock = TestNextFrameProvider::new(vec![]);
-        let cfg = Arc::new(RollupConfig { canyon_time: Some(0), ..Default::default() });
+        let cfg = Arc::new(RollupConfig {
+            hardforks: HardForkConfiguration { canyon_time: Some(0), ..Default::default() },
+            ..Default::default()
+        });
         let mut channel_bank = ChannelBank::new(cfg, mock);
         let id: ChannelId = [0xFF; 16];
         channel_bank.channel_queue.push_back(id);
@@ -467,7 +471,10 @@ mod tests {
     fn test_ingest_and_prune_channel_bank_fjord() {
         let mut frames = crate::frames!(0xFF, 0, vec![0xDD; 50], 100000);
         let mock = TestNextFrameProvider::new(vec![]);
-        let cfg = Arc::new(RollupConfig { fjord_time: Some(0), ..Default::default() });
+        let cfg = Arc::new(RollupConfig {
+            hardforks: HardForkConfiguration { fjord_time: Some(0), ..Default::default() },
+            ..Default::default()
+        });
         let mut channel_bank = ChannelBank::new(cfg, mock);
         // Ingest frames until the channel bank is full and it stops increasing in size
         let mut current_size = 0;

--- a/crates/protocol/derive/src/stages/channel/channel_provider.rs
+++ b/crates/protocol/derive/src/stages/channel/channel_provider.rs
@@ -163,14 +163,14 @@ mod test {
         types::ResetSignal,
     };
     use alloc::{sync::Arc, vec};
-    use kona_genesis::{HardForkConfiguration, RollupConfig};
+    use kona_genesis::{HardForkConfig, RollupConfig};
     use kona_protocol::BlockInfo;
 
     #[test]
     fn test_channel_provider_assembler_active() {
         let provider = TestNextFrameProvider::new(vec![]);
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         });
         let mut channel_provider = ChannelProvider::new(cfg, provider);
@@ -220,7 +220,7 @@ mod test {
     fn test_channel_provider_retain_current_assembler() {
         let provider = TestNextFrameProvider::new(vec![]);
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         });
         let mut channel_provider = ChannelProvider::new(cfg, provider);
@@ -246,7 +246,7 @@ mod test {
     fn test_channel_provider_transition_stage() {
         let provider = TestNextFrameProvider::new(vec![]);
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(2), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(2), ..Default::default() },
             ..Default::default()
         });
         let mut channel_provider = ChannelProvider::new(cfg, provider);
@@ -271,7 +271,7 @@ mod test {
     fn test_channel_provider_transition_stage_backwards() {
         let provider = TestNextFrameProvider::new(vec![]);
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(2), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(2), ..Default::default() },
             ..Default::default()
         });
         let mut channel_provider = ChannelProvider::new(cfg, provider);
@@ -339,7 +339,7 @@ mod test {
         ];
         let provider = TestNextFrameProvider::new(frames.into_iter().rev().map(Ok).collect());
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         });
         let mut channel_provider = ChannelProvider::new(cfg.clone(), provider);

--- a/crates/protocol/derive/src/stages/channel/channel_provider.rs
+++ b/crates/protocol/derive/src/stages/channel/channel_provider.rs
@@ -163,13 +163,16 @@ mod test {
         types::ResetSignal,
     };
     use alloc::{sync::Arc, vec};
-    use kona_genesis::RollupConfig;
+    use kona_genesis::{HardForkConfiguration, RollupConfig};
     use kona_protocol::BlockInfo;
 
     #[test]
     fn test_channel_provider_assembler_active() {
         let provider = TestNextFrameProvider::new(vec![]);
-        let cfg = Arc::new(RollupConfig { holocene_time: Some(0), ..Default::default() });
+        let cfg = Arc::new(RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        });
         let mut channel_provider = ChannelProvider::new(cfg, provider);
 
         assert!(channel_provider.attempt_update().is_ok());
@@ -216,7 +219,10 @@ mod test {
     #[test]
     fn test_channel_provider_retain_current_assembler() {
         let provider = TestNextFrameProvider::new(vec![]);
-        let cfg = Arc::new(RollupConfig { holocene_time: Some(0), ..Default::default() });
+        let cfg = Arc::new(RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        });
         let mut channel_provider = ChannelProvider::new(cfg, provider);
 
         // Assert the multiplexer hasn't been initialized.
@@ -239,7 +245,10 @@ mod test {
     #[test]
     fn test_channel_provider_transition_stage() {
         let provider = TestNextFrameProvider::new(vec![]);
-        let cfg = Arc::new(RollupConfig { holocene_time: Some(2), ..Default::default() });
+        let cfg = Arc::new(RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(2), ..Default::default() },
+            ..Default::default()
+        });
         let mut channel_provider = ChannelProvider::new(cfg, provider);
 
         channel_provider.attempt_update().unwrap();
@@ -261,7 +270,10 @@ mod test {
     #[test]
     fn test_channel_provider_transition_stage_backwards() {
         let provider = TestNextFrameProvider::new(vec![]);
-        let cfg = Arc::new(RollupConfig { holocene_time: Some(2), ..Default::default() });
+        let cfg = Arc::new(RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(2), ..Default::default() },
+            ..Default::default()
+        });
         let mut channel_provider = ChannelProvider::new(cfg, provider);
 
         channel_provider.attempt_update().unwrap();
@@ -326,7 +338,10 @@ mod test {
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
         let provider = TestNextFrameProvider::new(frames.into_iter().rev().map(Ok).collect());
-        let cfg = Arc::new(RollupConfig { holocene_time: Some(0), ..Default::default() });
+        let cfg = Arc::new(RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        });
         let mut channel_provider = ChannelProvider::new(cfg.clone(), provider);
 
         // Load in the first frame.

--- a/crates/protocol/derive/src/stages/channel/channel_reader.rs
+++ b/crates/protocol/derive/src/stages/channel/channel_reader.rs
@@ -168,6 +168,7 @@ mod test {
         errors::PipelineErrorKind, test_utils::TestChannelReaderProvider, types::ResetSignal,
     };
     use alloc::vec;
+    use kona_genesis::HardForkConfiguration;
 
     fn new_compressed_batch_data() -> Bytes {
         let file_contents =
@@ -245,7 +246,10 @@ mod test {
     #[tokio::test]
     async fn test_flush_post_holocene() {
         let raw = new_compressed_batch_data();
-        let config = Arc::new(RollupConfig { holocene_time: Some(0), ..RollupConfig::default() });
+        let config = Arc::new(RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        });
         let mock = TestChannelReaderProvider::new(vec![Ok(Some(raw))]);
         let mut reader = ChannelReader::new(mock, config);
         let res = reader.next_batch().await.unwrap();

--- a/crates/protocol/derive/src/stages/channel/channel_reader.rs
+++ b/crates/protocol/derive/src/stages/channel/channel_reader.rs
@@ -168,7 +168,7 @@ mod test {
         errors::PipelineErrorKind, test_utils::TestChannelReaderProvider, types::ResetSignal,
     };
     use alloc::vec;
-    use kona_genesis::HardForkConfiguration;
+    use kona_genesis::HardForkConfig;
 
     fn new_compressed_batch_data() -> Bytes {
         let file_contents =
@@ -247,7 +247,7 @@ mod test {
     async fn test_flush_post_holocene() {
         let raw = new_compressed_batch_data();
         let config = Arc::new(RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         });
         let mock = TestChannelReaderProvider::new(vec![Ok(Some(raw))]);

--- a/crates/protocol/derive/src/stages/frame_queue.rs
+++ b/crates/protocol/derive/src/stages/frame_queue.rs
@@ -195,6 +195,7 @@ pub(crate) mod tests {
     use super::*;
     use crate::{test_utils::TestFrameQueueProvider, types::ResetSignal};
     use alloc::vec;
+    use kona_genesis::HardForkConfiguration;
 
     #[tokio::test]
     async fn test_frame_queue_reset() {
@@ -296,8 +297,12 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 1, vec![0xDD; 50], false),
             crate::frame!(0xFF, 2, vec![0xDD; 50], true),
         ];
+        let cfg = RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        };
         let assert = crate::test_utils::FrameQueueBuilder::new()
-            .with_rollup_config(&RollupConfig { holocene_time: Some(0), ..Default::default() })
+            .with_rollup_config(&cfg)
             .with_origin(BlockInfo::default())
             .with_expected_frames(&frames)
             .with_frames(&frames)
@@ -309,8 +314,12 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn test_holocene_single_frame() {
         let frames = [crate::frame!(0xFF, 1, vec![0xDD; 50], true)];
+        let cfg = RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        };
         let assert = crate::test_utils::FrameQueueBuilder::new()
-            .with_rollup_config(&RollupConfig { holocene_time: Some(0), ..Default::default() })
+            .with_rollup_config(&cfg)
             .with_origin(BlockInfo::default())
             .with_expected_frames(&frames)
             .with_frames(&frames)
@@ -331,8 +340,12 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 0, vec![0xDD; 50], false),
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
+        let cfg = RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        };
         let assert = crate::test_utils::FrameQueueBuilder::new()
-            .with_rollup_config(&RollupConfig { holocene_time: Some(0), ..Default::default() })
+            .with_rollup_config(&cfg)
             .with_origin(BlockInfo::default())
             .with_expected_frames(&[&frames[0..3], &frames[4..]].concat())
             .with_frames(&frames)
@@ -350,8 +363,12 @@ pub(crate) mod tests {
             crate::frame!(0xEE, 3, vec![0xDD; 50], true), // Dropped
             crate::frame!(0xEE, 4, vec![0xDD; 50], false), // Dropped
         ];
+        let cfg = RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        };
         let assert = crate::test_utils::FrameQueueBuilder::new()
-            .with_rollup_config(&RollupConfig { holocene_time: Some(0), ..Default::default() })
+            .with_rollup_config(&cfg)
             .with_origin(BlockInfo::default())
             .with_expected_frames(&frames[0..2])
             .with_frames(&frames)
@@ -372,8 +389,12 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 0, vec![0xDD; 50], false),
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
+        let cfg = RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        };
         let assert = crate::test_utils::FrameQueueBuilder::new()
-            .with_rollup_config(&RollupConfig { holocene_time: Some(0), ..Default::default() })
+            .with_rollup_config(&cfg)
             .with_origin(BlockInfo::default())
             .with_expected_frames(&frames[4..])
             .with_frames(&frames)
@@ -397,8 +418,12 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 0, vec![0xDD; 50], false),
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
+        let cfg = RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        };
         let assert = crate::test_utils::FrameQueueBuilder::new()
-            .with_rollup_config(&RollupConfig { holocene_time: Some(0), ..Default::default() })
+            .with_rollup_config(&cfg)
             .with_origin(BlockInfo::default())
             .with_expected_frames(&[&frames[0..4], &frames[6..]].concat())
             .with_frames(&frames)
@@ -419,8 +444,12 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 1, vec![0xDD; 50], false), // Dropped
             crate::frame!(0xFF, 2, vec![0xDD; 50], true),  // Dropped
         ];
+        let cfg = RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        };
         let assert = crate::test_utils::FrameQueueBuilder::new()
-            .with_rollup_config(&RollupConfig { holocene_time: Some(0), ..Default::default() })
+            .with_rollup_config(&cfg)
             .with_origin(BlockInfo::default())
             .with_expected_frames(&frames[0..4])
             .with_frames(&frames)
@@ -442,8 +471,12 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 0, vec![0xDD; 50], false),
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
+        let cfg = RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        };
         let assert = crate::test_utils::FrameQueueBuilder::new()
-            .with_rollup_config(&RollupConfig { holocene_time: Some(0), ..Default::default() })
+            .with_rollup_config(&cfg)
             .with_origin(BlockInfo::default())
             .with_expected_frames(&[&frames[0..2], &frames[4..]].concat())
             .with_frames(&frames)
@@ -465,8 +498,12 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 0, vec![0xDD; 50], false),
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
+        let cfg = RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        };
         let assert = crate::test_utils::FrameQueueBuilder::new()
-            .with_rollup_config(&RollupConfig { holocene_time: Some(0), ..Default::default() })
+            .with_rollup_config(&cfg)
             .with_origin(BlockInfo::default())
             .with_expected_frames(&frames[4..])
             .with_frames(&frames)
@@ -488,8 +525,12 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 0, vec![0xDD; 50], false),
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
+        let cfg = RollupConfig {
+            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        };
         let assert = crate::test_utils::FrameQueueBuilder::new()
-            .with_rollup_config(&RollupConfig { holocene_time: Some(0), ..Default::default() })
+            .with_rollup_config(&cfg)
             .with_origin(BlockInfo::default())
             .with_expected_frames(&[&frames[1..2], &frames[3..]].concat())
             .with_frames(&frames)

--- a/crates/protocol/derive/src/stages/frame_queue.rs
+++ b/crates/protocol/derive/src/stages/frame_queue.rs
@@ -195,7 +195,7 @@ pub(crate) mod tests {
     use super::*;
     use crate::{test_utils::TestFrameQueueProvider, types::ResetSignal};
     use alloc::vec;
-    use kona_genesis::HardForkConfiguration;
+    use kona_genesis::HardForkConfig;
 
     #[tokio::test]
     async fn test_frame_queue_reset() {
@@ -298,7 +298,7 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 2, vec![0xDD; 50], true),
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -315,7 +315,7 @@ pub(crate) mod tests {
     async fn test_holocene_single_frame() {
         let frames = [crate::frame!(0xFF, 1, vec![0xDD; 50], true)];
         let cfg = RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -341,7 +341,7 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -364,7 +364,7 @@ pub(crate) mod tests {
             crate::frame!(0xEE, 4, vec![0xDD; 50], false), // Dropped
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -390,7 +390,7 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -419,7 +419,7 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -445,7 +445,7 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 2, vec![0xDD; 50], true),  // Dropped
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -472,7 +472,7 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -499,7 +499,7 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -526,7 +526,7 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfiguration { holocene_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()

--- a/crates/protocol/genesis/src/chain/config.rs
+++ b/crates/protocol/genesis/src/chain/config.rs
@@ -139,15 +139,7 @@ impl ChainConfig {
             seq_window_size: self.seq_window_size,
             max_sequencer_drift: self.max_sequencer_drift,
             canyon_base_fee_params: self.canyon_base_fee_params(),
-            regolith_time: Some(0),
-            canyon_time: self.hardfork_config.canyon_time,
-            delta_time: self.hardfork_config.delta_time,
-            ecotone_time: self.hardfork_config.ecotone_time,
-            fjord_time: self.hardfork_config.fjord_time,
-            granite_time: self.hardfork_config.granite_time,
-            holocene_time: self.hardfork_config.holocene_time,
-            isthmus_time: self.hardfork_config.isthmus_time,
-            interop_time: self.hardfork_config.interop_time,
+            hardforks: self.hardfork_config,
             batch_inbox_address: self.batch_inbox_addr,
             deposit_contract_address: self
                 .addresses

--- a/crates/protocol/genesis/src/chain/hardfork.rs
+++ b/crates/protocol/genesis/src/chain/hardfork.rs
@@ -8,21 +8,52 @@
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct HardForkConfig {
-    /// Canyon hardfork activation time
+    /// `regolith_time` sets the activation time of the Regolith network-upgrade:
+    /// a pre-mainnet Bedrock change that addresses findings of the Sherlock contest related to
+    /// deposit attributes. "Regolith" is the loose deposited rock that sits on top of Bedrock.
+    /// Active if regolith_time != None && L2 block timestamp >= Some(regolith_time), inactive
+    /// otherwise.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub regolith_time: Option<u64>,
+    /// `canyon_time` sets the activation time of the Canyon network upgrade.
+    /// Active if `canyon_time` != None && L2 block timestamp >= Some(canyon_time), inactive
+    /// otherwise.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub canyon_time: Option<u64>,
-    /// Delta hardfork activation time
+    /// `delta_time` sets the activation time of the Delta network upgrade.
+    /// Active if `delta_time` != None && L2 block timestamp >= Some(delta_time), inactive
+    /// otherwise.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub delta_time: Option<u64>,
-    /// Ecotone hardfork activation time
+    /// `ecotone_time` sets the activation time of the Ecotone network upgrade.
+    /// Active if `ecotone_time` != None && L2 block timestamp >= Some(ecotone_time), inactive
+    /// otherwise.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub ecotone_time: Option<u64>,
-    /// Fjord hardfork activation time
+    /// `fjord_time` sets the activation time of the Fjord network upgrade.
+    /// Active if `fjord_time` != None && L2 block timestamp >= Some(fjord_time), inactive
+    /// otherwise.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub fjord_time: Option<u64>,
-    /// Granite hardfork activation time
+    /// `granite_time` sets the activation time for the Granite network upgrade.
+    /// Active if `granite_time` != None && L2 block timestamp >= Some(granite_time), inactive
+    /// otherwise.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub granite_time: Option<u64>,
-    /// Holocene hardfork activation time
+    /// `holocene_time` sets the activation time for the Holocene network upgrade.
+    /// Active if `holocene_time` != None && L2 block timestamp >= Some(holocene_time), inactive
+    /// otherwise.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub holocene_time: Option<u64>,
-    /// Isthmus hardfork activation time
+    /// `isthmus_time` sets the activation time for the Isthmus network upgrade.
+    /// Active if `isthmus_time` != None && L2 block timestamp >= Some(isthmus_time), inactive
+    /// otherwise.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub isthmus_time: Option<u64>,
-    /// Interop hardfork activation time
+    /// `interop_time` sets the activation time for the Interop network upgrade.
+    /// Active if `interop_time` != None && L2 block timestamp >= Some(interop_time), inactive
+    /// otherwise.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub interop_time: Option<u64>,
 }
 
@@ -45,6 +76,7 @@ mod tests {
         "#;
 
         let hardforks = HardForkConfig {
+            regolith_time: None,
             canyon_time: Some(1699981200),
             delta_time: Some(1703203200),
             ecotone_time: Some(1708534800),
@@ -89,6 +121,7 @@ mod tests {
         "#;
 
         let hardforks = HardForkConfig {
+            regolith_time: None,
             canyon_time: Some(1699981200),
             delta_time: Some(1703203200),
             ecotone_time: Some(1708534800),

--- a/crates/protocol/genesis/src/superchain/chain.rs
+++ b/crates/protocol/genesis/src/superchain/chain.rs
@@ -88,6 +88,7 @@ mod tests {
                     explorer: "https://mainnet.explorer".to_string(),
                 },
                 hardforks: HardForkConfig {
+                    regolith_time: None,
                     canyon_time: Some(1699981200),
                     delta_time: Some(1703203200),
                     ecotone_time: Some(1708534800),

--- a/crates/protocol/genesis/src/superchain/chains.rs
+++ b/crates/protocol/genesis/src/superchain/chains.rs
@@ -95,6 +95,7 @@ mod tests {
                         explorer: "https://mainnet.explorer".to_string(),
                     },
                     hardforks: HardForkConfig {
+                        regolith_time: None,
                         canyon_time: Some(1699981200),
                         delta_time: Some(1703203200),
                         ecotone_time: Some(1708534800),

--- a/crates/protocol/genesis/src/superchain/config.rs
+++ b/crates/protocol/genesis/src/superchain/config.rs
@@ -58,6 +58,7 @@ mod tests {
                 explorer: "https://mainnet.explorer".to_string(),
             },
             hardforks: HardForkConfig {
+                regolith_time: None,
                 canyon_time: Some(1699981200),
                 delta_time: Some(1703203200),
                 ecotone_time: Some(1708534800),
@@ -150,6 +151,7 @@ mod tests {
                 explorer: "https://mainnet.explorer".to_string(),
             },
             hardforks: HardForkConfig {
+                regolith_time: None,
                 canyon_time: Some(1699981200),
                 delta_time: Some(1703203200),
                 ecotone_time: Some(1708534800),

--- a/crates/protocol/genesis/src/system/config.rs
+++ b/crates/protocol/genesis/src/system/config.rs
@@ -180,7 +180,7 @@ impl SystemConfig {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::CONFIG_UPDATE_EVENT_VERSION_0;
+    use crate::{HardForkConfig, CONFIG_UPDATE_EVENT_VERSION_0};
     use alloc::vec;
     use alloy_primitives::{address, b256, hex, LogData, B256};
 
@@ -253,7 +253,10 @@ mod test {
 
     #[test]
     fn test_eip_1559_params_from_system_config_some() {
-        let rollup_config = RollupConfig { holocene_time: Some(0), ..Default::default() };
+        let rollup_config = RollupConfig {
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        };
         let sys_config = SystemConfig {
             eip1559_denominator: Some(1),
             eip1559_elasticity: None,
@@ -265,7 +268,10 @@ mod test {
 
     #[test]
     fn test_eip_1559_params_from_system_config() {
-        let rollup_config = RollupConfig { holocene_time: Some(0), ..Default::default() };
+        let rollup_config = RollupConfig {
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        };
         let sys_config = SystemConfig {
             eip1559_denominator: Some(1),
             eip1559_elasticity: Some(2),
@@ -277,7 +283,10 @@ mod test {
 
     #[test]
     fn test_default_eip_1559_params_from_system_config() {
-        let rollup_config = RollupConfig { holocene_time: Some(0), ..Default::default() };
+        let rollup_config = RollupConfig {
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        };
         let sys_config = SystemConfig {
             eip1559_denominator: None,
             eip1559_elasticity: None,
@@ -300,7 +309,10 @@ mod test {
 
     #[test]
     fn test_default_eip_1559_params_first_block_holocene() {
-        let rollup_config = RollupConfig { holocene_time: Some(2), ..Default::default() };
+        let rollup_config = RollupConfig {
+            hardforks: HardForkConfig { holocene_time: Some(2), ..Default::default() },
+            ..Default::default()
+        };
         let sys_config = SystemConfig {
             eip1559_denominator: Some(1),
             eip1559_elasticity: Some(2),

--- a/crates/protocol/interop/src/graph.rs
+++ b/crates/protocol/interop/src/graph.rs
@@ -170,9 +170,9 @@ where
                 message.executing_timestamp,
                 initiating_timestamp,
             ));
-        } else if initiating_timestamp < rollup_config.interop_time.unwrap_or_default() {
+        } else if initiating_timestamp < rollup_config.hardforks.interop_time.unwrap_or_default() {
             return Err(MessageGraphError::InvalidMessageTimestamp(
-                rollup_config.interop_time.unwrap_or_default(),
+                rollup_config.hardforks.interop_time.unwrap_or_default(),
                 initiating_timestamp,
             ));
         }
@@ -240,7 +240,7 @@ mod test {
     use super::MessageGraph;
     use crate::{test_util::SuperchainBuilder, MessageGraphError};
     use alloy_primitives::{hex, keccak256, map::HashMap, Address};
-    use kona_genesis::RollupConfig;
+    use kona_genesis::{HardForkConfig, RollupConfig};
 
     const MESSAGE: [u8; 4] = hex!("deadbeef");
     const OP_CHAIN_ID: u64 = 10;
@@ -341,7 +341,13 @@ mod test {
         let (headers, provider) = superchain.build();
 
         let mut cfgs = HashMap::default();
-        cfgs.insert(0xDEAD, RollupConfig { interop_time: Some(50), ..Default::default() });
+        cfgs.insert(
+            0xDEAD,
+            RollupConfig {
+                hardforks: HardForkConfig { interop_time: Some(50), ..Default::default() },
+                ..Default::default()
+            },
+        );
         let graph = MessageGraph::derive(headers.as_slice(), &provider, &cfgs).await.unwrap();
         assert_eq!(
             graph.resolve().await.unwrap_err(),

--- a/crates/protocol/protocol/src/batch/reader.rs
+++ b/crates/protocol/protocol/src/batch/reader.rs
@@ -96,7 +96,9 @@ impl BatchReader {
 #[cfg(test)]
 mod test {
     use super::*;
-    use kona_genesis::{MAX_RLP_BYTES_PER_CHANNEL_BEDROCK, MAX_RLP_BYTES_PER_CHANNEL_FJORD};
+    use kona_genesis::{
+        HardForkConfig, MAX_RLP_BYTES_PER_CHANNEL_BEDROCK, MAX_RLP_BYTES_PER_CHANNEL_FJORD,
+    };
 
     fn new_compressed_batch_data() -> Bytes {
         let file_contents =
@@ -120,7 +122,12 @@ mod test {
         let raw = new_compressed_batch_data();
         let decompressed_len = decompress_to_vec_zlib(&raw).unwrap().len();
         let mut reader = BatchReader::new(raw, MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize);
-        reader.next_batch(&RollupConfig { fjord_time: Some(0), ..Default::default() }).unwrap();
+        reader
+            .next_batch(&RollupConfig {
+                hardforks: HardForkConfig { fjord_time: Some(0), ..Default::default() },
+                ..Default::default()
+            })
+            .unwrap();
         assert_eq!(reader.cursor, decompressed_len);
     }
 }

--- a/crates/protocol/protocol/src/batch/single.rs
+++ b/crates/protocol/protocol/src/batch/single.rs
@@ -179,6 +179,7 @@ mod tests {
     use alloy_consensus::{SignableTransaction, TxEip1559, TxEip7702, TxEnvelope};
     use alloy_eips::eip2718::{Decodable2718, Encodable2718};
     use alloy_primitives::{Address, PrimitiveSignature, Sealed, TxKind, U256};
+    use kona_genesis::HardForkConfig;
     use op_alloy_consensus::{OpTxEnvelope, TxDeposit};
 
     #[test]
@@ -243,7 +244,10 @@ mod tests {
 
     #[test]
     fn test_check_batch_timestamp_holocene_active_drop() {
-        let cfg = RollupConfig { holocene_time: Some(0), ..Default::default() };
+        let cfg = RollupConfig {
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        };
         let l2_safe_head = L2BlockInfo {
             block_info: BlockInfo { timestamp: 1, ..Default::default() },
             ..Default::default()
@@ -258,7 +262,10 @@ mod tests {
 
     #[test]
     fn test_check_batch_timestamp_holocene_active_past() {
-        let cfg = RollupConfig { holocene_time: Some(0), ..Default::default() };
+        let cfg = RollupConfig {
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        };
         let l2_safe_head = L2BlockInfo {
             block_info: BlockInfo { timestamp: 2, ..Default::default() },
             ..Default::default()
@@ -482,8 +489,11 @@ mod tests {
             SingleBatch { parent_hash, epoch_num, epoch_hash, timestamp, transactions };
 
         // Notice: Isthmus is active.
-        let cfg =
-            RollupConfig { max_sequencer_drift: 1, isthmus_time: Some(0), ..Default::default() };
+        let cfg = RollupConfig {
+            max_sequencer_drift: 1,
+            hardforks: HardForkConfig { isthmus_time: Some(0), ..Default::default() },
+            ..Default::default()
+        };
         let l1_blocks = vec![BlockInfo::default(), BlockInfo::default()];
         let l2_safe_head = L2BlockInfo {
             block_info: BlockInfo { timestamp: 1, ..Default::default() },

--- a/crates/protocol/protocol/src/batch/span.rs
+++ b/crates/protocol/protocol/src/batch/span.rs
@@ -505,7 +505,7 @@ mod tests {
     use alloy_consensus::{constants::EIP1559_TX_TYPE_ID, Header};
     use alloy_eips::BlockNumHash;
     use alloy_primitives::{b256, Bytes};
-    use kona_genesis::ChainGenesis;
+    use kona_genesis::{ChainGenesis, HardForkConfig};
     use op_alloy_consensus::OpBlock;
     use tracing::Level;
     use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -698,7 +698,10 @@ mod tests {
         let layer = CollectingLayer::new(trace_store.clone());
         tracing_subscriber::Registry::default().with(layer).init();
 
-        let cfg = RollupConfig { delta_time: Some(10), ..Default::default() };
+        let cfg = RollupConfig {
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            ..Default::default()
+        };
         let block = BlockInfo { number: 10, timestamp: 9, ..Default::default() };
         let l1_blocks = vec![block];
         let l2_safe_head = L2BlockInfo::default();
@@ -726,7 +729,11 @@ mod tests {
         let layer = CollectingLayer::new(trace_store.clone());
         tracing_subscriber::Registry::default().with(layer).init();
 
-        let cfg = RollupConfig { delta_time: Some(0), block_time: 10, ..Default::default() };
+        let cfg = RollupConfig {
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            block_time: 10,
+            ..Default::default()
+        };
         let block = BlockInfo { number: 10, timestamp: 10, ..Default::default() };
         let l1_blocks = vec![block];
         let l2_safe_head = L2BlockInfo {
@@ -754,7 +761,11 @@ mod tests {
         let layer = CollectingLayer::new(trace_store.clone());
         tracing_subscriber::Registry::default().with(layer).init();
 
-        let cfg = RollupConfig { delta_time: Some(0), block_time: 10, ..Default::default() };
+        let cfg = RollupConfig {
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            block_time: 10,
+            ..Default::default()
+        };
         let block = BlockInfo { number: 10, timestamp: 10, ..Default::default() };
         let l1_blocks = vec![block];
         let l2_safe_head = L2BlockInfo {
@@ -781,7 +792,7 @@ mod tests {
         tracing_subscriber::Registry::default().with(layer).init();
 
         let cfg = RollupConfig {
-            delta_time: Some(0),
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
             block_time: 10,
             max_sequencer_drift: 1000,
             ..Default::default()
@@ -850,7 +861,7 @@ mod tests {
         tracing_subscriber::Registry::default().with(layer).init();
 
         let cfg = RollupConfig {
-            delta_time: Some(0),
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
             block_time: 10,
             max_sequencer_drift: 1000,
             ..Default::default()
@@ -931,7 +942,11 @@ mod tests {
         let layer = CollectingLayer::new(trace_store.clone());
         tracing_subscriber::Registry::default().with(layer).init();
 
-        let cfg = RollupConfig { delta_time: Some(0), block_time: 10, ..Default::default() };
+        let cfg = RollupConfig {
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            block_time: 10,
+            ..Default::default()
+        };
         let l1_block = BlockInfo { number: 10, timestamp: 20, ..Default::default() };
         let l1_blocks = vec![l1_block];
         let l2_safe_head = L2BlockInfo {
@@ -964,7 +979,11 @@ mod tests {
         let layer = CollectingLayer::new(trace_store.clone());
         tracing_subscriber::Registry::default().with(layer).init();
 
-        let cfg = RollupConfig { delta_time: Some(0), block_time: 10, ..Default::default() };
+        let cfg = RollupConfig {
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            block_time: 10,
+            ..Default::default()
+        };
         let block = BlockInfo { number: 10, timestamp: 10, ..Default::default() };
         let l1_blocks = vec![block];
         let l2_safe_head = L2BlockInfo {
@@ -991,7 +1010,11 @@ mod tests {
         let layer = CollectingLayer::new(trace_store.clone());
         tracing_subscriber::Registry::default().with(layer).init();
 
-        let cfg = RollupConfig { delta_time: Some(0), block_time: 10, ..Default::default() };
+        let cfg = RollupConfig {
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            block_time: 10,
+            ..Default::default()
+        };
         let block = BlockInfo { number: 10, timestamp: 10, ..Default::default() };
         let l1_blocks = vec![block];
         let l2_safe_head = L2BlockInfo {
@@ -1018,7 +1041,11 @@ mod tests {
         let layer = CollectingLayer::new(trace_store.clone());
         tracing_subscriber::Registry::default().with(layer).init();
 
-        let cfg = RollupConfig { delta_time: Some(0), block_time: 10, ..Default::default() };
+        let cfg = RollupConfig {
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            block_time: 10,
+            ..Default::default()
+        };
         let block = BlockInfo { number: 10, timestamp: 10, ..Default::default() };
         let l1_blocks = vec![block];
         let l2_safe_head = L2BlockInfo {
@@ -1046,7 +1073,11 @@ mod tests {
         let layer = CollectingLayer::new(trace_store.clone());
         tracing_subscriber::Registry::default().with(layer).init();
 
-        let cfg = RollupConfig { delta_time: Some(0), block_time: 10, ..Default::default() };
+        let cfg = RollupConfig {
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            block_time: 10,
+            ..Default::default()
+        };
         let block = BlockInfo { number: 10, timestamp: 10, ..Default::default() };
         let l1_blocks = vec![block];
         let l2_safe_head = L2BlockInfo {
@@ -1087,7 +1118,11 @@ mod tests {
         let layer = CollectingLayer::new(trace_store.clone());
         tracing_subscriber::Registry::default().with(layer).init();
 
-        let cfg = RollupConfig { delta_time: Some(0), block_time: 10, ..Default::default() };
+        let cfg = RollupConfig {
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            block_time: 10,
+            ..Default::default()
+        };
         let block = BlockInfo { number: 10, timestamp: 10, ..Default::default() };
         let l1_blocks = vec![block];
         let parent_hash = b256!("1111111111111111111111111111111111111111000000000000000000000000");
@@ -1132,7 +1167,7 @@ mod tests {
 
         let cfg = RollupConfig {
             seq_window_size: 100,
-            delta_time: Some(0),
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
             block_time: 10,
             ..Default::default()
         };
@@ -1183,7 +1218,7 @@ mod tests {
 
         let cfg = RollupConfig {
             seq_window_size: 100,
-            delta_time: Some(0),
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
             block_time: 10,
             ..Default::default()
         };
@@ -1244,7 +1279,7 @@ mod tests {
 
         let cfg = RollupConfig {
             seq_window_size: 100,
-            delta_time: Some(0),
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
             block_time: 10,
             ..Default::default()
         };
@@ -1297,7 +1332,7 @@ mod tests {
 
         let cfg = RollupConfig {
             seq_window_size: 100,
-            delta_time: Some(0),
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
             block_time: 10,
             ..Default::default()
         };
@@ -1355,7 +1390,7 @@ mod tests {
         let cfg = RollupConfig {
             seq_window_size: 100,
             max_sequencer_drift: 0,
-            delta_time: Some(0),
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
             block_time: 10,
             ..Default::default()
         };
@@ -1411,7 +1446,7 @@ mod tests {
         let cfg = RollupConfig {
             seq_window_size: 100,
             max_sequencer_drift: 0,
-            delta_time: Some(0),
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
             block_time: 10,
             ..Default::default()
         };
@@ -1470,7 +1505,7 @@ mod tests {
         let cfg = RollupConfig {
             seq_window_size: 100,
             max_sequencer_drift: 0,
-            delta_time: Some(0),
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
             block_time: 10,
             ..Default::default()
         };
@@ -1539,7 +1574,7 @@ mod tests {
         let cfg = RollupConfig {
             seq_window_size: 100,
             max_sequencer_drift: 100,
-            delta_time: Some(0),
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
             block_time: 10,
             ..Default::default()
         };
@@ -1604,7 +1639,7 @@ mod tests {
         let cfg = RollupConfig {
             seq_window_size: 100,
             max_sequencer_drift: 100,
-            delta_time: Some(0),
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
             block_time: 10,
             ..Default::default()
         };
@@ -1671,7 +1706,7 @@ mod tests {
         let cfg = RollupConfig {
             seq_window_size: 100,
             max_sequencer_drift: 100,
-            delta_time: Some(0),
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
             block_time: 10,
             ..Default::default()
         };
@@ -1739,7 +1774,7 @@ mod tests {
 
         let cfg = RollupConfig {
             seq_window_size: 100,
-            delta_time: Some(0),
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
             block_time: 10,
             ..Default::default()
         };
@@ -1792,7 +1827,7 @@ mod tests {
 
         let cfg = RollupConfig {
             seq_window_size: 100,
-            delta_time: Some(0),
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
             block_time: 10,
             ..Default::default()
         };
@@ -1862,7 +1897,7 @@ mod tests {
             b256!("0e2ee9abe94ee4514b170d7039d8151a7469d434a8575dbab5bd4187a27732dd");
         let cfg = RollupConfig {
             seq_window_size: 100,
-            delta_time: Some(0),
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
             block_time: 10,
             genesis: ChainGenesis {
                 l2: BlockNumHash { number: 41, hash: payload_block_hash },
@@ -1932,7 +1967,7 @@ mod tests {
             b256!("0e2ee9abe94ee4514b170d7039d8151a7469d434a8575dbab5bd4187a27732dd");
         let cfg = RollupConfig {
             seq_window_size: 100,
-            delta_time: Some(0),
+            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
             block_time: 10,
             genesis: ChainGenesis {
                 l2: BlockNumHash { number: 41, hash: payload_block_hash },

--- a/crates/protocol/protocol/src/batch/span.rs
+++ b/crates/protocol/protocol/src/batch/span.rs
@@ -699,7 +699,7 @@ mod tests {
         tracing_subscriber::Registry::default().with(layer).init();
 
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: HardForkConfig { delta_time: Some(10), ..Default::default() },
             ..Default::default()
         };
         let block = BlockInfo { number: 10, timestamp: 9, ..Default::default() };

--- a/crates/protocol/protocol/src/info/variant.rs
+++ b/crates/protocol/protocol/src/info/variant.rs
@@ -53,7 +53,7 @@ impl L1BlockInfoTx {
         // upgrade transactions being placed after the L1 info transaction. Because of this,
         // for the first block of Ecotone, we send a Bedrock style L1 block info transaction
         let is_first_ecotone_block =
-            rollup_config.ecotone_time.unwrap_or_default() == l2_block_time;
+            rollup_config.hardforks.ecotone_time.unwrap_or_default() == l2_block_time;
 
         // If ecotone is *not* active or this is the first block of ecotone, use Bedrock block info.
         if !rollup_config.is_ecotone_active(l2_block_time) || is_first_ecotone_block {
@@ -85,7 +85,7 @@ impl L1BlockInfoTx {
         );
 
         if rollup_config.is_interop_active(l2_block_time) &&
-            rollup_config.interop_time.unwrap_or_default() != l2_block_time
+            rollup_config.hardforks.interop_time.unwrap_or_default() != l2_block_time
         {
             return Ok(Self::Interop(L1BlockInfoInterop {
                 number: l1_header.number,
@@ -101,7 +101,7 @@ impl L1BlockInfoTx {
         }
 
         if rollup_config.is_isthmus_active(l2_block_time) &&
-            rollup_config.isthmus_time.unwrap_or_default() != l2_block_time
+            rollup_config.hardforks.isthmus_time.unwrap_or_default() != l2_block_time
         {
             let operator_fee_scalar = system_config.operator_fee_scalar.unwrap_or_default();
             let operator_fee_constant = system_config.operator_fee_constant.unwrap_or_default();
@@ -339,6 +339,7 @@ mod test {
     };
     use alloc::{string::ToString, vec::Vec};
     use alloy_primitives::{address, b256};
+    use kona_genesis::HardForkConfig;
 
     #[test]
     fn test_l1_block_info_missing_selector() {
@@ -831,7 +832,10 @@ mod test {
 
     #[test]
     fn test_try_new_ecotone() {
-        let rollup_config = RollupConfig { ecotone_time: Some(1), ..Default::default() };
+        let rollup_config = RollupConfig {
+            hardforks: HardForkConfig { ecotone_time: Some(1), ..Default::default() },
+            ..Default::default()
+        };
         let system_config = SystemConfig::default();
         let sequence_number = 0;
         let l1_header = Header::default();
@@ -874,7 +878,10 @@ mod test {
 
     #[test]
     fn test_try_new_interop() {
-        let rollup_config = RollupConfig { interop_time: Some(1), ..Default::default() };
+        let rollup_config = RollupConfig {
+            hardforks: HardForkConfig { interop_time: Some(1), ..Default::default() },
+            ..Default::default()
+        };
         let system_config = SystemConfig::default();
         let sequence_number = 0;
         let l1_header = Header::default();
@@ -917,7 +924,10 @@ mod test {
 
     #[test]
     fn test_try_new_isthmus() {
-        let rollup_config = RollupConfig { isthmus_time: Some(1), ..Default::default() };
+        let rollup_config = RollupConfig {
+            hardforks: HardForkConfig { isthmus_time: Some(1), ..Default::default() },
+            ..Default::default()
+        };
         let system_config = SystemConfig {
             batcher_address: address!("6887246668a3b87f54deb3b94ba47a6f63f32985"),
             operator_fee_scalar: Some(0xabcd),
@@ -975,7 +985,10 @@ mod test {
 
     #[test]
     fn test_try_new_with_deposit_tx() {
-        let rollup_config = RollupConfig { isthmus_time: Some(1), ..Default::default() };
+        let rollup_config = RollupConfig {
+            hardforks: HardForkConfig { isthmus_time: Some(1), ..Default::default() },
+            ..Default::default()
+        };
         let system_config = SystemConfig {
             batcher_address: address!("6887246668a3b87f54deb3b94ba47a6f63f32985"),
             operator_fee_scalar: Some(0xabcd),

--- a/crates/protocol/protocol/src/utils.rs
+++ b/crates/protocol/protocol/src/utils.rs
@@ -165,7 +165,7 @@ mod tests {
     use alloc::vec;
     use alloy_eips::eip1898::BlockNumHash;
     use alloy_primitives::{address, bytes, uint, U256};
-    use kona_genesis::ChainGenesis;
+    use kona_genesis::{ChainGenesis, HardForkConfig};
 
     #[test]
     fn test_to_system_config_invalid_genesis_hash() {
@@ -328,7 +328,7 @@ mod tests {
                 l2: BlockNumHash { hash: block_hash, ..Default::default() },
                 ..Default::default()
             },
-            holocene_time: Some(0),
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         };
         assert!(rollup_config.is_holocene_active(block.header.timestamp));
@@ -375,8 +375,11 @@ mod tests {
                 l2: BlockNumHash { hash: block_hash, ..Default::default() },
                 ..Default::default()
             },
-            holocene_time: Some(0),
-            isthmus_time: Some(0),
+            hardforks: HardForkConfig {
+                holocene_time: Some(0),
+                isthmus_time: Some(0),
+                ..Default::default()
+            },
             ..Default::default()
         };
         assert!(rollup_config.is_holocene_active(block.header.timestamp));

--- a/crates/protocol/registry/src/superchain.rs
+++ b/crates/protocol/registry/src/superchain.rs
@@ -80,7 +80,7 @@ mod tests {
             governed_by_optimism: false,
             superchain_time: Some(0),
             batch_inbox_addr: address!("ff00000000000000000000000000000000008453"),
-            hardfork_config: crate::test_utils::BASE_MAINNET_CONFIG.hardfork_config(),
+            hardfork_config: crate::test_utils::BASE_MAINNET_CONFIG.hardforks,
             block_time: 2,
             seq_window_size: 3600,
             max_sequencer_drift: 600,

--- a/crates/protocol/registry/src/test_utils/base_mainnet.rs
+++ b/crates/protocol/registry/src/test_utils/base_mainnet.rs
@@ -3,8 +3,9 @@
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{address, b256, uint};
 use kona_genesis::{
-    ChainGenesis, RollupConfig, SystemConfig, DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW,
-    OP_MAINNET_BASE_FEE_PARAMS, OP_MAINNET_BASE_FEE_PARAMS_CANYON,
+    ChainGenesis, HardForkConfig, RollupConfig, SystemConfig,
+    DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW, OP_MAINNET_BASE_FEE_PARAMS,
+    OP_MAINNET_BASE_FEE_PARAMS_CANYON,
 };
 
 /// The [RollupConfig] for Base Mainnet.
@@ -41,15 +42,17 @@ pub const BASE_MAINNET_CONFIG: RollupConfig = RollupConfig {
     l2_chain_id: 8453,
     base_fee_params: OP_MAINNET_BASE_FEE_PARAMS,
     canyon_base_fee_params: OP_MAINNET_BASE_FEE_PARAMS_CANYON,
-    regolith_time: Some(0_u64),
-    canyon_time: Some(1704992401),
-    delta_time: Some(1708560000),
-    ecotone_time: Some(1710374401),
-    fjord_time: Some(1720627201),
-    granite_time: Some(1_726_070_401_u64),
-    holocene_time: Some(1736445601),
-    isthmus_time: None,
-    interop_time: None,
+    hardforks: HardForkConfig {
+        regolith_time: Some(0_u64),
+        canyon_time: Some(1704992401),
+        delta_time: Some(1708560000),
+        ecotone_time: Some(1710374401),
+        fjord_time: Some(1720627201),
+        granite_time: Some(1_726_070_401_u64),
+        holocene_time: Some(1736445601),
+        isthmus_time: None,
+        interop_time: None,
+    },
     batch_inbox_address: address!("ff00000000000000000000000000000000008453"),
     deposit_contract_address: address!("49048044d57e1c92a77f79988d21fa8faf74e97e"),
     l1_system_config_address: address!("73a79fab69143498ed3712e519a88a918e1f4072"),

--- a/crates/protocol/registry/src/test_utils/base_mainnet.rs
+++ b/crates/protocol/registry/src/test_utils/base_mainnet.rs
@@ -43,7 +43,7 @@ pub const BASE_MAINNET_CONFIG: RollupConfig = RollupConfig {
     base_fee_params: OP_MAINNET_BASE_FEE_PARAMS,
     canyon_base_fee_params: OP_MAINNET_BASE_FEE_PARAMS_CANYON,
     hardforks: HardForkConfig {
-        regolith_time: Some(0_u64),
+        regolith_time: None,
         canyon_time: Some(1704992401),
         delta_time: Some(1708560000),
         ecotone_time: Some(1710374401),

--- a/crates/protocol/registry/src/test_utils/base_sepolia.rs
+++ b/crates/protocol/registry/src/test_utils/base_sepolia.rs
@@ -3,7 +3,7 @@
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{address, b256, uint};
 use kona_genesis::{
-    ChainGenesis, RollupConfig, SystemConfig, BASE_SEPOLIA_BASE_FEE_PARAMS,
+    ChainGenesis, HardForkConfig, RollupConfig, SystemConfig, BASE_SEPOLIA_BASE_FEE_PARAMS,
     BASE_SEPOLIA_BASE_FEE_PARAMS_CANYON, DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW,
 };
 
@@ -41,15 +41,17 @@ pub const BASE_SEPOLIA_CONFIG: RollupConfig = RollupConfig {
     l2_chain_id: 84532,
     base_fee_params: BASE_SEPOLIA_BASE_FEE_PARAMS,
     canyon_base_fee_params: BASE_SEPOLIA_BASE_FEE_PARAMS_CANYON,
-    regolith_time: Some(0),
-    canyon_time: Some(1699981200),
-    delta_time: Some(1703203200),
-    ecotone_time: Some(1708534800),
-    fjord_time: Some(1716998400),
-    granite_time: Some(1723478400),
-    holocene_time: Some(1732633200),
-    isthmus_time: None,
-    interop_time: None,
+    hardforks: HardForkConfig {
+        regolith_time: Some(0),
+        canyon_time: Some(1699981200),
+        delta_time: Some(1703203200),
+        ecotone_time: Some(1708534800),
+        fjord_time: Some(1716998400),
+        granite_time: Some(1723478400),
+        holocene_time: Some(1732633200),
+        isthmus_time: None,
+        interop_time: None,
+    },
     batch_inbox_address: address!("ff00000000000000000000000000000000084532"),
     deposit_contract_address: address!("49f53e41452c74589e85ca1677426ba426459e85"),
     l1_system_config_address: address!("f272670eb55e895584501d564afeb048bed26194"),

--- a/crates/protocol/registry/src/test_utils/base_sepolia.rs
+++ b/crates/protocol/registry/src/test_utils/base_sepolia.rs
@@ -42,7 +42,7 @@ pub const BASE_SEPOLIA_CONFIG: RollupConfig = RollupConfig {
     base_fee_params: BASE_SEPOLIA_BASE_FEE_PARAMS,
     canyon_base_fee_params: BASE_SEPOLIA_BASE_FEE_PARAMS_CANYON,
     hardforks: HardForkConfig {
-        regolith_time: Some(0),
+        regolith_time: None,
         canyon_time: Some(1699981200),
         delta_time: Some(1703203200),
         ecotone_time: Some(1708534800),

--- a/crates/protocol/registry/src/test_utils/op_mainnet.rs
+++ b/crates/protocol/registry/src/test_utils/op_mainnet.rs
@@ -43,7 +43,7 @@ pub const OP_MAINNET_CONFIG: RollupConfig = RollupConfig {
     base_fee_params: OP_MAINNET_BASE_FEE_PARAMS,
     canyon_base_fee_params: OP_MAINNET_BASE_FEE_PARAMS_CANYON,
     hardforks: HardForkConfig {
-        regolith_time: Some(0_u64),
+        regolith_time: None,
         canyon_time: Some(1_704_992_401_u64),
         delta_time: Some(1_708_560_000_u64),
         ecotone_time: Some(1_710_374_401_u64),

--- a/crates/protocol/registry/src/test_utils/op_mainnet.rs
+++ b/crates/protocol/registry/src/test_utils/op_mainnet.rs
@@ -3,8 +3,9 @@
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{address, b256, uint};
 use kona_genesis::{
-    ChainGenesis, RollupConfig, SystemConfig, DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW,
-    OP_MAINNET_BASE_FEE_PARAMS, OP_MAINNET_BASE_FEE_PARAMS_CANYON,
+    ChainGenesis, HardForkConfig, RollupConfig, SystemConfig,
+    DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW, OP_MAINNET_BASE_FEE_PARAMS,
+    OP_MAINNET_BASE_FEE_PARAMS_CANYON,
 };
 
 /// The [RollupConfig] for OP Mainnet.
@@ -41,15 +42,17 @@ pub const OP_MAINNET_CONFIG: RollupConfig = RollupConfig {
     l2_chain_id: 10_u64,
     base_fee_params: OP_MAINNET_BASE_FEE_PARAMS,
     canyon_base_fee_params: OP_MAINNET_BASE_FEE_PARAMS_CANYON,
-    regolith_time: Some(0_u64),
-    canyon_time: Some(1_704_992_401_u64),
-    delta_time: Some(1_708_560_000_u64),
-    ecotone_time: Some(1_710_374_401_u64),
-    fjord_time: Some(1_720_627_201_u64),
-    granite_time: Some(1_726_070_401_u64),
-    holocene_time: Some(1736445601),
-    isthmus_time: None,
-    interop_time: None,
+    hardforks: HardForkConfig {
+        regolith_time: Some(0_u64),
+        canyon_time: Some(1_704_992_401_u64),
+        delta_time: Some(1_708_560_000_u64),
+        ecotone_time: Some(1_710_374_401_u64),
+        fjord_time: Some(1_720_627_201_u64),
+        granite_time: Some(1_726_070_401_u64),
+        holocene_time: Some(1736445601),
+        isthmus_time: None,
+        interop_time: None,
+    },
     batch_inbox_address: address!("ff00000000000000000000000000000000000010"),
     deposit_contract_address: address!("beb5fc579115071764c7423a4f12edde41f106ed"),
     l1_system_config_address: address!("229047fed2591dbec1ef1118d64f7af3db9eb290"),

--- a/crates/protocol/registry/src/test_utils/op_sepolia.rs
+++ b/crates/protocol/registry/src/test_utils/op_sepolia.rs
@@ -43,7 +43,7 @@ pub const OP_SEPOLIA_CONFIG: RollupConfig = RollupConfig {
     base_fee_params: OP_SEPOLIA_BASE_FEE_PARAMS,
     canyon_base_fee_params: OP_SEPOLIA_BASE_FEE_PARAMS_CANYON,
     hardforks: HardForkConfig {
-        regolith_time: Some(0),
+        regolith_time: None,
         canyon_time: Some(1699981200),
         delta_time: Some(1703203200),
         ecotone_time: Some(1708534800),

--- a/crates/protocol/registry/src/test_utils/op_sepolia.rs
+++ b/crates/protocol/registry/src/test_utils/op_sepolia.rs
@@ -3,8 +3,9 @@
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{address, b256, uint};
 use kona_genesis::{
-    ChainGenesis, RollupConfig, SystemConfig, DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW,
-    OP_SEPOLIA_BASE_FEE_PARAMS, OP_SEPOLIA_BASE_FEE_PARAMS_CANYON,
+    ChainGenesis, HardForkConfig, RollupConfig, SystemConfig,
+    DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW, OP_SEPOLIA_BASE_FEE_PARAMS,
+    OP_SEPOLIA_BASE_FEE_PARAMS_CANYON,
 };
 
 /// The [RollupConfig] for OP Sepolia.
@@ -41,15 +42,17 @@ pub const OP_SEPOLIA_CONFIG: RollupConfig = RollupConfig {
     l2_chain_id: 11155420,
     base_fee_params: OP_SEPOLIA_BASE_FEE_PARAMS,
     canyon_base_fee_params: OP_SEPOLIA_BASE_FEE_PARAMS_CANYON,
-    regolith_time: Some(0),
-    canyon_time: Some(1699981200),
-    delta_time: Some(1703203200),
-    ecotone_time: Some(1708534800),
-    fjord_time: Some(1716998400),
-    granite_time: Some(1723478400),
-    holocene_time: Some(1732633200),
-    isthmus_time: None,
-    interop_time: None,
+    hardforks: HardForkConfig {
+        regolith_time: Some(0),
+        canyon_time: Some(1699981200),
+        delta_time: Some(1703203200),
+        ecotone_time: Some(1708534800),
+        fjord_time: Some(1716998400),
+        granite_time: Some(1723478400),
+        holocene_time: Some(1732633200),
+        isthmus_time: None,
+        interop_time: None,
+    },
     batch_inbox_address: address!("ff00000000000000000000000000000011155420"),
     deposit_contract_address: address!("16fc5058f25648194471939df75cf27a2fdc48bc"),
     l1_system_config_address: address!("034edd2a225f7f429a63e0f1d2084b9e0a93b538"),


### PR DESCRIPTION
### Description

Uses `#[serde(flatten)]` to put hardfork timestamps in the rollup config inside the already defined `HardForkConfiguration` type.