### PR TITLE
fix: fix base sepolia

### DIFF
--- a/bin/client/justfile
+++ b/bin/client/justfile
@@ -90,7 +90,7 @@ run-client-native block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc rollu
   AGREED_L2_OUTPUT_ROOT=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $((CLAIMED_L2_BLOCK_NUMBER - 1))) | jq -r .outputRoot)
   AGREED_L2_HEAD_HASH=$(cast block --rpc-url $L2_NODE_ADDRESS $((CLAIMED_L2_BLOCK_NUMBER - 1)) --json | jq -r .hash)
   L1_ORIGIN_NUM=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $((CLAIMED_L2_BLOCK_NUMBER - 1))) | jq -r .blockRef.l1origin.number)
-  L1_HEAD=$(cast block --rpc-url $L1_NODE_ADDRESS $((L1_ORIGIN_NUM + 30)) --json | jq -r .hash)
+  L1_HEAD=$(cast block --rpc-url $L1_NODE_ADDRESS $((L1_ORIGIN_NUM + 50)) --json | jq -r .hash)
 
   # Move to the workspace root
   cd $(git rev-parse --show-toplevel)

--- a/crates/protocol/registry/etc/configs.json
+++ b/crates/protocol/registry/etc/configs.json
@@ -3521,7 +3521,7 @@
             },
             "l2_time": 1695768288,
             "system_config": {
-              "batcherAddress": "0x6cdebe940bc0f26850285caca097c11c33103e47",
+              "batcherAddress": "0xfc56E7272EEBBBA5bC6c544e159483C4a38f8bA3",
               "overhead": "0x834",
               "scalar": "0xf4240",
               "gasLimit": 25000000,

--- a/crates/protocol/registry/src/test_utils/base_sepolia.rs
+++ b/crates/protocol/registry/src/test_utils/base_sepolia.rs
@@ -20,7 +20,7 @@ pub const BASE_SEPOLIA_CONFIG: RollupConfig = RollupConfig {
         },
         l2_time: 1695768288,
         system_config: Some(SystemConfig {
-            batcher_address: address!("6cdebe940bc0f26850285caca097c11c33103e47"),
+            batcher_address: address!("fc56E7272EEBBBA5bC6c544e159483C4a38f8bA3"),
             overhead: uint!(0x834_U256),
             scalar: uint!(0xf4240_U256),
             gas_limit: 25000000,


### PR DESCRIPTION
Fixes derivation pipeline failing for base sepolia with below error.

```
2025-02-25T03:19:32.556338Z  INFO client_derivation_driver: Advanced origin
2025-02-25T03:19:32.565078Z  INFO client_derivation_driver: Advanced origin
2025-02-25T03:19:32.569594Z  WARN client_derivation_driver: Failed to step derivation pipeline: Critical(EndOfSource)
2025-02-25T03:19:32.569619Z  WARN client: Exhausted data source; Halting derivation and using current safe head.
2025-02-25T03:19:32.569621Z  INFO client: Derivation complete, reached L2 safe head.
2025-02-25T03:19:32.569623Z ERROR client: Failed to validate L2 block #22335000 with output root 0x0000000000000000000000000000000000000000000000000000000000000000
```

# How to reproduce error
Run below command on main
```
just run-client-native 22335001 <L1_RPC> <L1_NODE_RPC> <L2_RPC> <L2_NODE_RPC>
```

# Fixed by
1. Updating batcher address
- For some reason base-sepolia's batcher address has changed
- Old address: [0x6cdebe940bc0f26850285caca097c11c33103e47](https://sepolia.etherscan.io/address/0x6cdebe940bc0f26850285caca097c11c33103e47) has not been posting since 15 days ago.
- New address: [0xfc56E7272EEBBBA5bC6c544e159483C4a38f8bA3](https://sepolia.etherscan.io/address/0xfc56E7272EEBBBA5bC6c544e159483C4a38f8bA3)

2. Picking a longer L1 head block
- For some reason, L1 head with + 30 blocks from L1 origin for base sepolia is too close, failing with EndOfSource.
- + 40 blocks was not working as well.
