### PR TITLE
chore(workspace): Use versioned `asterisc-builder` + `cannon-builder` images

### DIFF
--- a/.github/workflows/rust_ci.yaml
+++ b/.github/workflows/rust_ci.yaml
@@ -115,6 +115,25 @@ jobs:
       - name: chown target
         run: |
           sudo chown -R $(id -u):$(id -g) ./target
+  cargo-udeps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    name: check-udeps
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: taiki-e/install-action@just
+      - name: Install Rust stable toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - uses: taiki-e/install-action@nextest
+      - uses: taiki-e/install-action@cargo-udeps
+      - name: cargo udeps
+        run: just check-unused-deps
   cargo-doc-lint:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3932,8 +3932,6 @@ dependencies = [
  "alloy-eips 0.12.4",
  "alloy-primitives",
  "op-alloy-consensus 0.11.0",
- "rand 0.9.0",
- "tokio",
 ]
 
 [[package]]
@@ -4026,7 +4024,6 @@ dependencies = [
  "serde",
  "thiserror 2.0.12",
  "tokio",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Justfile
+++ b/Justfile
@@ -76,7 +76,7 @@ lint-cannon:
     --rm \
     -v `pwd`/:/workdir \
     -w="/workdir" \
-    ghcr.io/op-rs/kona/cannon-builder:main cargo clippy -p kona-std-fpvm --all-features -Zbuild-std=core,alloc -- -D warnings --allow=unused-crate-dependencies
+    ghcr.io/op-rs/kona/cannon-builder:0.1.0 cargo clippy -p kona-std-fpvm --all-features -Zbuild-std=core,alloc -- -D warnings
 
 # Lint the workspace (risc-v arch). Currently, only the `kona-std-fpvm` crate is linted for the `asterisc` target, as it is the only crate with architecture-specific code.
 lint-asterisc:
@@ -84,7 +84,7 @@ lint-asterisc:
     --rm \
     -v `pwd`/:/workdir \
     -w="/workdir" \
-    ghcr.io/op-rs/kona/asterisc-builder:main cargo clippy -p kona-std-fpvm --all-features -Zbuild-std=core,alloc -- -D warnings --allow=unused-crate-dependencies
+    ghcr.io/op-rs/kona/asterisc-builder:0.1.0 cargo clippy -p kona-std-fpvm --all-features -Zbuild-std=core,alloc -- -D warnings
 
 # Lint the Rust documentation
 lint-docs:
@@ -104,7 +104,7 @@ build-cannon-client:
     --rm \
     -v `pwd`/:/workdir \
     -w="/workdir" \
-    ghcr.io/op-rs/kona/cannon-builder:main cargo build -Zbuild-std=core,alloc -p kona-client --bin kona --profile release-client-lto
+    ghcr.io/op-rs/kona/cannon-builder:0.1.0 cargo build -Zbuild-std=core,alloc -p kona-client --bin kona --profile release-client-lto
 
 # Build `kona-client` for the `asterisc` target.
 build-asterisc-client:
@@ -112,7 +112,11 @@ build-asterisc-client:
     --rm \
     -v `pwd`/:/workdir \
     -w="/workdir" \
-    ghcr.io/op-rs/kona/asterisc-builder:main cargo build -Zbuild-std=core,alloc -p kona-client --bin kona --profile release-client-lto
+    ghcr.io/op-rs/kona/asterisc-builder:0.1.0 cargo build -Zbuild-std=core,alloc -p kona-client --bin kona --profile release-client-lto
+
+# Check for unused dependencies in the crate graph.
+check-unused-deps:
+  cargo +nightly udeps --workspace --all-features --all-targets
 
 # Clones and checks out the monorepo at the commit present in `.monorepo`
 monorepo:

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -4,7 +4,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/op-rs/kona/main/assets/favicon.ico",
     issue_tracker_base_url = "https://github.com/op-rs/kona/issues/"
 )]
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod cli;

--- a/crates/node/engine/src/lib.rs
+++ b/crates/node/engine/src/lib.rs
@@ -4,7 +4,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/op-rs/kona/main/assets/favicon.ico",
     issue_tracker_base_url = "https://github.com/op-rs/kona/issues/"
 )]
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[macro_use]

--- a/crates/node/p2p/src/lib.rs
+++ b/crates/node/p2p/src/lib.rs
@@ -5,7 +5,6 @@
     issue_tracker_base_url = "https://github.com/op-rs/kona/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 pub mod builder;
 pub mod discovery;

