### PR TITLE
fix(derive): Use `SystemConfig` batcher key for DAP

### DIFF
--- a/bin/client/src/interop/mod.rs
+++ b/bin/client/src/interop/mod.rs
@@ -4,6 +4,7 @@ use alloc::sync::Arc;
 use alloy_primitives::B256;
 use consolidate::consolidate_dependencies;
 use core::fmt::Debug;
+use kona_derive::errors::PipelineErrorKind;
 use kona_driver::DriverError;
 use kona_executor::{ExecutorError, KonaHandleRegister};
 use kona_preimage::{HintWriterClient, PreimageOracleClient};
@@ -31,6 +32,9 @@ pub enum FaultProofProgramError {
     /// An error occurred in the driver.
     #[error(transparent)]
     Driver(#[from] DriverError<ExecutorError>),
+    /// An error occurred in the derivation pipeline.
+    #[error(transparent)]
+    PipelineError(#[from] PipelineErrorKind),
     /// Consolidation error.
     #[error(transparent)]
     Consolidation(#[from] ConsolidationError),

--- a/bin/client/src/interop/transition.rs
+++ b/bin/client/src/interop/transition.rs
@@ -6,11 +6,7 @@ use alloc::sync::Arc;
 use alloy_consensus::Sealed;
 use alloy_primitives::B256;
 use core::fmt::Debug;
-use kona_derive::{
-    errors::{PipelineError, PipelineErrorKind},
-    traits::{L2ChainProvider, SignalReceiver},
-    types::ResetSignal,
-};
+use kona_derive::errors::{PipelineError, PipelineErrorKind};
 use kona_driver::{Driver, DriverError};
 use kona_executor::{KonaHandleRegister, TrieDBProvider};
 use kona_preimage::{HintWriterClient, PreimageOracleClient};
@@ -102,31 +98,15 @@ where
             .await?;
     l2_provider.set_cursor(cursor.clone());
 
-    let mut pipeline = OraclePipeline::new(
+    let pipeline = OraclePipeline::new(
         rollup_config.clone(),
         cursor.clone(),
         oracle.clone(),
         beacon,
         l1_provider.clone(),
         l2_provider.clone(),
-    );
-
-    // Reset the pipeline to populate the initial system configuration in L1 Traversal.
-    let l2_safe_head = *cursor.read().l2_safe_head();
-    pipeline
-        .signal(
-            ResetSignal {
-                l2_safe_head,
-                l1_origin: cursor.read().origin(),
-                system_config: l2_provider
-                    .system_config_by_number(l2_safe_head.block_info.number, rollup_config.clone())
-                    .await
-                    .ok(),
-            }
-            .signal(),
-        )
-        .await?;
-
+    )
+    .await?;
     let executor = KonaExecutor::new(
         rollup_config.as_ref(),
         l2_provider.clone(),

--- a/bin/client/src/single.rs
+++ b/bin/client/src/single.rs
@@ -4,11 +4,7 @@ use alloc::sync::Arc;
 use alloy_consensus::Sealed;
 use alloy_primitives::B256;
 use core::fmt::Debug;
-use kona_derive::{
-    errors::PipelineErrorKind,
-    traits::{L2ChainProvider, SignalReceiver},
-    types::ResetSignal,
-};
+use kona_derive::errors::PipelineErrorKind;
 use kona_driver::{Driver, DriverError};
 use kona_executor::{ExecutorError, KonaHandleRegister, TrieDBProvider};
 use kona_preimage::{CommsClient, HintWriterClient, PreimageKey, PreimageOracleClient};
@@ -112,31 +108,15 @@ where
             .await?;
     l2_provider.set_cursor(cursor.clone());
 
-    let mut pipeline = OraclePipeline::new(
+    let pipeline = OraclePipeline::new(
         rollup_config.clone(),
         cursor.clone(),
         oracle.clone(),
         beacon,
         l1_provider.clone(),
         l2_provider.clone(),
-    );
-
-    // Reset the pipeline to populate the initial system configuration in L1 Traversal.
-    let l2_safe_head = *cursor.read().l2_safe_head();
-    pipeline
-        .signal(
-            ResetSignal {
-                l2_safe_head,
-                l1_origin: cursor.read().origin(),
-                system_config: l2_provider
-                    .system_config_by_number(l2_safe_head.block_info.number, rollup_config.clone())
-                    .await
-                    .ok(),
-            }
-            .signal(),
-        )
-        .await?;
-
+    )
+    .await?;
     let executor = KonaExecutor::new(
         rollup_config.as_ref(),
         l2_provider.clone(),

--- a/bin/client/src/single.rs
+++ b/bin/client/src/single.rs
@@ -4,6 +4,11 @@ use alloc::sync::Arc;
 use alloy_consensus::Sealed;
 use alloy_primitives::B256;
 use core::fmt::Debug;
+use kona_derive::{
+    errors::PipelineErrorKind,
+    traits::{L2ChainProvider, SignalReceiver},
+    types::ResetSignal,
+};
 use kona_driver::{Driver, DriverError};
 use kona_executor::{ExecutorError, KonaHandleRegister, TrieDBProvider};
 use kona_preimage::{CommsClient, HintWriterClient, PreimageKey, PreimageOracleClient};
@@ -27,6 +32,9 @@ pub enum FaultProofProgramError {
     /// An error occurred in the Oracle provider.
     #[error(transparent)]
     OracleProviderError(#[from] OracleProviderError),
+    /// An error occurred in the derivation pipeline.
+    #[error(transparent)]
+    PipelineError(#[from] PipelineErrorKind),
     /// An error occurred in the driver.
     #[error(transparent)]
     Driver(#[from] DriverError<ExecutorError>),
@@ -104,7 +112,7 @@ where
             .await?;
     l2_provider.set_cursor(cursor.clone());
 
-    let pipeline = OraclePipeline::new(
+    let mut pipeline = OraclePipeline::new(
         rollup_config.clone(),
         cursor.clone(),
         oracle.clone(),
@@ -112,6 +120,23 @@ where
         l1_provider.clone(),
         l2_provider.clone(),
     );
+
+    // Reset the pipeline to populate the initial system configuration in L1 Traversal.
+    let l2_safe_head = *cursor.read().l2_safe_head();
+    pipeline
+        .signal(
+            ResetSignal {
+                l2_safe_head,
+                l1_origin: cursor.read().origin(),
+                system_config: l2_provider
+                    .system_config_by_number(l2_safe_head.block_info.number, rollup_config.clone())
+                    .await
+                    .ok(),
+            }
+            .signal(),
+        )
+        .await?;
+
     let executor = KonaExecutor::new(
         rollup_config.as_ref(),
         l2_provider.clone(),

--- a/bin/host/src/interop/handler.rs
+++ b/bin/host/src/interop/handler.rs
@@ -483,7 +483,8 @@ impl HintHandler for InteropHintHandler {
                             beacon,
                             l1_provider,
                             l2_provider.clone(),
-                        );
+                        )
+                        .await?;
                         let executor = KonaExecutor::new(
                             rollup_config.as_ref(),
                             l2_provider.clone(),

--- a/crates/protocol/derive/src/stages/l1_retrieval.rs
+++ b/crates/protocol/derive/src/stages/l1_retrieval.rs
@@ -92,7 +92,7 @@ where
         // SAFETY: The above check ensures that `next` is not None.
         let next = self.next.as_ref().expect("infallible");
 
-        match self.provider.next(next).await {
+        match self.provider.next(next, self.prev.batcher_addr()).await {
             Ok(data) => Ok(data),
             Err(e) => {
                 if let PipelineErrorKind::Temporary(PipelineError::Eof) = e {

--- a/crates/protocol/derive/src/test_utils/data_availability_provider.rs
+++ b/crates/protocol/derive/src/test_utils/data_availability_provider.rs
@@ -2,7 +2,7 @@
 
 use crate::{errors::PipelineError, traits::DataAvailabilityProvider, types::PipelineResult};
 use alloc::{boxed::Box, vec::Vec};
-use alloy_primitives::Bytes;
+use alloy_primitives::{Address, Bytes};
 use async_trait::async_trait;
 use core::fmt::Debug;
 use kona_protocol::BlockInfo;
@@ -18,7 +18,7 @@ pub struct TestDAP {
 impl DataAvailabilityProvider for TestDAP {
     type Item = Bytes;
 
-    async fn next(&mut self, _: &BlockInfo) -> PipelineResult<Self::Item> {
+    async fn next(&mut self, _: &BlockInfo, _: Address) -> PipelineResult<Self::Item> {
         self.results.pop().unwrap_or(Err(PipelineError::Eof.temp()))
     }
 

--- a/crates/protocol/derive/src/traits/data_sources.rs
+++ b/crates/protocol/derive/src/traits/data_sources.rs
@@ -4,7 +4,7 @@
 use crate::{errors::PipelineErrorKind, types::PipelineResult};
 use alloc::{boxed::Box, fmt::Debug, string::ToString, vec::Vec};
 use alloy_eips::eip4844::{Blob, IndexedBlobHash};
-use alloy_primitives::Bytes;
+use alloy_primitives::{Address, Bytes};
 use async_trait::async_trait;
 use core::fmt::Display;
 use kona_protocol::BlockInfo;
@@ -29,9 +29,14 @@ pub trait DataAvailabilityProvider {
     /// The item type of the data iterator.
     type Item: Send + Sync + Debug + Into<Bytes>;
 
-    /// Returns the next data for the given [BlockInfo].
-    /// Returns a `PipelineError::Eof` if there is no more data for the given block ref.
-    async fn next(&mut self, block_ref: &BlockInfo) -> PipelineResult<Self::Item>;
+    /// Returns the next data for the given [BlockInfo], looking for transactions sent by the
+    /// `batcher_addr`. Returns a `PipelineError::Eof` if there is no more data for the given
+    /// block ref.
+    async fn next(
+        &mut self,
+        block_ref: &BlockInfo,
+        batcher_addr: Address,
+    ) -> PipelineResult<Self::Item>;
 
     /// Clears the data source for the next block ref.
     fn clear(&mut self);


### PR DESCRIPTION
## Overview

Alters the data availability provider in the derivation pipeline to use a dynamic batcher address. There is currently an issue in `kona` where chains that have changed their batch submitter key since genesis will not read batches from L1 correctly.

closes https://github.com/op-rs/kona/issues/1103