### PR TITLE
feat(registry): Lookup `Chain` + `RollupConfig` by identifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,7 @@ checksum = "996564c1782285d4e0299c29b318bc74f24b1d7f456cef3e040810b061ee3256"
 dependencies = [
  "alloy-primitives",
  "num_enum",
+ "serde",
  "strum 0.27.1",
 ]
 
@@ -4188,6 +4189,7 @@ dependencies = [
 name = "kona-registry"
 version = "0.1.0"
 dependencies = [
+ "alloy-chains",
  "alloy-eips",
  "alloy-primitives",
  "kona-genesis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ alloy-node-bindings = { version = "0.11.1", default-features = false }
 alloy-transport-http = { version = "0.11.1", default-features = false }
 alloy-rpc-types-engine = { version = "0.11.1", default-features = false }
 alloy-rpc-types-beacon = { version = "0.11.1", default-features = false }
+alloy-chains = { version = "0.1", default-features = false }
 
 # OP Alloy
 op-alloy-flz = { version = "0.10.5", default-features = false }

--- a/crates/protocol/registry/Cargo.toml
+++ b/crates/protocol/registry/Cargo.toml
@@ -20,6 +20,7 @@ kona-genesis = { workspace = true, features = ["serde"] }
 
 # Alloy
 alloy-primitives = { workspace = true, features = ["map"] }
+alloy-chains = { workspace = true, features = ["serde"] }
 
 # `serde`
 serde = { workspace = true, features = ["derive", "alloc"] }
@@ -42,5 +43,6 @@ std = [
 	"kona-genesis/std",
 	"serde_json/std",
 	"alloy-primitives/std",
-	"serde/std"
+	"serde/std",
+	"alloy-chains/std"
 ]

--- a/crates/protocol/registry/src/chain_list.rs
+++ b/crates/protocol/registry/src/chain_list.rs
@@ -4,9 +4,40 @@ use alloc::{string::String, vec::Vec};
 
 /// List of Chains.
 #[derive(Debug, Clone, Default, Hash, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
 pub struct ChainList {
     /// List of Chains.
     pub chains: Vec<Chain>,
+}
+
+impl ChainList {
+    /// Fetch a [Chain] by its identifier.
+    pub fn get_chain_by_ident(&self, identifier: &str) -> Option<&Chain> {
+        self.chains.iter().find(|c| c.identifier.eq_ignore_ascii_case(identifier))
+    }
+
+    /// Fetch a [Chain] by its chain id.
+    pub fn get_chain_by_id(&self, chain_id: u64) -> Option<&Chain> {
+        self.chains.iter().find(|c| c.chain_id == chain_id)
+    }
+
+    /// Returns the number of chains.
+    pub fn len(&self) -> usize {
+        self.chains.len()
+    }
+
+    /// Returns true if the list is empty.
+    pub fn is_empty(&self) -> bool {
+        self.chains.is_empty()
+    }
+}
+
+impl Iterator for ChainList {
+    type Item = Chain;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.chains.pop()
+    }
 }
 
 /// A Chain Definition.

--- a/crates/protocol/registry/src/chain_list.rs
+++ b/crates/protocol/registry/src/chain_list.rs
@@ -1,6 +1,7 @@
 //! List of OP Stack chains.
 
 use alloc::{string::String, vec::Vec};
+use alloy_chains::Chain as AlloyChain;
 
 /// List of Chains.
 #[derive(Debug, Clone, Default, Hash, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -19,6 +20,11 @@ impl ChainList {
     /// Fetch a [Chain] by its chain id.
     pub fn get_chain_by_id(&self, chain_id: u64) -> Option<&Chain> {
         self.chains.iter().find(|c| c.chain_id == chain_id)
+    }
+
+    /// Fetch a [Chain] by the corresponding [AlloyChain]
+    pub fn get_chain_by_alloy_ident(&self, chain: &AlloyChain) -> Option<&Chain> {
+        self.get_chain_by_id(chain.id())
     }
 
     /// Returns the number of chains.

--- a/crates/protocol/registry/src/chain_list.rs
+++ b/crates/protocol/registry/src/chain_list.rs
@@ -32,11 +32,12 @@ impl ChainList {
     }
 }
 
