### PR TITLE
chore(deps): Use `reth-execution-types` instead of `reth-provider`

### DIFF
--- a/.github/workflows/rust_ci.yaml
+++ b/.github/workflows/rust_ci.yaml
@@ -145,7 +145,7 @@ jobs:
       - name: Install Rust stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.81
+          toolchain: 1.82
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "996564c1782285d4e0299c29b318bc74f24b1d7f456cef3e040810b061ee3256"
 dependencies = [
  "alloy-primitives",
- "alloy-rlp",
  "num_enum",
  "serde",
  "strum 0.27.1",
@@ -128,7 +127,6 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde 0.4.2",
  "auto_impl",
- "c-kzg",
  "derive_more 1.0.0",
  "serde",
 ]
@@ -234,8 +232,6 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde 0.4.2",
  "c-kzg",
- "derive_more 1.0.0",
- "once_cell",
  "serde",
  "sha2 0.10.8",
 ]
@@ -310,10 +306,10 @@ dependencies = [
  "alloy-consensus-any",
  "alloy-eips 0.11.1",
  "alloy-json-rpc",
- "alloy-network-primitives 0.11.1",
+ "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-any",
- "alloy-rpc-types-eth 0.11.1",
+ "alloy-rpc-types-eth",
  "alloy-serde 0.11.1",
  "alloy-signer",
  "alloy-sol-types",
@@ -323,19 +319,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.11",
-]
-
-[[package]]
-name = "alloy-network-primitives"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801492711d4392b2ccf5fc0bc69e299fa1aab15167d74dcaa9aab96a54f684bd"
-dependencies = [
- "alloy-consensus 0.4.2",
- "alloy-eips 0.4.2",
- "alloy-primitives",
- "alloy-serde 0.4.2",
- "serde",
 ]
 
 [[package]]
@@ -367,7 +350,7 @@ dependencies = [
  "foldhash",
  "getrandom 0.2.15",
  "hashbrown 0.15.2",
- "indexmap 2.7.1",
+ "indexmap",
  "itoa",
  "k256",
  "keccak-asm",
@@ -393,7 +376,7 @@ dependencies = [
  "alloy-eips 0.11.1",
  "alloy-json-rpc",
  "alloy-network",
- "alloy-network-primitives 0.11.1",
+ "alloy-network-primitives",
  "alloy-primitives",
  "alloy-pubsub",
  "alloy-rpc-client",
@@ -492,26 +475,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ffc534b7919e18f35e3aa1f507b6f3d9d92ec298463a9f6beaac112809d8d06"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types-engine 0.4.2",
- "alloy-rpc-types-eth 0.4.2",
- "alloy-serde 0.4.2",
- "serde",
-]
-
-[[package]]
-name = "alloy-rpc-types"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f18e68a3882f372e045ddc89eb455469347767d17878ca492cfbac81e71a111"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-debug",
- "alloy-rpc-types-eth 0.11.1",
+ "alloy-rpc-types-eth",
  "alloy-serde 0.11.1",
  "serde",
 ]
@@ -523,7 +493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "318ae46dd12456df42527c3b94c1ae9001e1ceb707f7afe2c7807ac4e49ebad9"
 dependencies = [
  "alloy-consensus-any",
- "alloy-rpc-types-eth 0.11.1",
+ "alloy-rpc-types-eth",
  "alloy-serde 0.11.1",
 ]
 
