### PR TITLE
chore: Remove Magic 0x7E Deposit Identifier Bytes

### DIFF
--- a/crates/protocol/protocol/src/batch/single.rs
+++ b/crates/protocol/protocol/src/batch/single.rs
@@ -6,6 +6,7 @@ use alloy_eips::BlockNumHash;
 use alloy_primitives::{BlockHash, Bytes};
 use alloy_rlp::{RlpDecodable, RlpEncodable};
 use kona_genesis::RollupConfig;
+use op_alloy_consensus::OpTxType;
 
 /// Represents a single batch: a single encoded L2 block
 #[derive(Debug, Default, RlpDecodable, RlpEncodable, Clone, PartialEq, Eq)]
@@ -26,7 +27,7 @@ pub struct SingleBatch {
 impl SingleBatch {
     /// If any transactions are empty or deposited transaction types.
     pub fn has_invalid_transactions(&self) -> bool {
-        self.transactions.iter().any(|tx| tx.0.is_empty() || tx.0[0] == 0x7E)
+        self.transactions.iter().any(|tx| tx.0.is_empty() || tx.0[0] == OpTxType::Deposit as u8)
     }
 
     /// Returns the [BlockNumHash] of the batch.

--- a/crates/protocol/protocol/src/utils.rs
+++ b/crates/protocol/protocol/src/utils.rs
@@ -5,7 +5,7 @@ use alloy_consensus::{Transaction, TxType, Typed2718};
 use alloy_primitives::B256;
 use alloy_rlp::{Buf, Header};
 use kona_genesis::{RollupConfig, SystemConfig};
-use op_alloy_consensus::OpBlock;
+use op_alloy_consensus::{OpBlock, OpTxType};
 
 use crate::{
     L1BlockInfoBedrock, L1BlockInfoEcotone, L1BlockInfoIsthmus, L1BlockInfoTx,
@@ -17,7 +17,7 @@ pub fn starts_with_2718_deposit<B>(value: &B) -> bool
 where
     B: AsRef<[u8]>,
 {
-    value.as_ref().first() == Some(&0x7E)
+    value.as_ref().first() == Some(&(OpTxType::Deposit as u8))
 }
 
 /// Returns if the given `value` is a [`TxType::Eip7702`] transaction.


### PR DESCRIPTION
### Description

Removes magic deposit tx identifier bytes (`0x7E`) in favor of the strongly typed `op_alloy_consensus::OpTxType::Deposit` variant.