### PR TITLE
chore(ci): Deprecate --all Flag

### DIFF
--- a/.github/workflows/rust_ci.yaml
+++ b/.github/workflows/rust_ci.yaml
@@ -78,7 +78,7 @@ jobs:
         with:
           cache-on-failure: true
       - name: build benches
-        run: cargo bench --no-run --workspace --all --features test-utils
+        run: just benches
       - name: chown target
         run: |
           sudo chown -R $(id -u):$(id -g) ./target

--- a/Justfile
+++ b/Justfile
@@ -51,6 +51,10 @@ action-tests test_name='Test_ProgramAction' *args='':
 clean-actions:
   rm -rf monorepo/
 
+# Runs benchmarks
+benches:
+  cargo bench --no-run --workspace --features test-utils --exclude example-gossip --exclude example-discovery
+
 # Lint the workspace for all available targets
 lint-all: lint-native lint-cannon lint-asterisc lint-docs
 

--- a/Justfile
+++ b/Justfile
@@ -64,11 +64,11 @@ hack:
 
 # Fixes the formatting of the workspace
 fmt-native-fix:
-  cargo +nightly fmt --workspace
+  cargo +nightly fmt --all
 
 # Check the formatting of the workspace
 fmt-native-check:
-  cargo +nightly fmt --workspace -- --check
+  cargo +nightly fmt --all -- --check
 
 # Lint the workspace
 lint-native: fmt-native-check lint-docs

--- a/Justfile
+++ b/Justfile
@@ -16,7 +16,7 @@ tests: test test-docs
 
 # Test for the native target with all features. By default, excludes online tests.
 test *args="-E '!test(test_online)'":
-  cargo nextest run --workspace --all --all-features {{args}}
+  cargo nextest run --workspace --all-features {{args}}
 
 # Run all online tests
 test-online:
@@ -64,15 +64,15 @@ hack:
 
 # Fixes the formatting of the workspace
 fmt-native-fix:
-  cargo +nightly fmt --all
+  cargo +nightly fmt --workspace
 
 # Check the formatting of the workspace
 fmt-native-check:
-  cargo +nightly fmt --all -- --check
+  cargo +nightly fmt --workspace -- --check
 
 # Lint the workspace
 lint-native: fmt-native-check lint-docs
-  cargo clippy --workspace --all --all-features --all-targets -- -D warnings
+  cargo clippy --workspace --all-features --all-targets -- -D warnings
 
 # Lint the workspace (mips arch). Currently, only the `kona-std-fpvm` crate is linted for the `cannon` target, as it is the only crate with architecture-specific code.
 lint-cannon:
@@ -92,11 +92,11 @@ lint-asterisc:
 
 # Lint the Rust documentation
 lint-docs:
-  RUSTDOCFLAGS="-D warnings" cargo doc --all --no-deps --document-private-items
+  RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items
 
 # Test the Rust documentation
 test-docs:
-  cargo test --doc --all --locked
+  cargo test --doc --workspace --locked
 
 # Build for the native target
 build-native *args='':


### PR DESCRIPTION
### Description

Cargo deprecated the `--all` flag in favor of the `--workspace` flag.

See: https://doc.rust-lang.org/cargo/commands/cargo-test.html#package-selection