@@ -535,7 +505,7 @@ checksum = "799103aa44270c7bea076ec5d3d7b6c6d29557ab5485c91a74d3068327adb485"
 dependencies = [
  "alloy-eips 0.11.1",
  "alloy-primitives",
- "alloy-rpc-types-engine 0.11.1",
+ "alloy-rpc-types-engine",
  "serde",
  "serde_with",
  "thiserror 2.0.11",
@@ -549,22 +519,6 @@ checksum = "2834b7012054cb2f90ee9893b7cc97702edca340ec1ef386c30c42e55e6cd691"
 dependencies = [
  "alloy-primitives",
  "serde",
-]
-
-[[package]]
-name = "alloy-rpc-types-engine"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0285c4c09f838ab830048b780d7f4a4f460f309aa1194bb049843309524c64c"
-dependencies = [
- "alloy-consensus 0.4.2",
- "alloy-eips 0.4.2",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.4.2",
- "derive_more 1.0.0",
- "serde",
- "strum 0.26.3",
 ]
 
 [[package]]
@@ -589,22 +543,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413f4aa3ccf2c3e4234a047c5fa4727916d7daf25a89f9b765df0ba09784fd87"
-dependencies = [
- "alloy-consensus 0.4.2",
- "alloy-eips 0.4.2",
- "alloy-network-primitives 0.4.2",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-sol-types",
- "derive_more 1.0.0",
- "itertools 0.13.0",
-]
-
-[[package]]
-name = "alloy-rpc-types-eth"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b4dbee4d82f8a22dde18c28257bed759afeae7ba73da4a1479a039fd1445d04"
@@ -612,7 +550,7 @@ dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-consensus-any",
  "alloy-eips 0.11.1",
- "alloy-network-primitives 0.11.1",
+ "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde 0.11.1",
@@ -684,7 +622,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap 2.7.1",
+ "indexmap",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -840,21 +778,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,20 +838,6 @@ name = "anyhow"
 version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
-
-[[package]]
-name = "aquamarine"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21cc1548309245035eb18aa7f0967da6bc65587005170c56e6ef2788a4cf3f4e"
-dependencies = [
- "include_dir",
- "itertools 0.10.5",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.98",
-]
 
 [[package]]
 name = "arbitrary"
@@ -1310,12 +1219,6 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -1333,15 +1236,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bindgen"
 version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1353,24 +1247,6 @@ dependencies = [
  "itertools 0.12.1",
  "lazy_static",
  "lazycell",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
-dependencies = [
- "bitflags 2.8.0",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -1647,9 +1523,6 @@ version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
@@ -1922,15 +1795,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2156,7 +2020,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
- "serde",
 ]
 
 [[package]]
@@ -2258,7 +2121,7 @@ dependencies = [
  "arrayvec",
  "ctr",
  "delay_map",
- "enr 0.13.0",
+ "enr",
  "fnv",
  "futures",
  "hashlink",
@@ -2383,22 +2246,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "enr"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972070166c68827e64bd1ebc8159dd8e32d9bc2da7ebe8f20b61308f7974ad30"
-dependencies = [
- "alloy-rlp",
- "base64 0.21.7",
- "bytes",
- "hex",
- "log",
- "rand 0.8.5",
- "sha3",
- "zeroize",
 ]
 
 [[package]]
@@ -2541,16 +2388,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "eyre"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
-dependencies = [
- "indenter",
- "once_cell",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2593,18 +2430,6 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
-name = "filetime"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "findshlibs"
@@ -2664,15 +2489,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fsevent-sys"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -2946,7 +2762,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.7.1",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -2965,7 +2781,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.2.0",
- "indexmap 2.7.1",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -2981,18 +2797,6 @@ dependencies = [
  "cfg-if",
  "crunchy",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
 name = "hashbrown"
@@ -3320,29 +3124,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core 0.52.0",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "icu_collections"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3517,7 +3298,7 @@ dependencies = [
  "rtnetlink",
  "system-configuration",
  "tokio",
- "windows 0.53.0",
+ "windows",
 ]
 
 [[package]]
@@ -3560,42 +3341,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "indenter"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3614,7 +3359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
 dependencies = [
  "ahash",
- "indexmap 2.7.1",
+ "indexmap",
  "is-terminal",
  "itoa",
  "log",
@@ -3623,26 +3368,6 @@ dependencies = [
  "quick-xml",
  "rgb",
  "str_stack",
-]
-
-[[package]]
-name = "inotify"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
-dependencies = [
- "bitflags 1.3.2",
- "inotify-sys",
- "libc",
-]
-
-[[package]]
-name = "inotify-sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -4004,7 +3729,7 @@ dependencies = [
  "alloy-eips 0.11.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-engine 0.11.1",
+ "alloy-rpc-types-engine",
  "async-trait",
  "cfg-if",
  "kona-derive",
@@ -4021,8 +3746,8 @@ dependencies = [
  "kona-std-fpvm",
  "kona-std-fpvm-proc",
  "lru 0.13.0",
- "op-alloy-consensus 0.10.5",
- "op-alloy-rpc-types-engine 0.10.5",
+ "op-alloy-consensus",
+ "op-alloy-rpc-types-engine",
  "revm 19.5.0",
  "serde",
  "serde_json",
@@ -4039,14 +3764,14 @@ dependencies = [
  "alloy-eips 0.11.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-engine 0.11.1",
+ "alloy-rpc-types-engine",
  "async-trait",
  "kona-genesis",
  "kona-protocol",
  "kona-registry",
  "kona-rpc",
- "op-alloy-consensus 0.10.5",
- "op-alloy-rpc-types-engine 0.10.5",
+ "op-alloy-consensus",
+ "op-alloy-rpc-types-engine",
  "proptest",
  "serde_json",
  "spin 0.9.8",
@@ -4069,8 +3794,8 @@ dependencies = [
  "kona-genesis",
  "kona-protocol",
  "kona-rpc",
- "op-alloy-consensus 0.10.5",
- "op-alloy-rpc-types-engine 0.10.5",
+ "op-alloy-consensus",
+ "op-alloy-rpc-types-engine",
  "spin 0.9.8",
  "thiserror 2.0.11",
  "tracing",
@@ -4086,7 +3811,7 @@ dependencies = [
  "alloy-provider",
  "alloy-rlp",
  "alloy-rpc-client",
- "alloy-rpc-types-engine 0.11.1",
+ "alloy-rpc-types-engine",
  "alloy-transport",
  "alloy-transport-http",
  "alloy-trie 0.7.9",
@@ -4095,8 +3820,8 @@ dependencies = [
  "kona-host",
  "kona-mpt",
  "kona-registry",
- "op-alloy-consensus 0.10.5",
- "op-alloy-rpc-types-engine 0.10.5",
+ "op-alloy-consensus",
+ "op-alloy-rpc-types-engine",
  "pprof",
  "rand 0.9.0",
  "revm 19.5.0",
@@ -4135,7 +3860,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-eips 0.11.1",
  "alloy-primitives",
- "op-alloy-consensus 0.10.5",
+ "op-alloy-consensus",
  "rand 0.9.0",
  "tokio",
 ]
@@ -4150,7 +3875,7 @@ dependencies = [
  "alloy-provider",
  "alloy-rlp",
  "alloy-rpc-client",
- "alloy-rpc-types 0.11.1",
+ "alloy-rpc-types",
  "alloy-rpc-types-beacon",
  "alloy-serde 0.11.1",
  "alloy-transport-http",
@@ -4173,7 +3898,7 @@ dependencies = [
  "kona-rpc",
  "kona-std-fpvm",
  "op-alloy-network",
- "op-alloy-rpc-types-engine 0.10.5",
+ "op-alloy-rpc-types-engine",
  "proptest",
  "reqwest",
  "revm 19.5.0",
@@ -4201,7 +3926,7 @@ dependencies = [
  "kona-genesis",
  "kona-protocol",
  "kona-registry",
- "op-alloy-consensus 0.10.5",
+ "op-alloy-consensus",
  "rand 0.9.0",
  "serde",
  "serde_json",
@@ -4218,11 +3943,11 @@ dependencies = [
  "alloy-primitives",
  "alloy-provider",
  "alloy-rlp",
- "alloy-rpc-types 0.11.1",
+ "alloy-rpc-types",
  "alloy-transport-http",
  "alloy-trie 0.7.9",
  "criterion",
- "op-alloy-rpc-types-engine 0.10.5",
+ "op-alloy-rpc-types-engine",
  "pprof",
  "proptest",
  "rand 0.9.0",
@@ -4239,7 +3964,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-engine 0.11.1",
+ "alloy-rpc-types-engine",
  "arbitrary",
  "arbtest",
  "discv5",
@@ -4247,7 +3972,7 @@ dependencies = [
  "lazy_static",
  "libp2p",
  "libp2p-identity",
- "op-alloy-rpc-types-engine 0.10.5",
+ "op-alloy-rpc-types-engine",
  "openssl",
  "snap",
  "thiserror 2.0.11",
@@ -4340,7 +4065,7 @@ dependencies = [
  "alloy-eips 0.11.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-engine 0.11.1",
+ "alloy-rpc-types-engine",
  "arbitrary",
  "async-trait",
  "kona-executor",
@@ -4350,8 +4075,8 @@ dependencies = [
  "kona-preimage",
  "kona-proof",
  "kona-registry",
- "op-alloy-consensus 0.10.5",
- "op-alloy-rpc-types-engine 0.10.5",
+ "op-alloy-consensus",
+ "op-alloy-rpc-types-engine",
  "rand 0.9.0",
  "serde",
  "serde_json",
@@ -4376,7 +4101,7 @@ dependencies = [
  "brotli",
  "kona-genesis",
  "miniz_oxide",
- "op-alloy-consensus 0.10.5",
+ "op-alloy-consensus",
  "op-alloy-flz",
  "proptest",
  "rand 0.9.0",
@@ -4409,7 +4134,7 @@ dependencies = [
  "kona-genesis",
  "kona-protocol",
  "lru 0.13.0",
- "op-alloy-consensus 0.10.5",
+ "op-alloy-consensus",
  "reqwest",
  "serde",
  "thiserror 2.0.11",
@@ -4428,10 +4153,10 @@ dependencies = [
  "kona-derive",
  "kona-genesis",
  "kona-protocol",
- "op-alloy-consensus 0.10.5",
+ "op-alloy-consensus",
  "parking_lot",
+ "reth-execution-types",
  "reth-primitives",
- "reth-provider",
 ]
 
 [[package]]
@@ -4462,7 +4187,7 @@ dependencies = [
  "kona-interop",
  "kona-protocol",
  "op-alloy-rpc-jsonrpsee",
- "op-alloy-rpc-types-engine 0.10.5",
+ "op-alloy-rpc-types-engine",
  "serde",
  "serde_json",
  "thiserror 2.0.11",
@@ -4500,26 +4225,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
-]
-
-[[package]]
-name = "kqueue"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
-dependencies = [
- "kqueue-sys",
- "libc",
-]
-
-[[package]]
-name = "kqueue-sys"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
 ]
 
 [[package]]
@@ -4920,23 +4625,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "libredox"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags 2.8.0",
- "libc",
- "redox_syscall",
-]
-
-[[package]]
 name = "librocksdb-sys"
 version = "0.16.0+8.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen",
  "bzip2-sys",
  "cc",
  "glob",
@@ -5074,12 +4768,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lz4_flex"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
-
-[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5111,34 +4799,12 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884adb57038347dfbaf2d5065887b6cf4312330dc8e94bc30a1a839bd79d3261"
-dependencies = [
- "ahash",
- "portable-atomic",
-]
-
-[[package]]
-name = "metrics"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a7deb012b3b2767169ff203fadb4c6b0b82b947512e5eb9e0b78c2e186ad9e3"
 dependencies = [
  "ahash",
  "portable-atomic",
-]
-
-[[package]]
-name = "metrics-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3dbdd96ed57d565ec744cba02862d707acf373c5772d152abae6ec5c4e24f6c"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.98",
 ]
 
 [[package]]
@@ -5151,9 +4817,9 @@ dependencies = [
  "http-body-util",
  "hyper 1.6.0",
  "hyper-util",
- "indexmap 2.7.1",
+ "indexmap",
  "ipnet",
- "metrics 0.24.1",
+ "metrics",
  "metrics-util",
  "quanta",
  "thiserror 1.0.69",
@@ -5170,7 +4836,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.15.2",
- "metrics 0.24.1",
+ "metrics",
  "quanta",
  "rand 0.8.5",
  "rand_xoshiro",
@@ -5196,18 +4862,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
-]
-
-[[package]]
-name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5431,33 +5085,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "notify"
-version = "6.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
-dependencies = [
- "bitflags 2.8.0",
- "filetime",
- "fsevent-sys",
- "inotify",
- "kqueue",
- "libc",
- "log",
- "mio 0.8.11",
- "walkdir",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5643,22 +5270,6 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ea7162170c6f3cad8f67f4dd7108e3f78349fd553da5b8bebff1e7ef8f38896"
-dependencies = [
- "alloy-consensus 0.4.2",
- "alloy-eips 0.4.2",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.4.2",
- "derive_more 1.0.0",
- "serde",
- "spin 0.9.8",
-]
-
-[[package]]
-name = "op-alloy-consensus"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "621e69964165285ce750bf7ba961707e26c31df9f0b25652d6219dcee1f7f5b5"
@@ -5681,20 +5292,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbee9e684edfb73081bc22337be374b1b454d5eea87790b61ca95a6564953807"
 
 [[package]]
-name = "op-alloy-genesis"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3d31dfbbd8dd898c7512f8ce7d30103980485416f668566100b0ed0994b958"
-dependencies = [
- "alloy-consensus 0.4.2",
- "alloy-eips 0.4.2",
- "alloy-primitives",
- "alloy-sol-types",
- "serde",
- "serde_repr",
-]
-
-[[package]]
 name = "op-alloy-network"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5703,9 +5300,9 @@ dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-network",
  "alloy-primitives",
- "alloy-rpc-types-eth 0.11.1",
+ "alloy-rpc-types-eth",
  "alloy-signer",
- "op-alloy-consensus 0.10.5",
+ "op-alloy-consensus",
  "op-alloy-rpc-types",
 ]
 
@@ -5759,28 +5356,14 @@ checksum = "7a206be9e4aab37bfa352352d63d8dfa9d48d9df1f30478e4a9477865fd88ad6"
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-network-primitives 0.11.1",
+ "alloy-network-primitives",
  "alloy-primitives",
- "alloy-rpc-types-eth 0.11.1",
+ "alloy-rpc-types-eth",
  "alloy-serde 0.11.1",
  "derive_more 1.0.0",
- "op-alloy-consensus 0.10.5",
+ "op-alloy-consensus",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "op-alloy-rpc-types-engine"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349e7b420f45d1a00216ec4c65fcf3f0057a841bc39732c405c85ae782b94121"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types-engine 0.4.2",
- "alloy-serde 0.4.2",
- "derive_more 1.0.0",
- "op-alloy-protocol",
- "serde",
 ]
 
 [[package]]
@@ -5792,11 +5375,11 @@ dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
  "alloy-primitives",
- "alloy-rpc-types-engine 0.11.1",
+ "alloy-rpc-types-engine",
  "alloy-serde 0.11.1",
  "derive_more 1.0.0",
  "ethereum_ssz",
- "op-alloy-consensus 0.10.5",
+ "op-alloy-consensus",
  "serde",
  "snap",
  "thiserror 2.0.11",
@@ -5881,16 +5464,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "page_size"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "parity-scale-codec"
 version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5899,7 +5472,6 @@ dependencies = [
  "arrayvec",
  "bitvec",
  "byte-slice-cast",
- "bytes",
  "const_format",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
@@ -6176,30 +5748,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
  "toml_edit",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -6686,63 +6234,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-blockchain-tree-api"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "alloy-primitives",
- "reth-consensus",
- "reth-execution-errors",
- "reth-primitives",
- "reth-storage-errors",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "reth-chain-state"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "alloy-eips 0.4.2",
- "alloy-primitives",
- "auto_impl",
- "derive_more 1.0.0",
- "metrics 0.23.0",
- "parking_lot",
- "pin-project",
- "reth-chainspec",
- "reth-errors",
- "reth-execution-types",
- "reth-metrics",
- "reth-primitives",
- "reth-storage-api",
- "reth-trie",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-chainspec"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "alloy-chains",
- "alloy-eips 0.4.2",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-trie 0.6.0",
- "auto_impl",
- "derive_more 1.0.0",
- "once_cell",
- "reth-ethereum-forks",
- "reth-network-peers",
- "reth-primitives-traits",
- "reth-trie-common",
- "serde_json",
-]
-
-[[package]]
 name = "reth-codecs"
 version = "1.1.0"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
@@ -6780,116 +6271,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-db"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "alloy-primitives",
- "bytes",
- "derive_more 1.0.0",
- "eyre",
- "metrics 0.23.0",
- "page_size",
- "paste",
- "reth-db-api",
- "reth-fs-util",
- "reth-libmdbx",
- "reth-metrics",
- "reth-nippy-jar",
- "reth-primitives",
- "reth-primitives-traits",
- "reth-prune-types",
- "reth-stages-types",
- "reth-storage-errors",
- "reth-tracing",
- "reth-trie-common",
- "rustc-hash 2.1.1",
- "serde",
- "strum 0.26.3",
- "sysinfo",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "reth-db-api"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "alloy-genesis",
- "alloy-primitives",
- "bytes",
- "derive_more 1.0.0",
- "metrics 0.23.0",
- "modular-bitfield",
- "parity-scale-codec",
- "reth-codecs",
- "reth-db-models",
- "reth-primitives",
- "reth-primitives-traits",
- "reth-prune-types",
- "reth-stages-types",
- "reth-storage-errors",
- "reth-trie-common",
- "serde",
-]
-
-[[package]]
-name = "reth-db-models"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "alloy-primitives",
- "bytes",
- "modular-bitfield",
- "reth-codecs",
- "reth-primitives",
- "serde",
-]
-
-[[package]]
-name = "reth-engine-primitives"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "alloy-primitives",
- "reth-execution-types",
- "reth-payload-primitives",
- "reth-primitives",
- "reth-trie",
- "serde",
-]
-
-[[package]]
-name = "reth-errors"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "reth-blockchain-tree-api",
- "reth-consensus",
- "reth-execution-errors",
- "reth-fs-util",
- "reth-storage-errors",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "reth-eth-wire-types"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "alloy-chains",
- "alloy-eips 0.4.2",
- "alloy-primitives",
- "alloy-rlp",
- "bytes",
- "derive_more 1.0.0",
- "reth-chainspec",
- "reth-codecs-derive",
- "reth-primitives",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "reth-ethereum-forks"
 version = "1.1.0"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
@@ -6904,28 +6285,6 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "thiserror-no-std",
-]
-
-[[package]]
-name = "reth-evm"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "alloy-eips 0.4.2",
- "alloy-primitives",
- "auto_impl",
- "futures-util",
- "metrics 0.23.0",
- "reth-chainspec",
- "reth-execution-errors",
- "reth-execution-types",
- "reth-metrics",
- "reth-primitives",
- "reth-primitives-traits",
- "reth-prune-types",
- "reth-storage-errors",
- "revm 14.0.3",
- "revm-primitives 10.0.0",
 ]
 
 [[package]]
@@ -6968,143 +6327,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-libmdbx"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "bitflags 2.8.0",
- "byteorder",
- "dashmap",
- "derive_more 1.0.0",
- "indexmap 2.7.1",
- "parking_lot",
- "reth-mdbx-sys",
- "smallvec",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
-name = "reth-mdbx-sys"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "bindgen 0.70.1",
- "cc",
-]
-
-[[package]]
-name = "reth-metrics"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "metrics 0.23.0",
- "metrics-derive",
-]
-
-[[package]]
-name = "reth-net-banlist"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "alloy-primitives",
-]
-
-[[package]]
-name = "reth-network-p2p"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "alloy-eips 0.4.2",
- "alloy-primitives",
- "auto_impl",
- "derive_more 1.0.0",
- "futures",
- "reth-consensus",
- "reth-eth-wire-types",
- "reth-network-peers",
- "reth-network-types",
- "reth-primitives",
- "reth-storage-errors",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-network-peers"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "enr 0.12.1",
- "serde_with",
- "thiserror 1.0.69",
- "url",
-]
-
-[[package]]
-name = "reth-network-types"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "reth-ethereum-forks",
- "reth-net-banlist",
- "reth-network-peers",
- "serde_json",
- "tracing",
-]
-
-[[package]]
-name = "reth-nippy-jar"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "anyhow",
- "bincode",
- "derive_more 1.0.0",
- "lz4_flex",
- "memmap2",
- "reth-fs-util",
- "serde",
- "thiserror 1.0.69",
- "tracing",
- "zstd",
-]
-
-[[package]]
-name = "reth-node-types"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "reth-chainspec",
- "reth-db-api",
- "reth-engine-primitives",
-]
-
-[[package]]
-name = "reth-payload-primitives"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types 0.4.2",
- "async-trait",
- "op-alloy-rpc-types-engine 0.4.0",
- "pin-project",
- "reth-chain-state",
- "reth-chainspec",
- "reth-errors",
- "reth-primitives",
- "reth-transaction-pool",
- "serde",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
 name = "reth-primitives"
 version = "1.1.0"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
@@ -7114,21 +6336,16 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "bytes",
- "c-kzg",
  "derive_more 1.0.0",
  "k256",
- "modular-bitfield",
  "once_cell",
  "rayon",
- "reth-codecs",
  "reth-ethereum-forks",
  "reth-primitives-traits",
  "reth-static-file-types",
  "reth-trie-common",
  "revm-primitives 10.0.0",
- "secp256k1",
  "serde",
- "zstd",
 ]
 
 [[package]]
@@ -7149,48 +6366,6 @@ dependencies = [
  "revm-primitives 10.0.0",
  "roaring",
  "serde",
-]
-
-[[package]]
-name = "reth-provider"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "alloy-eips 0.4.2",
- "alloy-primitives",
- "alloy-rpc-types-engine 0.4.2",
- "auto_impl",
- "dashmap",
- "itertools 0.13.0",
- "metrics 0.23.0",
- "notify",
- "parking_lot",
- "rayon",
- "reth-blockchain-tree-api",
- "reth-chain-state",
- "reth-chainspec",
- "reth-codecs",
- "reth-db",
- "reth-db-api",
- "reth-errors",
- "reth-evm",
- "reth-execution-types",
- "reth-fs-util",
- "reth-metrics",
- "reth-network-p2p",
- "reth-nippy-jar",
- "reth-node-types",
- "reth-primitives",
- "reth-prune-types",
- "reth-stages-types",
- "reth-storage-api",
- "reth-storage-errors",
- "reth-trie",
- "reth-trie-db",
- "revm 14.0.3",
- "strum 0.26.3",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -7232,25 +6407,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-storage-api"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "alloy-eips 0.4.2",
- "alloy-primitives",
- "auto_impl",
- "reth-chainspec",
- "reth-db-api",
- "reth-db-models",
- "reth-execution-types",
- "reth-primitives",
- "reth-prune-types",
- "reth-stages-types",
- "reth-storage-errors",
- "reth-trie",
-]
-
-[[package]]
 name = "reth-storage-errors"
 version = "1.1.0"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
@@ -7264,71 +6420,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-tasks"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "auto_impl",
- "dyn-clone",
- "futures-util",
- "metrics 0.23.0",
- "reth-metrics",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "reth-tracing"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "clap",
- "eyre",
- "rolling-file",
- "tracing",
- "tracing-appender",
- "tracing-journald",
- "tracing-logfmt",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "reth-transaction-pool"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "alloy-eips 0.4.2",
- "alloy-primitives",
- "alloy-rlp",
- "aquamarine",
- "auto_impl",
- "bitflags 2.8.0",
- "futures-util",
- "metrics 0.23.0",
- "parking_lot",
- "reth-chain-state",
- "reth-chainspec",
- "reth-eth-wire-types",
- "reth-execution-types",
- "reth-fs-util",
- "reth-metrics",
- "reth-primitives",
- "reth-storage-api",
- "reth-tasks",
- "revm 14.0.3",
- "rustc-hash 2.1.1",
- "schnellru",
- "serde",
- "smallvec",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
 name = "reth-trie"
 version = "1.1.0"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
@@ -7338,10 +6429,8 @@ dependencies = [
  "auto_impl",
  "derive_more 1.0.0",
  "itertools 0.13.0",
- "metrics 0.23.0",
  "rayon",
  "reth-execution-errors",
- "reth-metrics",
  "reth-primitives",
  "reth-stages-types",
  "reth-storage-errors",
@@ -7368,31 +6457,6 @@ dependencies = [
  "reth-primitives-traits",
  "revm-primitives 10.0.0",
  "serde",
-]
-
-[[package]]
-name = "reth-trie-db"
-version = "1.1.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.0#1ba631ba9581973e7c6cadeea92cfe1802aceb4a"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "auto_impl",
- "derive_more 1.0.0",
- "itertools 0.13.0",
- "metrics 0.23.0",
- "rayon",
- "reth-db",
- "reth-db-api",
- "reth-execution-errors",
- "reth-metrics",
- "reth-primitives",
- "reth-stages-types",
- "reth-storage-errors",
- "reth-trie",
- "reth-trie-common",
- "revm 14.0.3",
- "tracing",
 ]
 
 [[package]]
@@ -7591,7 +6655,7 @@ dependencies = [
  "bytecheck",
  "bytes",
  "hashbrown 0.15.2",
- "indexmap 2.7.1",
+ "indexmap",
  "munge",
  "ptr_meta",
  "rancor",
@@ -7640,15 +6704,6 @@ checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
 dependencies = [
  "libc",
  "librocksdb-sys",
-]
-
-[[package]]
-name = "rolling-file"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8395b4f860856b740f20a296ea2cd4d823e81a2658cf05ef61be22916026a906"
-dependencies = [
- "chrono",
 ]
 
 [[package]]
@@ -7947,17 +7002,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schnellru"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356285bbf17bea63d9e52e96bd18f039672ac92b55b8cb997d6162a2a37d1649"
-dependencies = [
- "ahash",
- "cfg-if",
- "hashbrown 0.13.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8082,7 +7126,7 @@ version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -8130,8 +7174,6 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
- "indexmap 1.9.3",
- "indexmap 2.7.1",
  "serde",
  "serde_derive",
  "serde_json",
@@ -8529,19 +7571,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sysinfo"
-version = "0.31.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355dbe4f8799b304b05e1b0f05fc59b2a18d36645cf169607da45bde2f69a1be"
-dependencies = [
- "core-foundation-sys",
- "libc",
- "memchr",
- "ntapi",
- "windows 0.57.0",
-]
-
-[[package]]
 name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8745,7 +7774,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio 1.0.3",
+ "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -8855,7 +7884,7 @@ version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -8917,18 +7946,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-appender"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
-dependencies = [
- "crossbeam-channel",
- "thiserror 1.0.69",
- "time",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "tracing-attributes"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8950,27 +7967,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
-]
-
-[[package]]
-name = "tracing-journald"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0b4143302cf1022dac868d521e36e8b27691f72c84b3311750d5188ebba657"
-dependencies = [
- "libc",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8978,28 +7974,6 @@ checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
  "log",
  "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-logfmt"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1f47d22deb79c3f59fcf2a1f00f60cbdc05462bf17d1cd356c1fefa3f444bd"
-dependencies = [
- "time",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-serde"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
-dependencies = [
- "serde",
  "tracing-core",
 ]
 
@@ -9014,14 +7988,12 @@ dependencies = [
  "once_cell",
  "regex",
  "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]
@@ -9408,26 +8380,7 @@ version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efc5cf48f83140dcaab716eeaea345f9e93d0018fb81162753a3f76c3397b538"
 dependencies = [
- "windows-core 0.53.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
-dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
+ "windows-core",
  "windows-targets 0.52.6",
 ]
 
@@ -9946,32 +8899,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
-]
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3051792fbdc2e1e143244dc28c60f73d8470e93f3f9cbd0ead44da5ed802722"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.14+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb060d4926e4ac3a3ad15d864e99ceb5f343c6b34f5bd6d81ae6ed417311be5"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,8 +380,8 @@ dependencies = [
  "alloy-primitives",
  "alloy-pubsub",
  "alloy-rpc-client",
- "alloy-rpc-types-engine 0.11.1",
- "alloy-rpc-types-eth 0.11.1",
+ "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
  "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
@@ -695,7 +695,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20819c4cb978fb39ce6ac31991ba90f386d595f922f42ef888b4a18be190713e"
 dependencies = [
  "alloy-json-rpc",
- "alloy-rpc-types-engine 0.11.1",
+ "alloy-rpc-types-engine",
  "alloy-transport",
  "http-body-util",
  "hyper 1.6.0",
@@ -1525,8 +1525,6 @@ checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "num-traits",
  "serde",
- "wasm-bindgen",
- "windows-link",
 ]
 
 [[package]]
@@ -3989,7 +3987,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-client",
- "alloy-rpc-types-engine 0.11.1",
+ "alloy-rpc-types-engine",
  "alloy-transport-http",
  "anyhow",
  "clap",
@@ -4002,7 +4000,7 @@ dependencies = [
  "kona-providers-alloy",
  "kona-registry",
  "op-alloy-provider",
- "op-alloy-rpc-types-engine 0.10.5",
+ "op-alloy-rpc-types-engine",
  "serde_json",
  "thiserror 2.0.11",
  "tokio",
@@ -4046,8 +4044,8 @@ dependencies = [
  "kona-registry",
  "kona-rpc",
  "lru 0.13.0",
- "op-alloy-consensus 0.10.5",
- "op-alloy-rpc-types-engine 0.10.5",
+ "op-alloy-consensus",
+ "op-alloy-rpc-types-engine",
  "rstest",
  "serde",
  "serde_json",
@@ -5307,23 +5305,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "op-alloy-protocol"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310873e4fbfc41986716c4fb6000a8b49d025d932d2c261af58271c434b05288"
-dependencies = [
- "alloy-consensus 0.4.2",
- "alloy-eips 0.4.2",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.4.2",
- "derive_more 1.0.0",
- "op-alloy-consensus 0.4.0",
- "op-alloy-genesis",
- "serde",
-]
-
-[[package]]
 name = "op-alloy-provider"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5332,10 +5313,10 @@ dependencies = [
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
- "alloy-rpc-types-engine 0.11.1",
+ "alloy-rpc-types-engine",
  "alloy-transport",
  "async-trait",
- "op-alloy-rpc-types-engine 0.10.5",
+ "op-alloy-rpc-types-engine",
 ]
 
 [[package]]
@@ -8393,46 +8374,6 @@ dependencies = [
  "windows-result 0.1.2",
  "windows-targets 0.52.6",
 ]
-
-[[package]]
-name = "windows-core"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-registry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ op-alloy-rpc-jsonrpsee = { version = "0.10.5", default-features = false }
 op-alloy-rpc-types-engine = { version = "0.10.5", default-features = false }
 
 # Reth
-reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.0", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.0", default-features = false }
 reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.0", default-features = false }
 
 # General

--- a/crates/providers/providers-local/Cargo.toml
+++ b/crates/providers/providers-local/Cargo.toml
@@ -27,8 +27,8 @@ alloy-primitives = { workspace = true, features = ["map"] }
 op-alloy-consensus.workspace = true
 
 # Reth
-reth-provider = { workspace = true, default-features = false }
-reth-primitives = { workspace = true, default-features = false }
+reth-execution-types.workspace = true
+reth-primitives.workspace = true
 
 # Misc
 async-trait.workspace = true

--- a/crates/providers/providers-local/src/chain_provider.rs
+++ b/crates/providers/providers-local/src/chain_provider.rs
@@ -15,8 +15,8 @@ use kona_derive::{
 };
 use kona_protocol::BlockInfo;
 use parking_lot::RwLock;
+use reth_execution_types::Chain;
 use reth_primitives::Transaction;
-use reth_provider::Chain;
 
 /// An in-memory [ChainProvider] that stores chain data,
 /// meant to be shared between multiple readers.


### PR DESCRIPTION
Based on https://github.com/op-rs/kona/pull/1104

Replaces `reth-provider` with `reth-execution-types`. This enables bumping reth deps to v1.2.0, which wasn't possible before since `reth-provider` is not `no-std` compatible.