### PR TITLE
chore(cli): Refactors Backtrace Init

### DIFF
--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -14,12 +14,7 @@ fn main() {
     use clap::Parser;
 
     kona_cli::sigsegv_handler::install();
-
-    // Enable backtraces unless a RUST_BACKTRACE value has already been explicitly provided.
-    if std::env::var_os("RUST_BACKTRACE").is_none() {
-        // We accept the risk that another process may set RUST_BACKTRACE at the same time.
-        unsafe { std::env::set_var("RUST_BACKTRACE", "1") };
-    }
+    kona_cli::backtrace::enable();
 
     if let Err(err) = cli::Cli::parse().run() {
         eprintln!("Error: {err:?}");

--- a/crates/utilities/cli/src/backtrace.rs
+++ b/crates/utilities/cli/src/backtrace.rs
@@ -1,0 +1,10 @@
+//! Helper to set the backtrace env var.
+
+/// Sets the RUST_BACKTRACE environment variable to 1 if it is not already set.
+pub fn enable() {
+    // Enable backtraces unless a RUST_BACKTRACE value has already been explicitly provided.
+    if std::env::var_os("RUST_BACKTRACE").is_none() {
+        // We accept the risk that another process may set RUST_BACKTRACE at the same time.
+        unsafe { std::env::set_var("RUST_BACKTRACE", "1") };
+    }
+}

--- a/crates/utilities/cli/src/lib.rs
+++ b/crates/utilities/cli/src/lib.rs
@@ -8,6 +8,8 @@
 mod clap;
 pub use clap::cli_styles;
 
+pub mod backtrace;
+
 mod tracing;
 pub use tracing::init_tracing_subscriber;
 


### PR DESCRIPTION
### Description

Micro PR to move backtrace initialization into `kona_cli` to simplify the binaries.

Part of a larger effort to simplify binary entrypoints.