### PR TITLE
feat(providers-alloy): Refactor `AlloyL2ChainProvider`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4183,7 +4183,6 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-provider",
- "alloy-rlp",
  "alloy-rpc-types-beacon",
  "alloy-serde",
  "alloy-transport",

--- a/bin/node/src/node/mod.rs
+++ b/bin/node/src/node/mod.rs
@@ -120,7 +120,11 @@ impl RollupNode {
                 todo!(), // Need sync start
                 OnlineBlobProvider::init(self.l1_beacon).await,
                 AlloyChainProvider::new(self.l1_provider, PROVIDER_CACHE_SIZE),
-                AlloyL2ChainProvider::new(self.l2_provider.clone(), self.config.clone()),
+                AlloyL2ChainProvider::new(
+                    self.l2_provider.clone(),
+                    self.config.clone(),
+                    PROVIDER_CACHE_SIZE,
+                ),
             )
             .await;
 

--- a/crates/providers/providers-alloy/Cargo.toml
+++ b/crates/providers/providers-alloy/Cargo.toml
@@ -20,7 +20,6 @@ kona-derive.workspace = true
 kona-rpc.workspace = true
 
 # Alloy
-alloy-rlp.workspace = true
 alloy-serde.workspace = true
 alloy-eips = { workspace = true, features = ["kzg"] }
 alloy-transport.workspace = true

