### PR TITLE
Refactor: Clap attribute macros from #[clap(...)] to #[arg(...)] and #[command(...)] in v4.x

### DIFF
--- a/bin/host/src/bin/host.rs
+++ b/bin/host/src/bin/host.rs
@@ -27,7 +27,7 @@ pub struct HostCli {
     #[arg(long, short, action = ArgAction::Count)]
     pub v: u8,
     /// Host mode
-    #[arg(subcommand)]
+    #[command(subcommand)]
     pub mode: HostMode,
 }
 

--- a/bin/host/src/bin/host.rs
+++ b/bin/host/src/bin/host.rs
@@ -27,7 +27,7 @@ pub struct HostCli {
     #[arg(long, short, action = ArgAction::Count)]
     pub v: u8,
     /// Host mode
-    #[clap(subcommand)]
+    #[arg(subcommand)]
     pub mode: HostMode,
 }
 

--- a/bin/host/src/interop/cfg.rs
+++ b/bin/host/src/interop/cfg.rs
@@ -31,21 +31,21 @@ use tokio::{
 pub struct InteropHost {
     /// Hash of the L1 head block, marking a static, trusted cutoff point for reading data from the
     /// L1 chain.
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub l1_head: B256,
     /// Agreed [PreState] to start from.
     ///
     /// [PreState]: kona_proof_interop::PreState
-    #[clap(long, visible_alias = "l2-pre-state", value_parser = Bytes::from_str, env)]
+    #[arg(long, visible_alias = "l2-pre-state", value_parser = Bytes::from_str, env)]
     pub agreed_l2_pre_state: Bytes,
     /// Claimed L2 post-state to validate.
-    #[clap(long, visible_alias = "l2-claim", env)]
+    #[arg(long, visible_alias = "l2-claim", env)]
     pub claimed_l2_post_state: B256,
     /// Claimed L2 timestamp, corresponding to the L2 post-state.
-    #[clap(long, visible_alias = "l2-timestamp", env)]
+    #[arg(long, visible_alias = "l2-timestamp", env)]
     pub claimed_l2_timestamp: u64,
     /// Addresses of L2 JSON-RPC endpoints to use (eth and debug namespace required).
-    #[clap(
+    #[arg(
         long,
         visible_alias = "l2s",
         requires = "l1_node_address",
@@ -55,7 +55,7 @@ pub struct InteropHost {
     )]
     pub l2_node_addresses: Option<Vec<String>>,
     /// Address of L1 JSON-RPC endpoint to use (eth and debug namespace required)
-    #[clap(
+    #[arg(
         long,
         visible_alias = "l1",
         requires = "l2_node_addresses",
@@ -64,7 +64,7 @@ pub struct InteropHost {
     )]
     pub l1_node_address: Option<String>,
     /// Address of the L1 Beacon API endpoint to use.
-    #[clap(
+    #[arg(
         long,
         visible_alias = "beacon",
         requires = "l1_node_address",
@@ -74,7 +74,7 @@ pub struct InteropHost {
     pub l1_beacon_address: Option<String>,
     /// The Data Directory for preimage data storage. Optional if running in online mode,
     /// required if running in offline mode.
-    #[clap(
+    #[arg(
         long,
         visible_alias = "db",
         required_unless_present_all = ["l2_node_addresses", "l1_node_address", "l1_beacon_address"],
@@ -82,15 +82,15 @@ pub struct InteropHost {
     )]
     pub data_dir: Option<PathBuf>,
     /// Run the client program natively.
-    #[clap(long, conflicts_with = "server", required_unless_present = "server")]
+    #[arg(long, conflicts_with = "server", required_unless_present = "server")]
     pub native: bool,
     /// Run in pre-image server mode without executing any client program. If not provided, the
     /// host will run the client program in the host process.
-    #[clap(long, conflicts_with = "native", required_unless_present = "native")]
+    #[arg(long, conflicts_with = "native", required_unless_present = "native")]
     pub server: bool,
     /// Path to rollup configs. If provided, the host will use this config instead of attempting to
     /// look up the configs in the superchain registry.
-    #[clap(long, alias = "rollup-cfgs", value_delimiter = ',', env)]
+    #[arg(long, alias = "rollup-cfgs", value_delimiter = ',', env)]
     pub rollup_config_paths: Option<Vec<PathBuf>>,
 }
 

