### PR TITLE
chore(node/p2p): Cleanup Network Driver

### DIFF
--- a/bin/node/src/commands/net.rs
+++ b/bin/node/src/commands/net.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 use kona_p2p::{Config, NetRpcRequest, NetworkBuilder, NetworkRpc};
 use kona_rpc::{OpP2PApiServer, RpcConfig};
 use std::net::SocketAddr;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 /// The `net` Subcommand
 ///

--- a/bin/node/src/commands/net.rs
+++ b/bin/node/src/commands/net.rs
@@ -2,7 +2,7 @@
 
 use crate::flags::{GlobalArgs, P2PArgs, RpcArgs};
 use clap::Parser;
-use kona_p2p::{Config, NetworkBuilder, NetworkRpc};
+use kona_p2p::{Config, NetRpcRequest, NetworkBuilder, NetworkRpc};
 use kona_rpc::{OpP2PApiServer, RpcConfig};
 use std::net::SocketAddr;
 use tracing::{info, warn};
@@ -35,7 +35,7 @@ impl NetCommand {
 
         // Setup the RPC server with the P2P RPC Module
         let (tx, rx) = tokio::sync::mpsc::channel(1024);
-        let p2p_module = NetworkRpc::new(tx).into_rpc();
+        let p2p_module = NetworkRpc::new(tx.clone()).into_rpc();
         let rpc_config = RpcConfig::from(&self.rpc);
         let mut launcher = rpc_config.as_launcher().merge(p2p_module)?;
         let handle = launcher.start().await?;
@@ -52,24 +52,44 @@ impl NetCommand {
         network.start()?;
         info!("Network started, receiving blocks.");
 
-        // Try to receive blocks
+        // On an interval, use the rpc tx to request stats about the p2p network.
+        let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(2));
+
         loop {
             tokio::select! {
                 block = recv.recv() => {
                     match block {
-                        Some(block) => {
-                            info!("Received unsafe block: {:?}", block);
-                        }
-                        None => {
-                            warn!("Failed to receive unsafe block");
-                        }
+                        Some(block) => info!("Received unsafe block: {:?}", block),
+                        None => debug!("Failed to receive unsafe block"),
                     }
+                }
+                _ = interval.tick() => {
+                    let (otx, mut orx) = tokio::sync::oneshot::channel();
+                    if let Err(e) = tx.send(NetRpcRequest::PeerCount(otx)).await {
+                        warn!("Failed to send network rpc request: {:?}", e);
+                        continue;
+                    }
+                    tokio::time::timeout(tokio::time::Duration::from_secs(5), async move {
+                        loop {
+                            match orx.try_recv() {
+                                Ok((d, g)) => {
+                                    let d = d.unwrap_or_default();
+                                    info!("Peer counts: Discovery={} | Swarm={}", d, g);
+                                }
+                                Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {
+                                    /* Keep trying to receive */
+                                }
+                                Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+                                    break;
+                                }
+                            }
+                        }
+                    }).await.unwrap();
                 }
                 _ = handle.clone().stopped() => {
                     warn!("RPC server stopped");
                     return Ok(());
                 }
-
             }
         }
     }

--- a/crates/node/p2p/src/discv5/handler.rs
+++ b/crates/node/p2p/src/discv5/handler.rs
@@ -98,11 +98,15 @@ impl Discv5Handler {
         }
     }
 
-    /// Returns the number of connected peers.
-    pub async fn peers(&mut self) -> Option<usize> {
-        let _ = self.sender.send(HandlerRequest::PeerCount).await;
-        match self.receiver.recv().await {
-            Some(HandlerResponse::PeerCount(count)) => Some(count),
+    /// Non-blocking request for the discovery service peer count.
+    ///
+    /// Returns `None` if the request could not be sent or received.
+    pub fn peers(&mut self) -> Option<usize> {
+        if self.sender.try_send(HandlerRequest::PeerCount).is_err() {
+            return None;
+        }
+        match self.receiver.try_recv() {
+            Ok(HandlerResponse::PeerCount(count)) => Some(count),
             _ => None,
         }
     }

--- a/crates/node/p2p/src/rpc/request.rs
+++ b/crates/node/p2p/src/rpc/request.rs
@@ -8,4 +8,8 @@ use tokio::sync::oneshot::Sender;
 pub enum NetRpcRequest {
     /// Returns [`PeerInfo`] for the [`crate::Network`].
     PeerInfo(Sender<PeerInfo>),
+    /// Returns the current peer count for both the
+    /// - Discovery Service ([`crate::Discv5Driver`])
+    /// - Gossip Service ([`crate::GossipDriver`])
+    PeerCount(Sender<(Option<usize>, usize)>),
 }

--- a/examples/discovery/src/main.rs
+++ b/examples/discovery/src/main.rs
@@ -77,7 +77,7 @@ impl DiscCommand {
                 _ = interval.tick() => {
                     let metrics = handler.metrics().await;
                     tracing::info!("Discovery metrics: {:?}", metrics);
-                    let peers = handler.peers().await;
+                    let peers = handler.peers();
                     tracing::info!("Discovery peer count: {:?}", peers);
                 }
             }


### PR DESCRIPTION
### Description

Cleans up the network driver to remove the logs on an interval.

Allows the downstream user to request stats through the RPC channel instead of always logging on an interval, hurting perf.

Since this is an exposed mpsc, we should really move away from calling it an RPC channel since it's open to any external request and is used as such.