### PR TITLE
chore(interop): Replace Interop Feat Flag

### DIFF
--- a/crates/protocol/interop/Cargo.toml
+++ b/crates/protocol/interop/Cargo.toml
@@ -50,6 +50,9 @@ rand.workspace = true
 [features]
 default = []
 std = [
+  "dep:kona-protocol",
+  "dep:alloy-rpc-client",
+  "derive_more/display",
   "alloy-consensus/std",
   "alloy-eips/std",
   "alloy-primitives/std",
@@ -72,11 +75,4 @@ serde = [
   "alloy-eips/serde",
   "alloy-primitives/serde",
   "kona-protocol?/serde",
-]
-interop = [
-  "std",
-  "serde",
-  "dep:kona-protocol",
-  "dep:alloy-rpc-client",
-  "derive_more/display",
 ]

--- a/crates/protocol/interop/Cargo.toml
+++ b/crates/protocol/interop/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 # Workspace
 kona-genesis.workspace = true
 kona-registry.workspace = true
+kona-protocol.workspace = true
 
 # General
 thiserror.workspace = true
@@ -30,8 +31,7 @@ alloy-consensus.workspace = true
 alloy-primitives = { workspace = true, features = ["rlp"] }
 op-alloy-consensus.workspace = true
 
-# `interop` feature
-kona-protocol = { workspace = true, optional = true }
+# `client` feature
 alloy-rpc-client = { workspace = true, features = ["reqwest"], optional = true }
 
 # Arbitrary
@@ -50,8 +50,6 @@ rand.workspace = true
 [features]
 default = []
 std = [
-  "dep:kona-protocol",
-  "dep:alloy-rpc-client",
   "derive_more/display",
   "alloy-consensus/std",
   "alloy-eips/std",
@@ -61,7 +59,13 @@ std = [
   "derive_more/std",
   "serde?/std",
   "thiserror/std",
-  "kona-protocol?/std",
+  "kona-protocol/std",
+]
+client = [
+  "std",
+  "serde",
+  "dep:alloy-rpc-client",
+  "derive_more/display",
 ]
 arbitrary = [
   "std",
@@ -74,5 +78,5 @@ serde = [
   "dep:serde",
   "alloy-eips/serde",
   "alloy-primitives/serde",
-  "kona-protocol?/serde",
+  "kona-protocol/serde",
 ]

--- a/crates/protocol/interop/src/client.rs
+++ b/crates/protocol/interop/src/client.rs
@@ -1,0 +1,91 @@
+//! Supervisor client implementation.
+
+use crate::{
+    DerivedIdPair, ExecutingMessage, MessageIdentifier, SafetyLevel, SuperRootResponse, Supervisor,
+};
+use alloc::{boxed::Box, vec::Vec};
+use alloy_eips::eip1898::BlockNumHash;
+use alloy_primitives::B256;
+use alloy_rpc_client::ReqwestClient;
+use async_trait::async_trait;
+use derive_more::{Display, From};
+use kona_protocol::BlockInfo;
+
+/// A supervisor client.
+#[derive(Debug, Clone)]
+pub struct SupervisorClient {
+    /// The inner RPC client.
+    client: ReqwestClient,
+}
+
+impl SupervisorClient {
+    /// Creates a new `SupervisorClient` with the given `client`.
+    pub const fn new(client: ReqwestClient) -> Self {
+        Self { client }
+    }
+}
+
+/// An error from the `op-supervisor`.
+#[derive(Copy, Clone, Debug, Display, From, thiserror::Error)]
+pub enum SupervisorError {
+    /// A failed request.
+    RequestFailed,
+}
+
+#[async_trait]
+impl Supervisor for SupervisorClient {
+    type Error = SupervisorError;
+
+    async fn check_message(
+        &self,
+        identifier: MessageIdentifier,
+        payload_hash: B256,
+    ) -> Result<SafetyLevel, Self::Error> {
+        self.client
+            .request("supervisor_checkMessage", (identifier, payload_hash))
+            .await
+            .map_err(|_| SupervisorError::RequestFailed)
+    }
+
+    async fn check_messages(
+        &self,
+        messages: &[ExecutingMessage],
+        min_safety: SafetyLevel,
+    ) -> Result<(), Self::Error> {
+        self.client
+            .request("supervisor_checkMessages", (messages, min_safety))
+            .await
+            .map_err(|_| SupervisorError::RequestFailed)
+    }
+
+    async fn cross_derived_from(&self, _: u32, _: BlockNumHash) -> Result<BlockInfo, Self::Error> {
+        unimplemented!()
+    }
+
+    async fn local_unsafe(&self, _: u32) -> Result<BlockNumHash, Self::Error> {
+        unimplemented!()
+    }
+
+    async fn cross_safe(&self, _: u32) -> Result<DerivedIdPair, Self::Error> {
+        unimplemented!()
+    }
+
+    async fn finalized(&self, _: u32) -> Result<BlockNumHash, Self::Error> {
+        unimplemented!()
+    }
+
+    async fn finalized_l1(&self) -> Result<BlockInfo, Self::Error> {
+        unimplemented!()
+    }
+
+    async fn super_root_at_timestamp(&self, _: u64) -> Result<SuperRootResponse, Self::Error> {
+        unimplemented!()
+    }
+
+    async fn all_safe_derived_at(
+        &self,
+        _: BlockNumHash,
+    ) -> Result<Vec<(u32, BlockNumHash)>, Self::Error> {
+        unimplemented!()
+    }
+}

--- a/crates/protocol/interop/src/lib.rs
+++ b/crates/protocol/interop/src/lib.rs
@@ -5,7 +5,7 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
-#![cfg_attr(not(any(feature = "std", feature = "interop")), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
 
@@ -15,9 +15,9 @@ pub use graph::MessageGraph;
 mod traits;
 pub use traits::InteropProvider;
 
-#[cfg(feature = "interop")]
+#[cfg(feature = "std")]
 mod supervisor;
-#[cfg(feature = "interop")]
+#[cfg(feature = "std")]
 pub use supervisor::{Supervisor, SupervisorClient, SupervisorError};
 
 mod safety;

--- a/crates/protocol/interop/src/lib.rs
+++ b/crates/protocol/interop/src/lib.rs
@@ -15,10 +15,13 @@ pub use graph::MessageGraph;
 mod traits;
 pub use traits::InteropProvider;
 
-#[cfg(feature = "std")]
 mod supervisor;
-#[cfg(feature = "std")]
-pub use supervisor::{Supervisor, SupervisorClient, SupervisorError};
+pub use supervisor::Supervisor;
+
+#[cfg(feature = "client")]
+mod client;
+#[cfg(feature = "client")]
+pub use client::{SupervisorClient, SupervisorError};
 
 mod safety;
 pub use safety::SafetyLevel;

--- a/crates/protocol/interop/src/supervisor.rs
+++ b/crates/protocol/interop/src/supervisor.rs
@@ -4,9 +4,7 @@ use crate::{DerivedIdPair, ExecutingMessage, MessageIdentifier, SafetyLevel, Sup
 use alloc::{boxed::Box, vec::Vec};
 use alloy_eips::eip1898::BlockNumHash;
 use alloy_primitives::B256;
-use alloy_rpc_client::ReqwestClient;
 use async_trait::async_trait;
-use derive_more::{Display, From};
 use kona_protocol::BlockInfo;
 
 /// An interface for the `op-supervisor` component of the OP Stack.
@@ -61,83 +59,4 @@ pub trait Supervisor {
         &self,
         derived_from: BlockNumHash,
     ) -> Result<Vec<(u32, BlockNumHash)>, Self::Error>;
-}
-
-/// An error from the `op-supervisor`.
-#[derive(Copy, Clone, Debug, Display, From, thiserror::Error)]
-pub enum SupervisorError {
-    /// A failed request.
-    RequestFailed,
-}
-
-/// A supervisor client.
-#[derive(Debug, Clone)]
-pub struct SupervisorClient {
-    /// The inner RPC client.
-    client: ReqwestClient,
-}
-
-impl SupervisorClient {
-    /// Creates a new `SupervisorClient` with the given `client`.
-    pub const fn new(client: ReqwestClient) -> Self {
-        Self { client }
-    }
-}
-
-#[async_trait]
-impl Supervisor for SupervisorClient {
-    type Error = SupervisorError;
-
-    async fn check_message(
-        &self,
-        identifier: MessageIdentifier,
-        payload_hash: B256,
-    ) -> Result<SafetyLevel, Self::Error> {
-        self.client
-            .request("supervisor_checkMessage", (identifier, payload_hash))
-            .await
-            .map_err(|_| SupervisorError::RequestFailed)
-    }
-
-    async fn check_messages(
-        &self,
-        messages: &[ExecutingMessage],
-        min_safety: SafetyLevel,
-    ) -> Result<(), Self::Error> {
-        self.client
-            .request("supervisor_checkMessages", (messages, min_safety))
-            .await
-            .map_err(|_| SupervisorError::RequestFailed)
-    }
-
-    async fn cross_derived_from(&self, _: u32, _: BlockNumHash) -> Result<BlockInfo, Self::Error> {
-        unimplemented!()
-    }
-
-    async fn local_unsafe(&self, _: u32) -> Result<BlockNumHash, Self::Error> {
-        unimplemented!()
-    }
-
-    async fn cross_safe(&self, _: u32) -> Result<DerivedIdPair, Self::Error> {
-        unimplemented!()
-    }
-
-    async fn finalized(&self, _: u32) -> Result<BlockNumHash, Self::Error> {
-        unimplemented!()
-    }
-
-    async fn finalized_l1(&self) -> Result<BlockInfo, Self::Error> {
-        unimplemented!()
-    }
-
-    async fn super_root_at_timestamp(&self, _: u64) -> Result<SuperRootResponse, Self::Error> {
-        unimplemented!()
-    }
-
-    async fn all_safe_derived_at(
-        &self,
-        _: BlockNumHash,
-    ) -> Result<Vec<(u32, BlockNumHash)>, Self::Error> {
-        unimplemented!()
-    }
 }


### PR DESCRIPTION
### Description

Replaces the `interop` feature flag in the `kona-interop` crate with a `client` feature flag that holds the client impl for the `Supervisor` trait that is now exposed without a feature flag.