--- a/bin/host/src/single/cfg.rs
+++ b/bin/host/src/single/cfg.rs
@@ -30,22 +30,22 @@ use tokio::{
 #[command(styles = cli_styles())]
 pub struct SingleChainHost {
     /// Hash of the L1 head block. Derivation stops after this block is processed.
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub l1_head: B256,
     /// Hash of the agreed upon safe L2 block committed to by `--agreed-l2-output-root`.
-    #[clap(long, visible_alias = "l2-head", env)]
+    #[arg(long, visible_alias = "l2-head", env)]
     pub agreed_l2_head_hash: B256,
     /// Agreed safe L2 Output Root to start derivation from.
-    #[clap(long, visible_alias = "l2-output-root", env)]
+    #[arg(long, visible_alias = "l2-output-root", env)]
     pub agreed_l2_output_root: B256,
     /// Claimed L2 output root at block # `--claimed-l2-block-number` to validate.
-    #[clap(long, visible_alias = "l2-claim", env)]
+    #[arg(long, visible_alias = "l2-claim", env)]
     pub claimed_l2_output_root: B256,
     /// Number of the L2 block that the claimed output root commits to.
-    #[clap(long, visible_alias = "l2-block-number", env)]
+    #[arg(long, visible_alias = "l2-block-number", env)]
     pub claimed_l2_block_number: u64,
     /// Address of L2 JSON-RPC endpoint to use (eth and debug namespace required).
-    #[clap(
+    #[arg(
         long,
         visible_alias = "l2",
         requires = "l1_node_address",
@@ -54,7 +54,7 @@ pub struct SingleChainHost {
     )]
     pub l2_node_address: Option<String>,
     /// Address of L1 JSON-RPC endpoint to use (eth and debug namespace required)
-    #[clap(
+    #[arg(
         long,
         visible_alias = "l1",
         requires = "l2_node_address",
@@ -63,7 +63,7 @@ pub struct SingleChainHost {
     )]
     pub l1_node_address: Option<String>,
     /// Address of the L1 Beacon API endpoint to use.
-    #[clap(
+    #[arg(
         long,
         visible_alias = "beacon",
         requires = "l1_node_address",
@@ -73,7 +73,7 @@ pub struct SingleChainHost {
     pub l1_beacon_address: Option<String>,
     /// The Data Directory for preimage data storage. Optional if running in online mode,
     /// required if running in offline mode.
-    #[clap(
+    #[arg(
         long,
         visible_alias = "db",
         required_unless_present_all = ["l2_node_address", "l1_node_address", "l1_beacon_address"],
@@ -81,15 +81,15 @@ pub struct SingleChainHost {
     )]
     pub data_dir: Option<PathBuf>,
     /// Run the client program natively.
-    #[clap(long, conflicts_with = "server", required_unless_present = "server")]
+    #[arg(long, conflicts_with = "server", required_unless_present = "server")]
     pub native: bool,
     /// Run in pre-image server mode without executing any client program. If not provided, the
     /// host will run the client program in the host process.
-    #[clap(long, conflicts_with = "native", required_unless_present = "native")]
+    #[arg(long, conflicts_with = "native", required_unless_present = "native")]
     pub server: bool,
     /// The L2 chain ID of a supported chain. If provided, the host will look for the corresponding
     /// rollup config in the superchain registry.
-    #[clap(
+    #[arg(
         long,
         conflicts_with = "rollup_config_path",
         required_unless_present = "rollup_config_path",