--- a/crates/node/rpc/src/lib.rs
+++ b/crates/node/rpc/src/lib.rs
@@ -4,7 +4,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/op-rs/kona/main/assets/favicon.ico",
     issue_tracker_base_url = "https://github.com/op-rs/kona/issues/"
 )]
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/crates/node/service/src/lib.rs
+++ b/crates/node/service/src/lib.rs
@@ -4,7 +4,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/op-rs/kona/main/assets/favicon.ico",
     issue_tracker_base_url = "https://github.com/op-rs/kona/issues/"
 )]
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[macro_use]

--- a/crates/proof/executor/src/lib.rs
+++ b/crates/proof/executor/src/lib.rs
@@ -5,7 +5,6 @@
     issue_tracker_base_url = "https://github.com/op-rs/kona/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(test), no_std)]
 
 extern crate alloc;

--- a/crates/proof/mpt/Cargo.toml
+++ b/crates/proof/mpt/Cargo.toml
@@ -37,7 +37,6 @@ reqwest.workspace = true
 proptest.workspace = true
 tokio = { workspace = true, features = ["full"] }
 criterion = { workspace = true, features = ["html_reports"] }
-tracing-subscriber = { workspace = true, features = ["fmt"] }
 pprof = { workspace = true, features = ["criterion", "flamegraph", "frame-pointer"] }
 
 [features]

--- a/crates/proof/mpt/src/lib.rs
+++ b/crates/proof/mpt/src/lib.rs
@@ -5,7 +5,6 @@
     issue_tracker_base_url = "https://github.com/op-rs/kona/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(test), no_std)]
 
 extern crate alloc;

--- a/crates/proof/preimage/src/lib.rs
+++ b/crates/proof/preimage/src/lib.rs
@@ -5,7 +5,6 @@
     issue_tracker_base_url = "https://github.com/op-rs/kona/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;

--- a/crates/proof/proof-interop/src/lib.rs
+++ b/crates/proof/proof-interop/src/lib.rs
@@ -4,7 +4,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/op-rs/kona/main/assets/favicon.ico",
     issue_tracker_base_url = "https://github.com/op-rs/kona/issues/"
 )]
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "arbitrary"), no_std)]
 

--- a/crates/proof/proof/src/lib.rs
+++ b/crates/proof/proof/src/lib.rs
@@ -4,7 +4,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/op-rs/kona/main/assets/favicon.ico",
     issue_tracker_base_url = "https://github.com/op-rs/kona/issues/"
 )]
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![no_std]
 

--- a/crates/proof/std-fpvm-proc/Cargo.toml
+++ b/crates/proof/std-fpvm-proc/Cargo.toml
@@ -22,3 +22,6 @@ kona-std-fpvm.workspace = true
 quote = "1.0"
 proc-macro2 = "1.0"
 syn = { version = "2.0", features = ["full"] }
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["kona-std-fpvm"]

--- a/crates/proof/std-fpvm/Cargo.toml
+++ b/crates/proof/std-fpvm/Cargo.toml
@@ -24,5 +24,8 @@ async-trait.workspace = true
 # `tracing` feature dependencies
 tracing = { workspace = true, optional = true }
 
+[package.metadata.cargo-udeps.ignore]
+normal = ["linked_list_allocator"]
+
 [features]
 tracing = ["dep:tracing"]

--- a/crates/proof/std-fpvm/src/mips64/syscall.rs
+++ b/crates/proof/std-fpvm/src/mips64/syscall.rs
@@ -62,7 +62,7 @@ pub(crate) unsafe fn syscall1(n: usize, arg1: usize) -> usize {
         );
     }
 
-    (err == 0).then_some(ret).unwrap_or_else(|| ret.wrapping_neg())
+    if err == 0 { ret } else { ret.wrapping_neg() }
 }
 
 /// Issues a raw system call with 3 arguments. (e.g. read, write)
@@ -93,5 +93,5 @@ pub(crate) unsafe fn syscall3(n: usize, arg1: usize, arg2: usize, arg3: usize) -
         );
     }
 
-    (err == 0).then_some(ret).unwrap_or_else(|| ret.wrapping_neg())
+    if err == 0 { ret } else { ret.wrapping_neg() }
 }

--- a/crates/protocol/derive/src/lib.rs
+++ b/crates/protocol/derive/src/lib.rs
@@ -5,7 +5,6 @@
     issue_tracker_base_url = "https://github.com/op-rs/kona/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(test), no_std)]
 
 extern crate alloc;

