### PR TITLE
fix(node/p2p): OP Stack ENRs

### DIFF
--- a/crates/node/p2p/src/peers/store.rs
+++ b/crates/node/p2p/src/peers/store.rs
@@ -59,6 +59,15 @@ impl BootStore {
         }
     }
 
+    /// Returns the number of peers in the bootstore that
+    /// have the [`crate::OpStackEnr::OP_CL_KEY`] in the ENR.
+    pub fn valid_peers(&self) -> Vec<&Enr> {
+        self.peers
+            .iter()
+            .filter(|enr| enr.get_raw_rlp(crate::OpStackEnr::OP_CL_KEY.as_bytes()).is_some())
+            .collect()
+    }
+
     /// Returns the number of peers in the in-memory store.
     pub fn len(&self) -> usize {
         self.peers.len()


### PR DESCRIPTION
### Overview

Fixes `kona-p2p` to bootstrap the discv5 table with ENRs that contain the OP Stack CL ENR key.

### Description

Previously, we were populating the table with any enr found and recorded in the bootstore.
Quickly, as the bootstore filled up, we hit a limit on the number of ENRs that could be added to the discv5 table.
We essentially had no priority in which ENRs to place in the discovery table.

This PR filters out ENRs in the bootstore that do not contain op stack keys so the discv5 table is only initially populated with:
- Bootnodes, hardcoded into `kona-p2p`
- ENRs in the bootstore that have the op stack CL key

Bootstrapping now effectively ignores ENRs in the bootstore that do not have the op stack CL key.