@@ -98,7 +98,7 @@ pub struct SingleChainHost {
     pub l2_chain_id: Option<u64>,
     /// Path to rollup config. If provided, the host will use this config instead of attempting to
     /// look up the config in the superchain registry.
-    #[clap(
+    #[arg(
         long,
         alias = "rollup-cfg",
         conflicts_with = "l2_chain_id",

--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -2,7 +2,7 @@
 
 use crate::{commands::NodeCommand, flags::GlobalArgs};
 use anyhow::Result;
-use clap::{Args, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 use kona_cli::{cli_styles, init_prometheus_server, init_tracing_subscriber};
 use tracing_subscriber::EnvFilter;
 

--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -2,7 +2,7 @@
 
 use crate::{commands::NodeCommand, flags::GlobalArgs};
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use kona_cli::{cli_styles, init_prometheus_server, init_tracing_subscriber};
 use tracing_subscriber::EnvFilter;
 
@@ -19,10 +19,10 @@ pub enum Commands {
 #[command(author, version, about, styles = cli_styles(), long_about = None)]
 pub struct Cli {
     /// Global arguments for the CLI.
-    #[clap(flatten)]
+    #[command(flatten)]
     pub global: GlobalArgs,
     /// The subcommand to run.
-    #[clap(subcommand)]
+    #[command(subcommand)]
     pub subcommand: Commands,
 }
 

--- a/bin/node/src/commands/node.rs
+++ b/bin/node/src/commands/node.rs
@@ -24,27 +24,27 @@ use crate::flags::{GlobalArgs, P2PArgs};
 #[command(about = "Runs the consensus node")]
 pub struct NodeCommand {
     /// URL of the L1 execution client RPC API.
-    #[clap(long, visible_alias = "l1", env = "L1_ETH_RPC")]
+    #[arg(long, visible_alias = "l1", env = "L1_ETH_RPC")]
     pub l1_eth_rpc: Url,
     /// URL of the L1 beacon API.
-    #[clap(long, visible_alias = "l1.beacon", env = "L1_BEACON")]
+    #[arg(long, visible_alias = "l1.beacon", env = "L1_BEACON")]
     pub l1_beacon: Url,
     /// URL of the engine API endpoint of an L2 execution client.
-    #[clap(long, visible_alias = "l2", env = "L2_ENGINE_RPC")]
+    #[arg(long, visible_alias = "l2", env = "L2_ENGINE_RPC")]
     pub l2_engine_rpc: Url,
     /// An L2 RPC Url.
-    #[clap(long, visible_alias = "l2.provider", env = "L2_ETH_RPC")]
+    #[arg(long, visible_alias = "l2.provider", env = "L2_ETH_RPC")]
     pub l2_provider_rpc: Url,
     /// JWT secret for the auth-rpc endpoint of the execution client.
     /// This MUST be a valid path to a file containing the hex-encoded JWT secret.
-    #[clap(long, visible_alias = "l2.jwt-secret", env = "L2_ENGINE_AUTH")]
+    #[arg(long, visible_alias = "l2.jwt-secret", env = "L2_ENGINE_AUTH")]
     pub l2_engine_jwt_secret: Option<PathBuf>,
     /// Path to a custom L2 rollup configuration file
     /// (overrides the default rollup configuration from the registry)
-    #[clap(long, visible_alias = "rollup-cfg")]
+    #[arg(long, visible_alias = "rollup-cfg")]
     pub l2_config_file: Option<PathBuf>,
     /// Engine kind.
-    #[clap(
+    #[arg(
         long,
         visible_alias = "l2.enginekind",
         default_value = "geth",
@@ -53,7 +53,7 @@ pub struct NodeCommand {
     )]
     pub l2_engine_kind: EngineKind,
     /// P2P CLI arguments.
-    #[clap(flatten)]
+    #[command(flatten)]
     pub p2p_flags: P2PArgs,
 }
 

--- a/bin/node/src/flags/globals.rs
+++ b/bin/node/src/flags/globals.rs
@@ -9,10 +9,10 @@ pub struct GlobalArgs {
     #[arg(long, short, action = ArgAction::Count)]
     pub v: u8,
     /// The L2 chain ID to use.
-    #[clap(long, short = 'c', default_value = "10", help = "The L2 chain ID to use")]
+    #[arg(long, short = 'c', default_value = "10", help = "The L2 chain ID to use")]
     pub l2_chain_id: u64,
     /// A port to serve prometheus metrics on.
-    #[clap(
+    #[arg(
         long,
         short = 'm',
         default_value = "9090",

--- a/bin/node/src/flags/p2p.rs
+++ b/bin/node/src/flags/p2p.rs
@@ -6,7 +6,7 @@
 
 use alloy_primitives::B256;
 use anyhow::Result;
-use clap::{Parser};
+use clap::Parser;
 use libp2p_identity::Keypair;
 use std::{net::IpAddr, path::PathBuf};
 

--- a/bin/node/src/flags/p2p.rs
+++ b/bin/node/src/flags/p2p.rs
@@ -6,7 +6,7 @@
 
 use alloy_primitives::B256;
 use anyhow::Result;
-use clap::{Args, Parser};
+use clap::{Parser};
 use libp2p_identity::Keypair;
 use std::{net::IpAddr, path::PathBuf};
 

--- a/bin/node/src/flags/p2p.rs
+++ b/bin/node/src/flags/p2p.rs
@@ -6,7 +6,7 @@
 
 use alloy_primitives::B256;
 use anyhow::Result;
-use clap::Parser;
+use clap::{Args, Parser};
 use libp2p_identity::Keypair;
 use std::{net::IpAddr, path::PathBuf};
 
@@ -14,7 +14,7 @@ use std::{net::IpAddr, path::PathBuf};
 #[derive(Parser, Clone, Debug, PartialEq, Eq)]
 pub struct P2PArgs {
     /// Whether to disable the entire P2P stack.
-    #[clap(
+    #[arg(
         long = "p2p.disable",
         default_value = "false",
         env = "KONA_NODE_P2P_DISABLE",
@@ -22,7 +22,7 @@ pub struct P2PArgs {
     )]
     pub disabled: bool,
     /// Disable Discv5 (node discovery).
-    #[clap(
+    #[arg(
         long = "p2p.no-discovery",
         default_value = "false",
         env = "KONA_NODE_P2P_NO_DISCOVERY",
@@ -30,21 +30,21 @@ pub struct P2PArgs {
     )]
     pub no_discovery: bool,
     /// A private key file path.
-    #[clap(
+    #[arg(
         long = "p2p.priv.path",
         env = "KONA_NODE_P2P_PRIV_PATH",
         help = "Read the hex-encoded 32-byte private key for the peer ID from this txt file. Created if not already exists. Important to persist to keep the same network identity after restarting, maintaining the previous advertised identity."
     )]
     pub priv_path: Option<PathBuf>,
     /// The hex-encoded 32-byte private key for the peer ID.