--- a/crates/protocol/driver/src/lib.rs
+++ b/crates/protocol/driver/src/lib.rs
@@ -5,7 +5,6 @@
     issue_tracker_base_url = "https://github.com/op-rs/kona/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(test), no_std)]
 
 extern crate alloc;

--- a/crates/protocol/genesis/src/lib.rs
+++ b/crates/protocol/genesis/src/lib.rs
@@ -4,7 +4,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/op-rs/kona/main/assets/favicon.ico",
     issue_tracker_base_url = "https://github.com/op-rs/kona/issues/"
 )]
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/crates/protocol/hardforks/Cargo.toml
+++ b/crates/protocol/hardforks/Cargo.toml
@@ -23,8 +23,6 @@ alloy-primitives = { workspace = true, features = ["rlp"] }
 op-alloy-consensus.workspace = true
 
 [dev-dependencies]
-rand.workspace = true
-tokio = { workspace = true, features = ["macros"] }
 alloy-primitives = { workspace = true, features = ["rand", "arbitrary"] }
 
 [features]

--- a/crates/protocol/hardforks/src/lib.rs
+++ b/crates/protocol/hardforks/src/lib.rs
@@ -4,7 +4,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/op-rs/kona/main/assets/favicon.ico",
     issue_tracker_base_url = "https://github.com/op-rs/kona/issues/"
 )]
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/crates/protocol/interop/src/lib.rs
+++ b/crates/protocol/interop/src/lib.rs
@@ -4,7 +4,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/op-rs/kona/main/assets/favicon.ico"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;

--- a/crates/protocol/protocol/src/lib.rs
+++ b/crates/protocol/protocol/src/lib.rs
@@ -4,7 +4,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/op-rs/kona/main/assets/favicon.ico",
     issue_tracker_base_url = "https://github.com/op-rs/kona/issues/"
 )]
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/crates/protocol/registry/src/lib.rs
+++ b/crates/protocol/registry/src/lib.rs
@@ -4,7 +4,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/op-rs/kona/main/assets/favicon.ico",
     issue_tracker_base_url = "https://github.com/op-rs/kona/issues/"
 )]
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/crates/providers/providers-alloy/src/lib.rs
+++ b/crates/providers/providers-alloy/src/lib.rs
@@ -5,7 +5,6 @@
     issue_tracker_base_url = "https://github.com/op-rs/kona/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod beacon_client;
 pub use beacon_client::{

--- a/crates/providers/providers-local/src/lib.rs
+++ b/crates/providers/providers-local/src/lib.rs
@@ -5,7 +5,6 @@
     issue_tracker_base_url = "https://github.com/op-rs/kona/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(test), no_std)]
 
 extern crate alloc;

--- a/crates/utilities/cli/src/lib.rs
+++ b/crates/utilities/cli/src/lib.rs
@@ -4,7 +4,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/op-rs/kona/main/assets/favicon.ico"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod clap;
 pub use clap::cli_styles;

--- a/crates/utilities/serde/Cargo.toml
+++ b/crates/utilities/serde/Cargo.toml
@@ -22,6 +22,9 @@ serde_json = { workspace = true, features = ["alloc"] }
 [dev-dependencies]
 toml = { workspace = true, features = ["parse"] }
 
+[package.metadata.cargo-udeps.ignore]
+development = ["toml"]
+
 [features]
 default = []
 std = [

--- a/crates/utilities/serde/src/lib.rs
+++ b/crates/utilities/serde/src/lib.rs
@@ -4,7 +4,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/op-rs/kona/main/assets/favicon.ico",
     issue_tracker_base_url = "https://github.com/op-rs/kona/issues/"
 )]
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![no_std]
 

--- a/docker/fpvm-prestates/asterisc-repro.dockerfile
+++ b/docker/fpvm-prestates/asterisc-repro.dockerfile
@@ -30,7 +30,7 @@ RUN git clone https://github.com/ethereum-optimism/asterisc && \
 #               Build kona-client @ `CLIENT_TAG`               #
 ################################################################
 
-FROM ghcr.io/op-rs/kona/asterisc-builder@sha256:56c57453ebe09875e96df527d3734d781e987dbdc1e0ce9e813e1e88590036bd AS client-build
+FROM ghcr.io/op-rs/kona/asterisc-builder:0.1.0 AS client-build
 SHELL ["/bin/bash", "-c"]
 
 ARG CLIENT_TAG


### PR DESCRIPTION
## Overview

Starts to use the versioned `asterisc-builder` + `cannon-builder` images. Cleans up the reproducible prestate job, no longer have to pin it to a certain image digest.