### PR TITLE
feat(engine): Insert New Payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3845,7 +3845,6 @@ dependencies = [
  "http-body-util",
  "kona-genesis",
  "kona-protocol",
- "kona-rpc",
  "op-alloy-network",
  "op-alloy-provider",
  "op-alloy-rpc-types-engine",

--- a/crates/node/engine/Cargo.toml
+++ b/crates/node/engine/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 
 [dependencies]
 # workspace
-kona-rpc.workspace = true
 kona-genesis.workspace = true
 kona-protocol.workspace = true
 

--- a/crates/node/engine/src/actor.rs
+++ b/crates/node/engine/src/actor.rs
@@ -37,7 +37,7 @@ pub enum EngineActorError {}
 #[derive(Debug)]
 pub struct EngineActor {
     /// The internal engine client.
-    pub client: EngineClient,
+    pub client: Arc<EngineClient>,
     /// The sync status.
     pub sync_status: SyncStatus,
     /// A reference to the rollup config.
@@ -54,7 +54,7 @@ pub struct EngineActor {
 impl EngineActor {
     /// Creates a new engine actor.
     pub const fn new(
-        client: EngineClient,
+        client: Arc<EngineClient>,
         sync_status: SyncStatus,
         rollup_config: Arc<RollupConfig>,
         receiver: Receiver<EngineEvent>,
@@ -88,7 +88,7 @@ impl EngineActor {
                     warn!(target: "engine", "Forkchoice task already running.");
                     return Ok(());
                 }
-                self.forkchoice_task = Some(ForkchoiceTaskExt::spawn());
+                self.forkchoice_task = Some(ForkchoiceTaskExt::spawn(self.client.clone()));
             }
         }
         Ok(())

--- a/crates/node/engine/src/tasks/forkchoice/task.rs
+++ b/crates/node/engine/src/tasks/forkchoice/task.rs
@@ -1,9 +1,15 @@
 //! A task for the `engine_forkchoiceUpdated` query.
 
+use op_alloy_provider::ext::engine::OpEngineApi;
+use std::sync::Arc;
+
 use crate::{
-    EngineForkchoiceVersion, EngineState, EngineTask, ForkchoiceTaskError, ForkchoiceTaskInput,
+    EngineClient, EngineState, EngineTask, ForkchoiceTaskError, ForkchoiceTaskInput,
     ForkchoiceTaskOut, SyncStatus,
 };
+
+/// The input type for the [ForkchoiceTask].
+type Input = Arc<EngineClient>;
 
 /// An external handle to communicate with a [ForkchoiceTask] spawned
 /// in a new thread.
@@ -21,11 +27,11 @@ impl ForkchoiceTaskExt {
     /// Spawns the [ForkchoiceTask] in a new thread, returning an
     /// external-facing wrapper that can be used to communicate with
     /// the spawned task.
-    pub fn spawn() -> Self {
+    pub fn spawn(input: Input) -> Self {
         let (sender, task_receiver) = tokio::sync::broadcast::channel(1);
         let (task_sender, receiver) = tokio::sync::broadcast::channel(1);
         let mut task = ForkchoiceTask::new(task_receiver, task_sender);
-        let handle = tokio::spawn(async move { task.execute(()).await });
+        let handle = tokio::spawn(async move { task.execute(input).await });
         Self { receiver, sender, handle }
     }
 }
@@ -77,9 +83,9 @@ impl ForkchoiceTask {
 #[async_trait::async_trait]
 impl EngineTask for ForkchoiceTask {
     type Error = ForkchoiceTaskError;
-    type Input = ();
+    type Input = Input;
 
-    async fn execute(&mut self, _: Self::Input) -> Result<(), Self::Error> {
+    async fn execute(&mut self, input: Self::Input) -> Result<(), Self::Error> {
         // Check if a forkchoice update is not needed, return early.
         let state = self.fetch_state().await?;
         if !state.forkchoice_update_needed {
@@ -101,21 +107,12 @@ impl EngineTask for ForkchoiceTask {
             ));
         }
 
+        // Send the forkchoice update through the input.
         let forkchoice = state.create_forkchoice_state();
-        let msg = ForkchoiceTaskOut::ExecuteForkchoiceUpdate(
-            EngineForkchoiceVersion::V3,
-            forkchoice,
-            None,
-        );
-        crate::send_until_success!("fcu", self.sender, msg);
-        let response = self.receiver.recv().await.map_err(|_| ForkchoiceTaskError::ReceiveError)?;
-        let update = match response {
-            ForkchoiceTaskInput::ForkchoiceUpdated(update) => update,
-            ForkchoiceTaskInput::ForkchoiceUpdateFailed => {
-                return Err(ForkchoiceTaskError::ForkchoiceUpdateFailed)
-            }
-            _ => return Err(ForkchoiceTaskError::InvalidForkchoiceResponse),
-        };
+        let update = input
+            .fork_choice_updated_v3(forkchoice, None)
+            .await
+            .map_err(|_| ForkchoiceTaskError::ForkchoiceUpdateFailed)?;
 
         if update.payload_status.is_valid() {
             let msg = ForkchoiceTaskOut::ForkchoiceUpdated(update);

--- a/crates/node/engine/src/tasks/insert/error.rs
+++ b/crates/node/engine/src/tasks/insert/error.rs
@@ -12,4 +12,7 @@ pub enum InsertTaskError {
     /// Received an invalid message response from the external actor.
     #[error("received invalid message response from external actor")]
     InvalidMessageResponse,
+    /// Failed to insert new payload.
+    #[error("failed to insert new payload")]
+    FailedToInsertNewPayload,
 }

--- a/crates/node/engine/src/tasks/insert/error.rs
+++ b/crates/node/engine/src/tasks/insert/error.rs
@@ -15,4 +15,7 @@ pub enum InsertTaskError {
     /// Failed to insert new payload.
     #[error("failed to insert new payload")]
     FailedToInsertNewPayload,
+    /// Temporary derivation error.
+    #[error("temporary derivation error")]
+    TemporaryDerivationError,
 }

--- a/crates/node/engine/src/tasks/insert/messages.rs
+++ b/crates/node/engine/src/tasks/insert/messages.rs
@@ -40,4 +40,16 @@ pub enum InsertTaskOut {
     UpdatePayloadStatus(PayloadStatus),
     /// Failed to process new unsafe payload.
     FailedToProcessNewPayload,
+
+    /// Update engine state with non finalized el sync new payload.
+    NewPayloadNotFinalizedUpdate(L2BlockInfo),
+
+    /// Cross safe update.
+    CrossSafeUpdate(L2BlockInfo),
+
+    /// Update the engine state with the forkchoice updated state.
+    UpdateForkchoiceState(PayloadStatus, L2BlockInfo),
+
+    /// Forkchoice updated event.
+    ForkchoiceUpdated,
 }

--- a/crates/node/engine/src/tasks/insert/messages.rs
+++ b/crates/node/engine/src/tasks/insert/messages.rs
@@ -1,7 +1,8 @@
 //! Contains the message types for the insert task.
 
-use crate::SyncStatus;
+use crate::{EngineState, SyncStatus};
 use alloy_eips::eip1898::BlockNumberOrTag;
+use alloy_rpc_types_engine::PayloadStatus;
 use kona_protocol::L2BlockInfo;
 
 /// An inbound message from an external actor to the [crate::InsertTask].
@@ -11,6 +12,10 @@ pub enum InsertTaskInput {
     SyncStatusResponse(SyncStatus),
     /// A response from feching L2 block info.
     L2BlockInfoResponse(L2BlockInfo),
+    /// An Engine State new payload response.
+    NewPayloadResponse(bool),
+    /// A response from the state snapshot request.
+    StateResponse(Box<EngineState>),
 }
 
 /// An outbound message from the [crate::InsertTask] to an external actor.
@@ -22,4 +27,17 @@ pub enum InsertTaskOut {
     L2BlockInfo(BlockNumberOrTag),
     /// Update the sync status.
     UpdateSyncStatus(SyncStatus),
+    /// Request a state snapshot.
+    StateSnapshot,
+    /// The new payload was invalid.
+    InvalidNewPayload,
+
+    // TODO: This needs to be handled by the rollup node as a temporary derivation error.
+    // TODO: see: https://github.com/ethereum-optimism/optimism/blob/develop/op-node/rollup/engine/engine_controller.go#L389
+    /// An error from the `engine_newPayload` call.
+    FailedToInsertNewPayload,
+    /// Update the engine state with a new [PayloadStatus].
+    UpdatePayloadStatus(PayloadStatus),
+    /// Failed to process new unsafe payload.
+    FailedToProcessNewPayload,
 }

--- a/crates/node/engine/src/tasks/insert/messages.rs
+++ b/crates/node/engine/src/tasks/insert/messages.rs
@@ -11,7 +11,7 @@ pub enum InsertTaskInput {
     /// A response from the sync status request.
     SyncStatusResponse(SyncStatus),
     /// A response from feching L2 block info.
-    L2BlockInfoResponse(L2BlockInfo),
+    L2BlockInfoResponse(Option<L2BlockInfo>),
     /// An Engine State new payload response.
     NewPayloadResponse(bool),
     /// A response from the state snapshot request.

--- a/crates/node/engine/src/tasks/insert/task.rs
+++ b/crates/node/engine/src/tasks/insert/task.rs
@@ -1,10 +1,21 @@
 //! A task to insert an unsafe payload into the execution engine.
 
 use alloy_eips::BlockNumberOrTag;
+use alloy_rpc_types_engine::{
+    ExecutionPayloadInputV2, ExecutionPayloadV1, ForkchoiceState, PayloadStatus, PayloadStatusEnum,
+};
 use kona_protocol::L2BlockInfo;
 use kona_rpc::OpAttributesWithParent;
+use op_alloy_provider::ext::engine::OpEngineApi;
+use std::sync::Arc;
 
-use crate::{EngineTask, InsertTaskError, InsertTaskInput, InsertTaskOut, SyncStatus};
+use crate::{
+    EngineClient, EngineNewPayloadVersion, EngineState, EngineTask, InsertTaskError,
+    InsertTaskInput, InsertTaskOut, SyncStatus,
+};
+
+/// The input type for the [InsertTask].
+type Input = (Arc<EngineClient>, EngineNewPayloadVersion, OpAttributesWithParent, L2BlockInfo);
 
 /// An external handle to communicate with a [InsertTask] spawned
 /// in a new thread.
@@ -22,7 +33,7 @@ impl InsertTaskExt {
     /// Spawns the [InsertTask] in a new thread, returning an
     /// external-facing wrapper that can be used to communicate with
     /// the spawned task.
-    pub fn spawn(input: (OpAttributesWithParent, L2BlockInfo)) -> Self {
+    pub fn spawn(input: Input) -> Self {
         let (sender, task_receiver) = tokio::sync::broadcast::channel(1);
         let (task_sender, receiver) = tokio::sync::broadcast::channel(1);
         let mut task = InsertTask::new(task_receiver, task_sender);
@@ -63,6 +74,17 @@ impl InsertTask {
         }
     }
 
+    /// Fetches a state snapshot through the external API.
+    pub async fn fetch_state(&mut self) -> Result<EngineState, InsertTaskError> {
+        crate::send_until_success!("insert", self.sender, InsertTaskOut::StateSnapshot);
+        let response = self.receiver.recv().await.map_err(|_| InsertTaskError::ReceiveFailed)?;
+        if let InsertTaskInput::StateResponse(response) = response {
+            Ok(*response)
+        } else {
+            Err(InsertTaskError::InvalidMessageResponse)
+        }
+    }
+
     /// Requests an [L2BlockInfo] for the [BlockNumberOrTag::Finalized].
     pub async fn fetch_finalized_info(&mut self) -> Result<L2BlockInfo, InsertTaskError> {
         let msg = InsertTaskOut::L2BlockInfo(BlockNumberOrTag::Finalized);
@@ -79,9 +101,9 @@ impl InsertTask {
 #[async_trait::async_trait]
 impl EngineTask for InsertTask {
     type Error = InsertTaskError;
-    type Input = (OpAttributesWithParent, L2BlockInfo);
+    type Input = Input;
 
-    async fn execute(&mut self, _input: Self::Input) -> Result<(), Self::Error> {
+    async fn execute(&mut self, input: Self::Input) -> Result<(), Self::Error> {
         // Request the sync status.
         let sync = self.fetch_sync_status().await?;
         if sync == SyncStatus::ExecutionLayerWillStart {
@@ -97,7 +119,87 @@ impl EngineTask for InsertTask {
             }
         }
 
-        // TODO: Insert Payload in Engine API
+        let (client, version, attributes, block_info) = input;
+        let response = match version {
+            EngineNewPayloadVersion::V2 => {
+                let input = ExecutionPayloadInputV2 {
+                    execution_payload: ExecutionPayloadV1 {
+                        parent_hash: attributes.parent.block_info.hash,
+                        fee_recipient: attributes
+                            .attributes
+                            .payload_attributes
+                            .suggested_fee_recipient,
+                        state_root: Default::default(),
+                        receipts_root: Default::default(),
+                        logs_bloom: Default::default(),
+                        prev_randao: attributes.attributes.payload_attributes.prev_randao,
+                        block_number: block_info.block_info.number,
+                        gas_limit: attributes.attributes.gas_limit.unwrap_or(0),
+                        gas_used: Default::default(),
+                        timestamp: attributes.attributes.payload_attributes.timestamp,
+                        extra_data: Default::default(),
+                        base_fee_per_gas: Default::default(),
+                        block_hash: block_info.block_info.hash,
+                        transactions: attributes.attributes.transactions.unwrap_or_default(),
+                    },
+                    withdrawals: attributes.attributes.payload_attributes.withdrawals,
+                };
+                client.new_payload_v2(input).await
+            }
+            EngineNewPayloadVersion::V3 => {
+                // client.new_payload_v3(attributes, block_info).await,
+                Ok(PayloadStatus { status: PayloadStatusEnum::Valid, latest_valid_hash: None })
+            }
+            EngineNewPayloadVersion::V4 => {
+                // client.new_payload_v4(attributes, block_info).await,
+                Ok(PayloadStatus { status: PayloadStatusEnum::Valid, latest_valid_hash: None })
+            }
+        };
+        let status = match response {
+            Ok(s) => s,
+            Err(_) => {
+                return Err(InsertTaskError::FailedToInsertNewPayload);
+            }
+        };
+
+        if status.is_invalid() {
+            let msg = InsertTaskOut::InvalidNewPayload;
+            crate::send_until_success!("insert", self.sender, msg);
+        }
+
+        // Tell the engine state to update if needed with the new payload.
+        let msg = InsertTaskOut::UpdatePayloadStatus(status);
+        crate::send_until_success!("insert", self.sender, msg);
+
+        // Receive response from state.
+        let response = self.receiver.recv().await.map_err(|_| InsertTaskError::ReceiveFailed)?;
+        match response {
+            InsertTaskInput::NewPayloadResponse(true) => {
+                info!(target: "insert", "Engine State updated with new payload.");
+            }
+            InsertTaskInput::NewPayloadResponse(false) => {
+                warn!(target: "insert", "Failed to update Engine State with new payload.");
+                let msg = InsertTaskOut::FailedToProcessNewPayload;
+                crate::send_until_success!("insert", self.sender, msg);
+            }
+            _ => {
+                return Err(InsertTaskError::InvalidMessageResponse);
+            }
+        }
+
+        // Fetch the state snapshot.
+        let state = self.fetch_state().await?;
+
+        // Mark the new payload as valid
+        let _fcu = ForkchoiceState {
+            head_block_hash: block_info.block_info.hash,
+            safe_block_hash: state.safe_head.block_info.hash,
+            finalized_block_hash: state.finalized_head.block_info.hash,
+        };
+
+        // TODO: In the engine state, process the state update.
+        // SEE: https://github.com/ethereum-optimism/optimism/blob/develop/op-node/rollup/engine/engine_controller.go#L407-L416
+
         // TODO: Call FCU
         // TODO: Update sync status
         // TODO: Fire off FCU updated event

--- a/crates/node/net/Cargo.toml
+++ b/crates/node/net/Cargo.toml
@@ -16,7 +16,6 @@ rust-version.workspace = true
 # Alloy
 alloy-rlp.workspace = true
 alloy-primitives = { workspace = true, features = ["k256", "getrandom"] }
-alloy-rpc-types-engine = { workspace = true, features = ["std"] }
 
 # Op Alloy
 op-alloy-rpc-types-engine = { workspace = true, features = ["std"] }
@@ -43,6 +42,7 @@ arbitrary = { workspace = true, features = ["derive"], optional = true }
 arbtest.workspace = true
 arbitrary = { workspace = true, features = ["derive"] }
 alloy-primitives = { workspace = true, features = ["arbitrary"] }
+alloy-rpc-types-engine = { workspace = true, features = ["std"] }
 
 [features]
 default = []

--- a/crates/node/net/src/driver.rs
+++ b/crates/node/net/src/driver.rs
@@ -3,8 +3,8 @@
 use std::sync::mpsc::Receiver;
 
 use alloy_primitives::Address;
-use alloy_rpc_types_engine::ExecutionPayload;
 use libp2p::TransportError;
+use op_alloy_rpc_types_engine::OpNetworkPayloadEnvelope;
 use tokio::{select, sync::watch};
 
 use crate::{
@@ -19,7 +19,7 @@ use crate::{
 /// - Peer discovery with `discv5`.
 pub struct NetworkDriver {
     /// Channel to receive unsafe blocks.
-    pub(crate) unsafe_block_recv: Option<Receiver<ExecutionPayload>>,
+    pub(crate) unsafe_block_recv: Option<Receiver<OpNetworkPayloadEnvelope>>,
     /// Channel to send unsafe signer updates.
     pub(crate) unsafe_block_signer_sender: Option<watch::Sender<Address>>,
     /// The swarm instance.
@@ -35,7 +35,7 @@ impl NetworkDriver {
     }
 
     /// Take the unsafe block receiver.
-    pub fn take_unsafe_block_recv(&mut self) -> Option<Receiver<ExecutionPayload>> {
+    pub fn take_unsafe_block_recv(&mut self) -> Option<Receiver<OpNetworkPayloadEnvelope>> {
         self.unsafe_block_recv.take()
     }
 


### PR DESCRIPTION
### Description

- Updates forkchoice and insert tasks to perform engine api calls through client inside the task instead of messaging as described in #1194.
- Implements a bunch of the new payload insert logic - the type argument is taken as the output from derivation which doesn't line up with the inputs to the engine_newPayload methods though so that will need to be cleaned up.