-    #[clap(
+    #[arg(
         long = "p2p.priv.raw",
         env = "KONA_NODE_P2P_PRIV_RAW",
         help = "The hex-encoded 32-byte private key for the peer ID"
     )]
     pub private_key: Option<B256>,
     /// IP to bind LibP2P and Discv5 to.
-    #[clap(
+    #[arg(
         long = "p2p.listen.ip",
         default_value = "0.0.0.0",
         env = "KONA_NODE_P2P_LISTEN_IP",
@@ -52,7 +52,7 @@ pub struct P2PArgs {
     )]
     pub listen_ip: IpAddr,
     /// TCP port to bind LibP2P to. Any available system port if set to 0.
-    #[clap(
+    #[arg(
         long = "p2p.listen.tcp",
         default_value = "9222",
         env = "KONA_NODE_P2P_LISTEN_TCP_PORT",
@@ -60,7 +60,7 @@ pub struct P2PArgs {
     )]
     pub listen_tcp_port: u16,
     /// UDP port to bind Discv5 to. Same as TCP port if left 0.
-    #[clap(
+    #[arg(
         long = "p2p.listen.udp",
         default_value = "0",
         env = "KONA_NODE_P2P_LISTEN_UDP_PORT",

--- a/examples/discovery/src/main.rs
+++ b/examples/discovery/src/main.rs
@@ -31,13 +31,13 @@ pub struct DiscCommand {
     #[arg(long, short, action = ArgAction::Count)]
     pub v: u8,
     /// The L2 chain ID to use.
-    #[clap(long, short = 'c', default_value = "10", help = "The L2 chain ID to use")]
+    #[arg(long, short = 'c', default_value = "10", help = "The L2 chain ID to use")]
     pub l2_chain_id: u64,
     /// Discovery port to listen on.
-    #[clap(long, short = 'l', default_value = "9099", help = "Port to listen to discovery")]
+    #[arg(long, short = 'l', default_value = "9099", help = "Port to listen to discovery")]
     pub disc_port: u16,
     /// Interval to send discovery packets.
-    #[clap(long, short = 'i', default_value = "1", help = "Interval to send discovery packets")]
+    #[arg(long, short = 'i', default_value = "1", help = "Interval to send discovery packets")]
     pub interval: u64,
 }
 

--- a/examples/gossip/src/main.rs
+++ b/examples/gossip/src/main.rs
@@ -32,16 +32,16 @@ pub struct GossipCommand {
     #[arg(long, short, action = ArgAction::Count)]
     pub v: u8,
     /// The L2 chain ID to use.
-    #[clap(long, short = 'c', default_value = "10", help = "The L2 chain ID to use")]
+    #[arg(long, short = 'c', default_value = "10", help = "The L2 chain ID to use")]
     pub l2_chain_id: u64,
     /// Port to listen for gossip on.
-    #[clap(long, short = 'l', default_value = "9099", help = "Port to listen for gossip on")]
+    #[arg(long, short = 'l', default_value = "9099", help = "Port to listen for gossip on")]
     pub gossip_port: u16,
     /// Port to listen for discovery on.
-    #[clap(long, short = 'd', default_value = "9098", help = "Port to listen for discovery on")]
+    #[arg(long, short = 'd', default_value = "9098", help = "Port to listen for discovery on")]
     pub disc_port: u16,
     /// Interval to send discovery packets.
-    #[clap(long, short = 'i', default_value = "1", help = "Interval to send discovery packets")]
+    #[arg(long, short = 'i', default_value = "1", help = "Interval to send discovery packets")]
     pub interval: u64,
 }
 


### PR DESCRIPTION
This PR updates deprecated #[clap(...)] attributes to their modern equivalents in clap 4.x.
The current codebase still uses outdated syntax that has been deprecated since version 4.0.
By making this update, we ensure compatibility with future versions and maintain code quality.

I ran cargo check --features clap/deprecated after making the changes, and the previous clap deprecation warnings are no longer present.

![image](https://github.com/user-attachments/assets/75ed6a32-8bb6-4dcb-a204-75b89cf98ab8)

Fixes #1284 

