### PR TITLE
feat(engine): Wire up Insert Task

### DIFF
--- a/crates/node/engine/src/actor.rs
+++ b/crates/node/engine/src/actor.rs
@@ -8,18 +8,25 @@
 //!
 //! [op-node]: https://github.com/ethereum-optimism/optimism/blob/develop/op-node/rollup/engine/engine_controller.go#L46
 
-use crate::{EngineClient, ForkchoiceTaskExt, ForkchoiceTaskInput, ForkchoiceTaskOut, SyncStatus};
 use kona_genesis::RollupConfig;
+use kona_protocol::L2BlockInfo;
 use op_alloy_provider::ext::engine::OpEngineApi;
+use op_alloy_rpc_types_engine::OpNetworkPayloadEnvelope;
 use std::sync::Arc;
 use tokio::sync::broadcast::{Receiver, Sender};
-use tracing::{trace, warn};
+
+use crate::{
+    EngineClient, EngineForkchoiceVersion, ForkchoiceTaskExt, ForkchoiceTaskInput,
+    ForkchoiceTaskOut, InsertTaskExt, InsertTaskOut, SyncConfig, SyncStatus,
+};
 
 /// A stub event from the consensus node to the engine actor.
 #[derive(Debug, Clone)]
 pub enum EngineEvent {
     /// Try to update the forkchoice.
     TryUpdateForkchoice,
+    /// A message to insert an unsafe payload.
+    InsertUnsafePayload(OpNetworkPayloadEnvelope, L2BlockInfo),
 }
 
 /// A message from the engine actor to the consensus node.
@@ -27,6 +34,8 @@ pub enum EngineEvent {
 pub enum EngineActorMessage {
     /// A message from the Forkchoice Task.
     ForkchoiceTask(ForkchoiceTaskOut),
+    /// A message from the Insert Unsafe Payload Task.
+    InsertTask(InsertTaskOut),
 }
 
 /// An error that occurs when running the engine actor.
@@ -40,6 +49,8 @@ pub struct EngineActor {
     pub client: Arc<EngineClient>,
     /// The sync status.
     pub sync_status: SyncStatus,
+    /// The sync configuration.
+    pub sync_config: Arc<SyncConfig>,
     /// A reference to the rollup config.
     pub rollup_config: Arc<RollupConfig>,
     /// A receiver channel to receive messages from the rollup node.
@@ -49,6 +60,8 @@ pub struct EngineActor {
 
     /// The external communication handle to the forkchoice task.
     pub forkchoice_task: Option<ForkchoiceTaskExt>,
+    /// The external communication handle to the insert task.
+    pub insert_task: Option<InsertTaskExt>,
 }
 
 impl EngineActor {
@@ -56,11 +69,21 @@ impl EngineActor {
     pub const fn new(
         client: Arc<EngineClient>,
         sync_status: SyncStatus,
+        sync_config: Arc<SyncConfig>,
         rollup_config: Arc<RollupConfig>,
         receiver: Receiver<EngineEvent>,
         sender: Sender<EngineActorMessage>,
     ) -> Self {
-        Self { client, sync_status, rollup_config, receiver, sender, forkchoice_task: None }
+        Self {
+            client,
+            sync_status,
+            sync_config,
+            rollup_config,
+            receiver,
+            sender,
+            forkchoice_task: None,
+            insert_task: None,
+        }
     }
 
     /// Runs the engine actor.
@@ -77,6 +100,13 @@ impl EngineActor {
                     self.process_forkchoice_message(msg).await;
                 }
             }
+            if let Some(ref mut ext) = self.insert_task {
+                let receiver = &mut ext.receiver;
+                if let Ok(msg) = receiver.try_recv() {
+                    trace!(target: "engine", "Received message from insert task: {:?}", msg);
+                    self.process_insert_message(msg).await;
+                }
+            }
         }
     }
 
@@ -90,8 +120,32 @@ impl EngineActor {
                 }
                 self.forkchoice_task = Some(ForkchoiceTaskExt::spawn(self.client.clone()));
             }
+            EngineEvent::InsertUnsafePayload(envelope, info) => {
+                if self.insert_task.is_some() {
+                    warn!(target: "engine", "Insert task already running.");
+                    return Ok(());
+                }
+                let version = EngineForkchoiceVersion::from_cfg(
+                    &self.rollup_config,
+                    info.block_info.timestamp,
+                );
+                let input = (
+                    self.client.clone(),
+                    self.sync_config.clone(),
+                    self.rollup_config.genesis.l2.hash,
+                    version,
+                    envelope,
+                    info,
+                );
+                self.insert_task = Some(InsertTaskExt::spawn(input));
+            }
         }
         Ok(())
