### PR TITLE
chore(proof-interop): Adjust `TRANSITION_STATE_MAX_STEPS`

### DIFF
--- a/crates/proof/proof-interop/src/pre_state.rs
+++ b/crates/proof/proof-interop/src/pre_state.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 pub(crate) const TRANSITION_STATE_VERSION: u8 = 255;
 
 /// The maximum number of steps allowed in a [TransitionState].
-pub const TRANSITION_STATE_MAX_STEPS: u64 = 2u64.pow(10) - 1;
+pub const TRANSITION_STATE_MAX_STEPS: u64 = 2u64.pow(7) - 1;
 
 /// The [Bytes] representation of the string "invalid".
 pub const INVALID_TRANSITION: Bytes = Bytes::from_static(b"invalid");


### PR DESCRIPTION
## Overview

Adjusts the `TRANSITION_STATE_MAX_STEPS` to `128 -1`.

closes #1138 