### PR TITLE
chore(host): Update `README.md`

### DIFF
--- a/bin/host/README.md
+++ b/bin/host/README.md
@@ -4,6 +4,15 @@ kona-host is a CLI application that runs the [pre-image server][p-server] and [c
 
 ## Modes
 
+**Host Modes**
+
+| Mode     | Description                                                                   |
+|----------|-------------------------------------------------------------------------------|
+| `single` | Runs the preimage server + client program for a single-chain (pre-interop.)   |
+| `super`  | Runs the preimage server + client program for a superchain cluster (interop.) |
+
+**Preimage Server Modes**
+
 | Mode     | Description                                                                                                                                                                             |
 | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `server` | Starts with the preimage server only, expecting the client program to have been invoked by the host process. This mode is intended for use by the FPVM when running the client program. |
@@ -18,42 +27,17 @@ server and waits for the client program in the parent process to request pre-ima
 mode, the host runs the client program in a separate thread with the pre-image server in the
 primary thread.
 
+Usage: kona-host [OPTIONS] <COMMAND>
 
-Usage: kona-host [OPTIONS] --l1-head <L1_HEAD> --agreed-l2-head-hash <AGREED_L2_HEAD_HASH> --agreed-l2-output-root <AGREED_L2_OUTPUT_ROOT> --claimed-l2-output-root <CLAIMED_L2_OUTPUT_ROOT> --claimed-l2-block-number <CLAIMED_L2_BLOCK_NUMBER>
+Commands:
+  single  Run the host in single-chain mode
+  super   Run the host in super-chain (interop) mode
+  help    Print this message or the help of the given subcommand(s)
 
 Options:
-  -v, --v...
-          Verbosity level (0-2)
-      --l1-head <L1_HEAD>
-          Hash of the L1 head block. Derivation stops after this block is processed [env: L1_HEAD=]
-      --agreed-l2-head-hash <AGREED_L2_HEAD_HASH>
-          Hash of the agreed upon safe L2 block committed to by `--agreed-l2-output-root` [env: AGREED_L2_HEAD_HASH=] [aliases: l2-head]
-      --agreed-l2-output-root <AGREED_L2_OUTPUT_ROOT>
-          Agreed safe L2 Output Root to start derivation from [env: AGREED_L2_OUTPUT_ROOT=] [aliases: l2-output-root]
-      --claimed-l2-output-root <CLAIMED_L2_OUTPUT_ROOT>
-          Claimed L2 output root at block # `--claimed-l2-block-number` to validate [env: CLAIMED_L2_OUTPUT_ROOT=] [aliases: l2-claim]
-      --claimed-l2-block-number <CLAIMED_L2_BLOCK_NUMBER>
-          Number of the L2 block that the claimed output root commits to [env: CLAIMED_L2_BLOCK_NUMBER=] [aliases: l2-block-number]
-      --l2-node-address <L2_NODE_ADDRESS>
-          Address of L2 JSON-RPC endpoint to use (eth and debug namespace required) [env: L2_NODE_ADDRESS=] [aliases: l2]
-      --l1-node-address <L1_NODE_ADDRESS>
-          Address of L1 JSON-RPC endpoint to use (eth and debug namespace required) [env: L1_NODE_ADDRESS=] [aliases: l1]
-      --l1-beacon-address <L1_BEACON_ADDRESS>
-          Address of the L1 Beacon API endpoint to use [env: L1_BEACON_ADDRESS=] [aliases: beacon]
-      --data-dir <DATA_DIR>
-          The Data Directory for preimage data storage. Optional if running in online mode, required if running in offline mode [env: DATA_DIR=] [aliases: db]
-      --native
-          Run the specified client program natively
-      --server
-          Run in pre-image server mode without executing any client program. If not provided, the host will run the client program in the host process
-      --l2-chain-id <L2_CHAIN_ID>
-          The L2 chain ID of a supported chain. If provided, the host will look for the corresponding rollup config in the superchain registry [env: L2_CHAIN_ID=]
-      --rollup-config-path <ROLLUP_CONFIG_PATH>
-          Path to rollup config. If provided, the host will use this config instead of attempting to look up the config in the superchain registry [env: ROLLUP_CONFIG_PATH=]
-  -h, --help
-          Print help
-  -V, --version
-          Print version
+  -v, --v...     Verbosity level (0-2)
+  -h, --help     Print help
+  -V, --version  Print version
 ```
 
 [p-server]: https://specs.optimism.io/fault-proof/index.html#pre-image-oracle

--- a/crates/proof/executor/README.md
+++ b/crates/proof/executor/README.md
@@ -1,3 +1,8 @@
 # `kona-executor`
 
+<a href="https://github.com/op-rs/kona/actions/workflows/rust_ci.yaml"><img src="https://github.com/op-rs/kona/actions/workflows/rust_ci.yaml/badge.svg?label=ci" alt="CI"></a>
+<a href="https://crates.io/crates/kona-executor"><img src="https://img.shields.io/crates/v/kona-executor.svg?label=kona-executor&labelColor=2a2f35" alt="Kona Stateless Executor"></a>
+<a href="https://github.com/op-rs/kona/blob/main/LICENSE.md"><img src="https://img.shields.io/badge/License-MIT-d1d1f6.svg?label=license&labelColor=2a2f35" alt="License"></a>
+<a href="https://img.shields.io/codecov/c/github/op-rs/kona"><img src="https://img.shields.io/codecov/c/github/op-rs/kona" alt="Codecov"></a>
+
 A `no_std` implementation of a stateless block executor for the OP stack, backed by [`kona-mpt`](../mpt)'s `TrieDB`.

--- a/crates/proof/preimage/README.md
+++ b/crates/proof/preimage/README.md
@@ -1,5 +1,10 @@
 # `kona-preimage`
 
+<a href="https://github.com/op-rs/kona/actions/workflows/rust_ci.yaml"><img src="https://github.com/op-rs/kona/actions/workflows/rust_ci.yaml/badge.svg?label=ci" alt="CI"></a>
+<a href="https://crates.io/crates/kona-preimage"><img src="https://img.shields.io/crates/v/kona-preimage.svg?label=kona-preimage&labelColor=2a2f35" alt="Kona Preimage ABI client"></a>
+<a href="https://github.com/op-rs/kona/blob/main/LICENSE.md"><img src="https://img.shields.io/badge/License-MIT-d1d1f6.svg?label=license&labelColor=2a2f35" alt="License"></a>
+<a href="https://img.shields.io/codecov/c/github/op-rs/kona"><img src="https://img.shields.io/codecov/c/github/op-rs/kona" alt="Codecov"></a>
+
 This crate offers a high-level API over the [`Preimage Oracle`][preimage-abi-spec]. It is `no_std` compatible to be used in
 `client` programs, and the `host` handles are `async` colored to allow for the `host` programs to reach out to external
 data sources to populate the `Preimage Oracle`.


### PR DESCRIPTION
## Overview

Updates the `README.md` file of `kona-host` - the "Usage" section was out of date, and it didn't describe the interop mode.