### PR TITLE
feat(engine): Insert Task Updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3845,6 +3845,7 @@ dependencies = [
  "http-body-util",
  "kona-genesis",
  "kona-protocol",
+ "kona-rpc",
  "op-alloy-network",
  "op-alloy-provider",
  "op-alloy-rpc-types-engine",

--- a/crates/node/engine/Cargo.toml
+++ b/crates/node/engine/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 # workspace
+kona-rpc.workspace = true
 kona-genesis.workspace = true
 kona-protocol.workspace = true
 

--- a/crates/node/engine/src/lib.rs
+++ b/crates/node/engine/src/lib.rs
@@ -16,7 +16,7 @@ pub use actor::{EngineActor, EngineActorError, EngineActorMessage, EngineEvent};
 mod tasks;
 pub use tasks::{
     EngineTask, ForkchoiceTask, ForkchoiceTaskError, ForkchoiceTaskExt, ForkchoiceTaskInput,
-    ForkchoiceTaskOut, InsertTask, InsertTaskError, InsertTaskInput, InsertTaskOut,
+    ForkchoiceTaskOut, InsertTask, InsertTaskError, InsertTaskExt, InsertTaskInput, InsertTaskOut,
 };
 
 mod client;

--- a/crates/node/engine/src/tasks/forkchoice/error.rs
+++ b/crates/node/engine/src/tasks/forkchoice/error.rs
@@ -15,9 +15,6 @@ pub enum ForkchoiceTaskError {
     /// The sync status response is invalid.
     #[error("Invalid sync status response")]
     InvalidSyncStatusResponse,
-    /// Failed to send a message to the engine actor.
-    #[error("Failed to send message to engine actor")]
-    FailedToSend,
     /// A receive error occurred.
     #[error("Receive error")]
     ReceiveError,

--- a/crates/node/engine/src/tasks/insert/error.rs
+++ b/crates/node/engine/src/tasks/insert/error.rs
@@ -2,4 +2,14 @@
 
 /// An error that occurs when running the [crate::InsertTask].
 #[derive(Debug, thiserror::Error)]
-pub enum InsertTaskError {}
+pub enum InsertTaskError {
+    /// An invalid sync status response.
+    #[error("invalid sync status response")]
+    InvalidSyncStatusResponse,
+    /// Failed to receive a message from the external actor.
+    #[error("failed to receive message from external actor")]
+    ReceiveFailed,
+    /// Received an invalid message response from the external actor.
+    #[error("received invalid message response from external actor")]
+    InvalidMessageResponse,
+}

--- a/crates/node/engine/src/tasks/insert/messages.rs
+++ b/crates/node/engine/src/tasks/insert/messages.rs
@@ -1,12 +1,25 @@
 //! Contains the message types for the insert task.
 
+use crate::SyncStatus;
+use alloy_eips::eip1898::BlockNumberOrTag;
+use kona_protocol::L2BlockInfo;
+
 /// An inbound message from an external actor to the [crate::InsertTask].
 #[derive(Debug, Clone)]
-pub enum InsertTaskInput {}
+pub enum InsertTaskInput {
+    /// A response from the sync status request.
+    SyncStatusResponse(SyncStatus),
+    /// A response from feching L2 block info.
+    L2BlockInfoResponse(L2BlockInfo),
+}
 
 /// An outbound message from the [crate::InsertTask] to an external actor.
 #[derive(Debug, Clone)]
 pub enum InsertTaskOut {
     /// Request the sync status.
     SyncStatus,
+    /// Request an L2 block info by block number or tag.
+    L2BlockInfo(BlockNumberOrTag),
+    /// Update the sync status.
+    UpdateSyncStatus(SyncStatus),
 }

--- a/crates/node/engine/src/tasks/insert/mod.rs
+++ b/crates/node/engine/src/tasks/insert/mod.rs
@@ -1,7 +1,7 @@
 //! Task to insert an unsafe payload into the execution engine.
 
 mod task;
-pub use task::InsertTask;
+pub use task::{InsertTask, InsertTaskExt};
 
 mod error;
 pub use error::InsertTaskError;

--- a/crates/node/engine/src/tasks/insert/task.rs
+++ b/crates/node/engine/src/tasks/insert/task.rs
@@ -1,6 +1,35 @@
 //! A task to insert an unsafe payload into the execution engine.
 
-use crate::{EngineTask, InsertTaskError, InsertTaskInput, InsertTaskOut};
+use alloy_eips::BlockNumberOrTag;
+use kona_protocol::L2BlockInfo;
+use kona_rpc::OpAttributesWithParent;
+
+use crate::{EngineTask, InsertTaskError, InsertTaskInput, InsertTaskOut, SyncStatus};
+
+/// An external handle to communicate with a [InsertTask] spawned
+/// in a new thread.
+#[derive(Debug)]
+pub struct InsertTaskExt {
+    /// A receiver channel to receive [InsertTaskOut] events *from* the [InsertTask].
+    pub receiver: tokio::sync::broadcast::Receiver<InsertTaskOut>,
+    /// A sender channel to send [InsertTaskInput] event *to* the [InsertTask].
+    pub sender: tokio::sync::broadcast::Sender<InsertTaskInput>,
+    /// A join handle to the spawned thread containing the [InsertTask].
+    pub handle: tokio::task::JoinHandle<Result<(), InsertTaskError>>,
+}
+
+impl InsertTaskExt {
+    /// Spawns the [InsertTask] in a new thread, returning an
+    /// external-facing wrapper that can be used to communicate with
+    /// the spawned task.
+    pub fn spawn(input: (OpAttributesWithParent, L2BlockInfo)) -> Self {
+        let (sender, task_receiver) = tokio::sync::broadcast::channel(1);
+        let (task_sender, receiver) = tokio::sync::broadcast::channel(1);
+        let mut task = InsertTask::new(task_receiver, task_sender);
+        let handle = tokio::spawn(async move { task.execute(input).await });
+        Self { receiver, sender, handle }
+    }
+}
 
 /// A strongly typed receiver channel.
 type Receiver = tokio::sync::broadcast::Receiver<InsertTaskInput>;
@@ -22,13 +51,57 @@ impl InsertTask {
     pub const fn new(receiver: Receiver, sender: Sender) -> Self {
         Self { receiver, sender }
     }
+
+    /// Fetches the sync status through the external API.
+    pub async fn fetch_sync_status(&mut self) -> Result<SyncStatus, InsertTaskError> {
+        crate::send_until_success!("insert", self.sender, InsertTaskOut::SyncStatus);
+        let response = self.receiver.recv().await.map_err(|_| InsertTaskError::ReceiveFailed)?;
+        if let InsertTaskInput::SyncStatusResponse(response) = response {
+            Ok(response)
+        } else {
+            Err(InsertTaskError::InvalidSyncStatusResponse)
+        }
+    }
+
+    /// Requests an [L2BlockInfo] for the [BlockNumberOrTag::Finalized].
+    pub async fn fetch_finalized_info(&mut self) -> Result<L2BlockInfo, InsertTaskError> {
+        let msg = InsertTaskOut::L2BlockInfo(BlockNumberOrTag::Finalized);
+        crate::send_until_success!("insert", self.sender, msg);
+        let response = self.receiver.recv().await.map_err(|_| InsertTaskError::ReceiveFailed)?;
+        if let InsertTaskInput::L2BlockInfoResponse(bi) = response {
+            Ok(bi)
+        } else {
+            Err(InsertTaskError::InvalidMessageResponse)
+        }
+    }
 }
 
 #[async_trait::async_trait]
 impl EngineTask for InsertTask {
     type Error = InsertTaskError;
+    type Input = (OpAttributesWithParent, L2BlockInfo);
 
-    async fn execute(&mut self) -> Result<(), Self::Error> {
-        todo!()
+    async fn execute(&mut self, _input: Self::Input) -> Result<(), Self::Error> {
+        // Request the sync status.
+        let sync = self.fetch_sync_status().await?;
+        if sync == SyncStatus::ExecutionLayerWillStart {
+            match self.fetch_finalized_info().await {
+                Ok(_) => {
+                    // If there is a finalized block, finish EL sync.
+                    let msg = InsertTaskOut::UpdateSyncStatus(SyncStatus::ExecutionLayerFinished);
+                    crate::send_until_success!("insert", self.sender, msg);
+                }
+                Err(_) => {
+                    todo!()
+                }
+            }
+        }
+
+        // TODO: Insert Payload in Engine API
+        // TODO: Call FCU
+        // TODO: Update sync status
+        // TODO: Fire off FCU updated event
+
+        Ok(())
     }
 }

--- a/crates/node/engine/src/tasks/mod.rs
+++ b/crates/node/engine/src/tasks/mod.rs
@@ -1,7 +1,7 @@
 //! Tasks to update the engine state.
 
 mod insert;
-pub use insert::{InsertTask, InsertTaskError, InsertTaskInput, InsertTaskOut};
+pub use insert::{InsertTask, InsertTaskError, InsertTaskExt, InsertTaskInput, InsertTaskOut};
 
 mod traits;
 pub use traits::EngineTask;

--- a/crates/node/engine/src/tasks/traits.rs
+++ b/crates/node/engine/src/tasks/traits.rs
@@ -5,9 +5,11 @@ use async_trait::async_trait;
 /// An Engine Task.
 #[async_trait]
 pub trait EngineTask {
-    /// An error type.
+    /// The error returned by the task if execution fails.
     type Error;
+    /// An input type to the execution method.
+    type Input;
 
     /// Executes the task.
-    async fn execute(&mut self) -> Result<(), Self::Error>;
+    async fn execute(&mut self, input: Self::Input) -> Result<(), Self::Error>;
 }


### PR DESCRIPTION
### Description

Updates the insert unsafe payload task.

I'm starting to think messaging out engine api calls from the individual engine tasks doesn't make sense.

Decoupling the state from the engine controller seems like the right abstraction, but further decoupling of the engine tasks and the engine api doesn't seem warranted.

Will follow up to give engine tasks a reference to the `EngineClient` so they can perform engine api requests internal to the task. This way, the only messages that should
be needed from engine tasks are updates to and requests for the engine state.