### PR TITLE
chore: Allow udeps in `-Zbuild-std` lints

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -76,7 +76,7 @@ lint-cannon:
     --rm \
     -v `pwd`/:/workdir \
     -w="/workdir" \
-    ghcr.io/op-rs/kona/cannon-builder:main cargo clippy -p kona-std-fpvm --all-features -Zbuild-std=core,alloc -- -D warnings
+    ghcr.io/op-rs/kona/cannon-builder:main cargo clippy -p kona-std-fpvm --all-features -Zbuild-std=core,alloc -- -D warnings --allow=unused-crate-dependencies
 
 # Lint the workspace (risc-v arch). Currently, only the `kona-std-fpvm` crate is linted for the `asterisc` target, as it is the only crate with architecture-specific code.
 lint-asterisc:
@@ -84,7 +84,7 @@ lint-asterisc:
     --rm \
     -v `pwd`/:/workdir \
     -w="/workdir" \
-    ghcr.io/op-rs/kona/asterisc-builder:main cargo clippy -p kona-std-fpvm --all-features -Zbuild-std=core,alloc -- -D warnings
+    ghcr.io/op-rs/kona/asterisc-builder:main cargo clippy -p kona-std-fpvm --all-features -Zbuild-std=core,alloc -- -D warnings --allow=unused-crate-dependencies
 
 # Lint the Rust documentation
 lint-docs:


### PR DESCRIPTION
## Overview

Allows unused dependencies in lint jobs that use `-Zbuild-std`. ref: https://github.com/google/wasefire/pull/764