### PR TITLE
docs: fx incorrect link reference for MSRV section

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 <p align="center">
   <a href="#whats-kona">What's Kona?</a> •
   <a href="#overview">Overview</a> •
-  <a href="#overview">MSRV</a> •
+  <a href="#msrv">MSRV</a> •
   <a href="https://op-rs.github.io/kona/CONTRIBUTING.html">Contributing</a> •
   <a href="#credits">Credits</a> •
   <a href="#license">License</a>


### PR DESCRIPTION
Hello, team!

I noticed that the link for "MSRV" was pointing to the "Overview" section instead of its intended target.
I’ve updated the link to correctly point to the "MSRV" section by changing the href to `#msrv`.

Thanks!