+    }
+
+    /// Process an [InsertTaskOut] message received from the insert task.
+    pub async fn process_insert_message(&mut self, _msg: InsertTaskOut) {
+        unimplemented!()
     }
 
     /// Process a [ForkchoiceTaskOut] message received from the forkchoice task.

--- a/crates/node/engine/src/tasks/forkchoice/messages.rs
+++ b/crates/node/engine/src/tasks/forkchoice/messages.rs
@@ -1,9 +1,8 @@
 //! Contains the message types for the forkchoice task.
 
-use alloy_rpc_types_engine::{ForkchoiceState, ForkchoiceUpdated};
-use op_alloy_rpc_types_engine::OpPayloadAttributes;
+use alloy_rpc_types_engine::ForkchoiceUpdated;
 
-use crate::{EngineForkchoiceVersion, EngineState, SyncStatus};
+use crate::{EngineState, SyncStatus};
 
 /// An inbound message from an external actor to the [crate::ForkchoiceTask].
 #[derive(Debug, Clone)]
@@ -14,12 +13,6 @@ pub enum ForkchoiceTaskInput {
     StateResponse(Box<EngineState>),
     /// A response from the sync status request.
     SyncStatusResponse(SyncStatus),
-    /// Tells the [crate::ForkchoiceTask] that the engine api forkchoice update was valid.
-    ///
-    /// Provides the returned [ForkchoiceUpdated] response from the `engine_forkchoiceUpdated` call.
-    ForkchoiceUpdated(ForkchoiceUpdated),
-    /// Tells the [crate::ForkchoiceTask] that the forkchoice update call failed.
-    ForkchoiceUpdateFailed,
 }
 
 /// An outbound message from the [crate::ForkchoiceTask] to an external actor.
@@ -29,8 +22,6 @@ pub enum ForkchoiceTaskOut {
     StateSnapshot,
     /// Request the sync status.
     SyncStatus,
-    /// A message to update the forkchoice.
-    ExecuteForkchoiceUpdate(EngineForkchoiceVersion, ForkchoiceState, Option<OpPayloadAttributes>),
     /// Instruct the state to update the backup unsafe head.
     UpdateBackupUnsafeHead,
     /// Instruct the state that a forkchoice update is not needed.

--- a/crates/node/engine/src/tasks/insert/task.rs
+++ b/crates/node/engine/src/tasks/insert/task.rs
@@ -18,7 +18,7 @@ use crate::{
 /// The third argument is the genesis l2 hash expected to be provided by the rollup config.
 type Input = (
     Arc<EngineClient>,
-    SyncConfig,
+    Arc<SyncConfig>,
     B256,
     EngineForkchoiceVersion,
     OpNetworkPayloadEnvelope,

--- a/crates/node/engine/src/versions.rs
+++ b/crates/node/engine/src/versions.rs
@@ -5,7 +5,6 @@
 //! [vp]: https://github.com/ethereum-optimism/optimism/blob/develop/op-node/rollup/types.go#L546
 
 use kona_genesis::RollupConfig;
-use op_alloy_rpc_types_engine::OpPayloadAttributes;
 
 /// The method version for the `engine_forkchoiceUpdated` api.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -22,12 +21,11 @@ impl EngineForkchoiceVersion {
     /// Returns the appropriate [`EngineForkchoiceVersion`] for the chain at the given attributes.
     ///
     /// Uses the [`RollupConfig`] to check which hardfork is active at the given timestamp.
-    pub fn from_cfg(cfg: &RollupConfig, attributes: &OpPayloadAttributes) -> Self {
-        let ts = attributes.payload_attributes.timestamp;
-        if cfg.is_ecotone_active(ts) {
+    pub fn from_cfg(cfg: &RollupConfig, timestamp: u64) -> Self {
+        if cfg.is_ecotone_active(timestamp) {
             // Cancun
             Self::V3
-        } else if cfg.is_canyon_active(ts) {
+        } else if cfg.is_canyon_active(timestamp) {
             // Shanghai
             Self::V2
         } else {


### PR DESCRIPTION
### Description

Wires up the `InsertTask` into the engine actor.

Notice, since we previously removed the engine client decoupling, passing in the engine client reference directly to the task, we can now removing custom msg processing in the engine actor. Instead, we just pass along the message for the orchestrator to handle.