--- a/crates/providers/providers-alloy/src/chain_provider.rs
+++ b/crates/providers/providers-alloy/src/chain_provider.rs
@@ -35,6 +35,9 @@ pub struct AlloyChainProvider {
 
 impl AlloyChainProvider {
     /// Creates a new [AlloyChainProvider] with the given alloy provider.
+    ///
+    /// ## Panics
+    /// - Panics if `cache_size` is zero.
     pub fn new(inner: RootProvider, cache_size: usize) -> Self {
         Self {
             inner,

--- a/crates/providers/providers-alloy/src/l2_chain_provider.rs
+++ b/crates/providers/providers-alloy/src/l2_chain_provider.rs
@@ -1,8 +1,6 @@
 //! Providers that use alloy provider types on the backend.
 
-use alloy_primitives::{Bytes, U64};
 use alloy_provider::{Provider, RootProvider};
-use alloy_rlp::Decodable;
 use alloy_transport::{RpcError, TransportErrorKind};
 use async_trait::async_trait;
 use kona_derive::{
@@ -11,9 +9,10 @@ use kona_derive::{
 };
 use kona_genesis::{RollupConfig, SystemConfig};
 use kona_protocol::{BatchValidationProvider, L2BlockInfo, to_system_config};
+use lru::LruCache;
 use op_alloy_consensus::OpBlock;
-use op_alloy_network::Optimism;
-use std::sync::Arc;
+use op_alloy_network::{Optimism, primitives::BlockTransactionsKind};
+use std::{num::NonZeroUsize, sync::Arc};
 
 /// The [AlloyL2ChainProvider] is a concrete implementation of the [L2ChainProvider] trait,
 /// providing data over Ethereum JSON-RPC using an alloy provider as the backend.
@@ -27,12 +26,25 @@ pub struct AlloyL2ChainProvider {
     inner: RootProvider<Optimism>,
     /// The rollup configuration.
     rollup_config: Arc<RollupConfig>,
+    /// The `block_by_number` LRU cache.
+    block_by_number_cache: LruCache<u64, OpBlock>,
 }
 
 impl AlloyL2ChainProvider {
     /// Creates a new [AlloyL2ChainProvider] with the given alloy provider and [RollupConfig].
-    pub fn new(inner: RootProvider<Optimism>, rollup_config: Arc<RollupConfig>) -> Self {
-        Self { inner, rollup_config }
+    ///
+    /// ## Panics
+    /// - Panics if `cache_size` is zero.
+    pub fn new(
+        inner: RootProvider<Optimism>,
+        rollup_config: Arc<RollupConfig>,
+        cache_size: usize,
+    ) -> Self {
+        Self {
+            inner,
+            rollup_config,
+            block_by_number_cache: LruCache::new(NonZeroUsize::new(cache_size).unwrap()),
+        }
     }
 
     /// Returns the chain ID.
@@ -46,24 +58,28 @@ impl AlloyL2ChainProvider {
     }
 
     /// Creates a new [AlloyL2ChainProvider] from the provided [reqwest::Url].
-    pub fn new_http(url: reqwest::Url, rollup_config: Arc<RollupConfig>) -> Self {
+    pub fn new_http(
+        url: reqwest::Url,
+        rollup_config: Arc<RollupConfig>,
+        cache_size: usize,
+    ) -> Self {
         let inner = RootProvider::new_http(url);
-        Self::new(inner, rollup_config)
+        Self::new(inner, rollup_config, cache_size)
     }
 }
 
 /// An error for the [AlloyL2ChainProvider].
 #[derive(Debug, thiserror::Error)]
 pub enum AlloyL2ChainProviderError {
+    /// Transport error
+    #[error(transparent)]
+    Transport(#[from] RpcError<TransportErrorKind>),
     /// Failed to find a block.
     #[error("Failed to fetch block {0}")]
     BlockNotFound(u64),
     /// Failed to construct [L2BlockInfo] from the block and genesis.
     #[error("Failed to construct L2BlockInfo from block {0} and genesis")]
     L2BlockInfoConstruction(u64),
-    /// Failed to decode an [OpBlock] from the raw block.
-    #[error("Failed to decode OpBlock from raw block {0}")]
-    OpBlockDecode(u64),
     /// Failed to convert the block into a [SystemConfig].
     #[error("Failed to convert block {0} into SystemConfig")]
     SystemConfigConversion(u64),
@@ -72,14 +88,14 @@ pub enum AlloyL2ChainProviderError {
 impl From<AlloyL2ChainProviderError> for PipelineErrorKind {
     fn from(e: AlloyL2ChainProviderError) -> Self {
         match e {
+            AlloyL2ChainProviderError::Transport(e) => PipelineErrorKind::Temporary(
+                PipelineError::Provider(format!("Transport error: {e}")),
+            ),
             AlloyL2ChainProviderError::BlockNotFound(_) => {
-                PipelineErrorKind::Temporary(PipelineError::Provider("block not found".to_string()))
+                PipelineErrorKind::Temporary(PipelineError::Provider("Block not found".to_string()))
             }
             AlloyL2ChainProviderError::L2BlockInfoConstruction(_) => PipelineErrorKind::Temporary(
-                PipelineError::Provider("l2 block info construction failed".to_string()),
-            ),
-            AlloyL2ChainProviderError::OpBlockDecode(_) => PipelineErrorKind::Temporary(
-                PipelineError::Provider("op block decode failed".to_string()),
+                PipelineError::Provider("L2 block info construction failed".to_string()),
             ),
             AlloyL2ChainProviderError::SystemConfigConversion(_) => PipelineErrorKind::Temporary(
                 PipelineError::Provider("system config conversion failed".to_string()),
@@ -102,13 +118,20 @@ impl BatchValidationProvider for AlloyL2ChainProvider {
     }
 
     async fn block_by_number(&mut self, number: u64) -> Result<OpBlock, Self::Error> {
-        let raw_block: Bytes = self
+        if let Some(block) = self.block_by_number_cache.get(&number) {
+            return Ok(block.clone());
+        }
+
+        let block = self
             .inner
-            .raw_request("debug_getRawBlock".into(), [U64::from(number)])
-            .await
-            .map_err(|_| AlloyL2ChainProviderError::BlockNotFound(number))?;
-        OpBlock::decode(&mut raw_block.as_ref())
-            .map_err(|_| AlloyL2ChainProviderError::OpBlockDecode(number))
+            .get_block_by_number(number.into(), BlockTransactionsKind::Full)
+            .await?
+            .ok_or(AlloyL2ChainProviderError::BlockNotFound(number))?
+            .into_consensus()
+            .map_transactions(|t| t.inner.inner);
+
+        self.block_by_number_cache.put(number, block.clone());
+        Ok(block)
     }
 }
 


### PR DESCRIPTION
## Overview

Refactors the `AlloyL2ChainProvider` to use functions from the `alloy_provider::Provider` trait to fetch blocks. Since we wrote this, APIs to convert from RPC types -> consensus types have improved.