### PR TITLE
chore(protocol): Update Sepolia-only fork to activate on L1 blocktime

### DIFF
--- a/crates/proof/executor/src/executor/env.rs
+++ b/crates/proof/executor/src/executor/env.rs
@@ -48,7 +48,11 @@ where
         base_fee_params: &BaseFeeParams,
     ) -> ExecutorResult<BlockEnv> {
         let blob_excess_gas_and_price = parent_header
-            .next_block_excess_blob_gas(BlobParams::cancun())
+            .next_block_excess_blob_gas(if spec_id.is_enabled_in(SpecId::ISTHMUS) {
+                BlobParams::prague()
+            } else {
+                BlobParams::cancun()
+            })
             .or_else(|| spec_id.is_enabled_in(SpecId::ECOTONE).then_some(0))
             .map(|e| BlobExcessGasAndPrice::new(e, spec_id.is_enabled_in(SpecId::PRAGUE)));
         let next_block_base_fee =


### PR DESCRIPTION
## Overview

Adjusts the fork implemented in #1195 to activate based off of the L1 block time, rather than the L2 block time. This keeps the consistency where for all L2 blocks in a given epoch, the L1 block info is constant.

Also:
* Adds a test to the L1 block info variant to ensure the fork activation rules, when the fork is present, are respected.
* Adjusts `prepare_block_env` to use `BlobParams::prague` on L2 after _Isthmus activation_
    * This one should be a no-op since the blob fee on L2 is constant at `1`, but for semantic reasons, I think it's good that we don't just leave that one using `BlobParams::cancun`.