### PR TITLE
release: kona-driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.2.4] - 2025-03-07
+## [0.2.4] - 2025-03-10
+
+### ⚙️ Miscellaneous Tasks
+
+- Release 0.2.4
+
+## [0.1.3] - 2025-03-10
 
 ### 🚀 Features
 
@@ -38,6 +44,7 @@ All notable changes to this project will be documented in this file.
 - *(engine)* Engine Client (#1169)
 - *(protocol)* Use `Prague` blob fee calculation for L1 info tx (#1192)
 - *(protocol)* Add optional pectra blob fee schedule fork (#1195)
+- *(executor)* Dep on kona-host (#1224)
 
 ### ⚙️ Miscellaneous Tasks
 
@@ -88,12 +95,15 @@ All notable changes to this project will be documented in this file.
 - *(rpc)* Rename `RollupNode` -> `RollupNodeApi`, export (#1215)
 - Bump alloy 0.12 (#1208)
 - *(genesis)* Update `SystemConfig` ser (#1217)
-- Release 0.2.4
+- *(net)* P2P Rename (#1221)
+- Update Dependencies (#1226)
+- Codecov Config (#1225)
+- Release 0.1.3
 
 ### Release
 
 - *(maili)* 0.2.9 (#1087)
-- 0.2.4
+- Maili crates one last time (#1218)
 
 ## [kona-host/v0.1.0-beta.11] - 2025-02-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "kona-driver"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "alloy-consensus 0.12.4",
  "alloy-primitives",
@@ -3874,7 +3874,7 @@ dependencies = [
 
 [[package]]
 name = "kona-executor"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "alloy-consensus 0.12.4",
  "alloy-eips 0.12.4",
@@ -4008,7 +4008,7 @@ dependencies = [
 
 [[package]]
 name = "kona-mpt"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "alloy-consensus 0.12.4",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ kona-host = { path = "bin/host", version = "0.1.1", default-features = false }
 kona-client = { path = "bin/client", version = "0.1.0", default-features = false }
 
 # Protocol
-kona-driver = { path = "crates/protocol/driver", version = "0.2.3", default-features = false }
+kona-driver = { path = "crates/protocol/driver", version = "0.2.4", default-features = false }
 kona-derive = { path = "crates/protocol/derive", version = "0.2.4", default-features = false }
 kona-interop = { path = "crates/protocol/interop", version = "0.2.4", default-features = false }
 kona-genesis = { path = "crates/protocol/genesis", version = "0.2.4", default-features = false }
@@ -88,9 +88,9 @@ kona-providers-local = { path = "crates/providers/providers-local", version = "0
 kona-providers-alloy = { path = "crates/providers/providers-alloy", version = "0.1.0", default-features = false }
 
 # Proof
-kona-mpt = { path = "crates/proof/mpt", version = "0.1.2", default-features = false }
+kona-mpt = { path = "crates/proof/mpt", version = "0.1.3", default-features = false }
 kona-proof = { path = "crates/proof/proof", version = "0.2.3", default-features = false }
-kona-executor = { path = "crates/proof/executor", version = "0.2.3", default-features = false }
+kona-executor = { path = "crates/proof/executor", version = "0.2.4", default-features = false }
 kona-std-fpvm = { path = "crates/proof/std-fpvm", version = "0.1.2", default-features = false }
 kona-preimage = { path = "crates/proof/preimage", version = "0.2.1", default-features = false }
 kona-std-fpvm-proc = { path = "crates/proof/std-fpvm-proc", version = "0.1.2", default-features = false }

--- a/crates/proof/executor/Cargo.toml
+++ b/crates/proof/executor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kona-executor"
 description = "An no_std implementation of a stateless L2 block executor for the OP Stack."
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/proof/mpt/Cargo.toml
+++ b/crates/proof/mpt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kona-mpt"
 description = "Utilities for interacting with and iterating through a merkle patricia trie"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/protocol/driver/Cargo.toml
+++ b/crates/protocol/driver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kona-driver"
 description = "A no_std derivation pipeline driver"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
### Description

Finally releases the `kona-driver` which was blocked on the `kona-executor` importing `kona-host` (an unpublished binary).