### PR TITLE
chore(executor): Fix comments in EIP-2935 syscall module

### DIFF
--- a/crates/proof/executor/src/syscalls/eip2935.rs
+++ b/crates/proof/executor/src/syscalls/eip2935.rs
@@ -43,7 +43,7 @@ where
     F: TrieDBProvider,
     H: TrieHinter,
 {
-    // apply pre-block EIP-4788 contract call
+    // apply pre-block EIP-2935 contract call
     let mut evm_pre_block = Evm::builder()
         .with_db(db)
         .with_env_with_handler_cfg(EnvWithHandlerCfg::new_with_cfg_env(
@@ -63,7 +63,7 @@ where
     )
 }
 
-/// Apply the EIP-4788 pre-block beacon root contract call to a given EVM instance.
+/// Apply the EIP-2935 pre-block block hash accumulator contract call to a given EVM instance.
 fn apply_block_hash_contract_call<F, H>(
     config: &RollupConfig,
     timestamp: u64,

--- a/crates/proof/executor/src/syscalls/tx_env.rs
+++ b/crates/proof/executor/src/syscalls/tx_env.rs
@@ -44,7 +44,7 @@ pub(crate) fn fill_tx_env_for_contract_call(
             source_hash: None,
             mint: None,
             is_system_transaction: Some(false),
-            // The L1 fee is not charged for the EIP-4788 transaction, submit zero bytes for the
+            // The L1 fee is not charged for system transactions, submit zero bytes for the
             // enveloped tx size.
             enveloped_tx: Some(Bytes::default()),
         },


### PR DESCRIPTION
## Overview

Fixes some comments in the EIP-2935 syscall module.