-impl Iterator for ChainList {
+impl IntoIterator for ChainList {
     type Item = Chain;
+    type IntoIter = alloc::vec::IntoIter<Self::Item>;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        self.chains.pop()
+    fn into_iter(self) -> Self::IntoIter {
+        self.chains.into_iter()
     }
 }
 

--- a/crates/protocol/registry/src/chain_list.rs
+++ b/crates/protocol/registry/src/chain_list.rs
@@ -17,6 +17,11 @@ impl ChainList {
         self.chains.iter().find(|c| c.identifier.eq_ignore_ascii_case(identifier))
     }
 
+    /// Returns all available [Chain] identifiers.
+    pub fn chain_idents(&self) -> Vec<String> {
+        self.chains.iter().map(|c| c.identifier.clone()).collect()
+    }
+
     /// Fetch a [Chain] by its chain id.
     pub fn get_chain_by_id(&self, chain_id: u64) -> Option<&Chain> {
         self.chains.iter().find(|c| c.chain_id == chain_id)
@@ -35,15 +40,6 @@ impl ChainList {
     /// Returns true if the list is empty.
     pub fn is_empty(&self) -> bool {
         self.chains.is_empty()
-    }
-}
-
-impl IntoIterator for ChainList {
-    type Item = Chain;
-    type IntoIter = alloc::vec::IntoIter<Self::Item>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.chains.into_iter()
     }
 }
 

--- a/crates/protocol/registry/src/lib.rs
+++ b/crates/protocol/registry/src/lib.rs
@@ -10,7 +10,6 @@
 
 extern crate alloc;
 
-use alloc::{string::String, vec::Vec};
 pub use alloy_primitives::map::{DefaultHashBuilder, HashMap};
 pub use kona_genesis::{ChainConfig, RollupConfig};
 
@@ -37,24 +36,9 @@ lazy_static::lazy_static! {
     pub static ref ROLLUP_CONFIGS: HashMap<u64, RollupConfig, DefaultHashBuilder> = _INIT.rollup_configs.clone();
 }
 
-/// Returns all available [Chain] identifiers.
-pub fn chain_idents() -> Vec<String> {
-    CHAINS.chains.iter().map(|c| c.identifier.clone()).collect()
-}
-
-/// Returns a [Chain] by its identifier.
-pub fn chain_by_ident(ident: &str) -> Option<&Chain> {
-    CHAINS.get_chain_by_ident(ident)
-}
-
-/// Returns a [Chain] by its identifier.
-pub fn chain_by_alloy_ident(chain: &alloy_chains::Chain) -> Option<&Chain> {
-    CHAINS.get_chain_by_id(chain.id())
-}
-
 /// Returns a [RollupConfig] by its identifier.
 pub fn rollup_config_by_ident(ident: &str) -> Option<&RollupConfig> {
-    let chain_id = chain_by_ident(ident)?.chain_id;
+    let chain_id = CHAINS.get_chain_by_ident(ident)?.chain_id;
     ROLLUP_CONFIGS.get(&chain_id)
 }
 
@@ -88,8 +72,8 @@ mod tests {
     fn test_chain_by_ident() {
         const ALLOY_BASE: AlloyChain = AlloyChain::base_mainnet();
 
-        let chain_by_ident = chain_by_ident("mainnet/base").unwrap();
-        let chain_by_alloy_ident = chain_by_alloy_ident(&ALLOY_BASE).unwrap();
+        let chain_by_ident = CHAINS.get_chain_by_ident("mainnet/base").unwrap();
+        let chain_by_alloy_ident = CHAINS.get_chain_by_alloy_ident(&ALLOY_BASE).unwrap();
         let chain_by_id = CHAINS.get_chain_by_id(8453).unwrap();
 
         assert_eq!(chain_by_ident, chain_by_id);

--- a/crates/protocol/registry/src/lib.rs
+++ b/crates/protocol/registry/src/lib.rs
@@ -10,6 +10,7 @@
 
 extern crate alloc;
 
+use alloc::{string::String, vec::Vec};
 pub use alloy_primitives::map::{DefaultHashBuilder, HashMap};
 pub use kona_genesis::{ChainConfig, RollupConfig};
 
@@ -27,13 +28,29 @@ lazy_static::lazy_static! {
     static ref _INIT: Registry = Registry::from_chain_list();
 
     /// Chain configurations exported from the registry
-    pub static ref CHAINS: alloc::vec::Vec<Chain> = _INIT.chains.clone();
+    pub static ref CHAINS: ChainList = _INIT.chain_list.clone();
 
     /// OP Chain configurations exported from the registry
     pub static ref OPCHAINS: HashMap<u64, ChainConfig, DefaultHashBuilder> = _INIT.op_chains.clone();
 
     /// Rollup configurations exported from the registry
     pub static ref ROLLUP_CONFIGS: HashMap<u64, RollupConfig, DefaultHashBuilder> = _INIT.rollup_configs.clone();
+}
+
+/// Returns all available [Chain] identifiers.
+pub fn chain_idents() -> Vec<String> {
+    CHAINS.chains.iter().map(|c| c.identifier.clone()).collect()
+}
+
+/// Returns a [Chain] by its identifier.
+pub fn chain_by_ident(ident: &str) -> Option<&Chain> {
+    CHAINS.get_chain_by_ident(ident)
+}
+
+/// Returns a [RollupConfig] by its identifier.
+pub fn rollup_config_by_ident(ident: &str) -> Option<&RollupConfig> {
+    let chain_id = chain_by_ident(ident)?.chain_id;
+    ROLLUP_CONFIGS.get(&chain_id)
 }
 
 #[cfg(test)]
@@ -54,5 +71,19 @@ mod tests {
             let derived = super::ROLLUP_CONFIGS.get(&chain_id).unwrap();
             assert_eq!(expected, *derived);
         }
+    }
+
+    #[test]
+    fn test_chain_by_ident() {
+        let chain_by_ident = chain_by_ident("mainnet/base").unwrap();
+        let chain_by_id = CHAINS.get_chain_by_id(8453).unwrap();
+        assert_eq!(chain_by_ident, chain_by_id);
+    }
+
+    #[test]
+    fn test_rollup_config_by_ident() {
+        let rollup_config_by_ident = rollup_config_by_ident("mainnet/base").unwrap();
+        let rollup_config_by_id = ROLLUP_CONFIGS.get(&8453).unwrap();
+        assert_eq!(rollup_config_by_ident, rollup_config_by_id);
     }
 }

--- a/crates/protocol/registry/src/lib.rs
+++ b/crates/protocol/registry/src/lib.rs
@@ -47,15 +47,26 @@ pub fn chain_by_ident(ident: &str) -> Option<&Chain> {
     CHAINS.get_chain_by_ident(ident)
 }
 
+/// Returns a [Chain] by its identifier.
+pub fn chain_by_alloy_ident(chain: &alloy_chains::Chain) -> Option<&Chain> {
+    CHAINS.get_chain_by_id(chain.id())
+}
+
 /// Returns a [RollupConfig] by its identifier.
 pub fn rollup_config_by_ident(ident: &str) -> Option<&RollupConfig> {
     let chain_id = chain_by_ident(ident)?.chain_id;
     ROLLUP_CONFIGS.get(&chain_id)
 }
 
+/// Returns a [RollupConfig] by its identifier.
+pub fn rollup_config_by_alloy_ident(chain: &alloy_chains::Chain) -> Option<&RollupConfig> {
+    ROLLUP_CONFIGS.get(&chain.id())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_chains::Chain as AlloyChain;
 
     #[test]
     fn test_hardcoded_rollup_configs() {
@@ -75,15 +86,25 @@ mod tests {
 
     #[test]
     fn test_chain_by_ident() {
+        const ALLOY_BASE: AlloyChain = AlloyChain::base_mainnet();
+
         let chain_by_ident = chain_by_ident("mainnet/base").unwrap();
+        let chain_by_alloy_ident = chain_by_alloy_ident(&ALLOY_BASE).unwrap();
         let chain_by_id = CHAINS.get_chain_by_id(8453).unwrap();
+
         assert_eq!(chain_by_ident, chain_by_id);
+        assert_eq!(chain_by_alloy_ident, chain_by_id);
     }
 
     #[test]
     fn test_rollup_config_by_ident() {
+        const ALLOY_BASE: AlloyChain = AlloyChain::base_mainnet();
+
         let rollup_config_by_ident = rollup_config_by_ident("mainnet/base").unwrap();
+        let rollup_config_by_alloy_ident = rollup_config_by_alloy_ident(&ALLOY_BASE).unwrap();
         let rollup_config_by_id = ROLLUP_CONFIGS.get(&8453).unwrap();
+
         assert_eq!(rollup_config_by_ident, rollup_config_by_id);
+        assert_eq!(rollup_config_by_alloy_ident, rollup_config_by_id);
     }
 }

--- a/crates/protocol/registry/src/superchain.rs
+++ b/crates/protocol/registry/src/superchain.rs
@@ -1,7 +1,6 @@
 //! Contains the full superchain data.
 
-use super::Chain;
-use alloc::vec::Vec;
+use super::ChainList;
 use alloy_primitives::map::{DefaultHashBuilder, HashMap};
 use kona_genesis::{ChainConfig, RollupConfig, Superchains};
 
@@ -10,7 +9,7 @@ use kona_genesis::{ChainConfig, RollupConfig, Superchains};
 #[serde(rename_all = "camelCase")]
 pub struct Registry {
     /// The list of chains.
-    pub chains: Vec<Chain>,
+    pub chain_list: ChainList,
     /// Map of chain IDs to their chain configuration.
     pub op_chains: HashMap<u64, ChainConfig, DefaultHashBuilder>,
     /// Map of chain IDs to their rollup configurations.
@@ -19,7 +18,7 @@ pub struct Registry {
 
 impl Registry {
     /// Read the chain list.
-    pub fn read_chain_list() -> Vec<Chain> {
+    pub fn read_chain_list() -> ChainList {
         let chain_list = include_str!("../etc/chainList.json");
         serde_json::from_str(chain_list).expect("Failed to read chain list")
     }
@@ -32,7 +31,7 @@ impl Registry {
 
     /// Initialize the superchain configurations from the chain list.
     pub fn from_chain_list() -> Self {
-        let chains = Self::read_chain_list();
+        let chain_list = Self::read_chain_list();
         let superchains = Self::read_superchain_configs();
         let mut op_chains = HashMap::default();
         let mut rollup_configs = HashMap::default();
@@ -54,7 +53,7 @@ impl Registry {
             }
         }
 
-        Self { chains, op_chains, rollup_configs }
+        Self { chain_list, op_chains, rollup_configs }
     }
 }
 
@@ -68,7 +67,7 @@ mod tests {
     #[test]
     fn test_read_chain_configs() {
         let superchains = Registry::from_chain_list();
-        assert!(superchains.chains.len() > 1);
+        assert!(superchains.chain_list.len() > 1);
         let base_config = ChainConfig {
             name: String::from("Base"),
             chain_id: 8453,


### PR DESCRIPTION
## Overview

Adds some simple convenience functions that fetch `Chain` and `RollupConfig`s by their human-readable identifiers. This is useful for the rollup node entrypoint, where we want to have a nice `--network` flag that doesn't only accept opaque numeric chain IDs for the argument.