### PR TITLE
fix(node/p2p): Unsafe Payload Sending

### DIFF
--- a/bin/node/src/commands/net.rs
+++ b/bin/node/src/commands/net.rs
@@ -46,8 +46,7 @@ impl NetCommand {
             .with_chain_id(args.l2_chain_id)
             .with_rpc_receiver(rx)
             .build()?;
-        let mut recv =
-            network.take_unsafe_block_recv().ok_or(anyhow::anyhow!("No unsafe block receiver"))?;
+        let mut recv = network.unsafe_block_recv();
         network.start()?;
         info!("Network started, receiving blocks.");
 
@@ -58,8 +57,8 @@ impl NetCommand {
             tokio::select! {
                 payload = recv.recv() => {
                     match payload {
-                        Some(payload) => info!("Received unsafe payload: {:?}", payload.payload_hash),
-                        None => debug!("Failed to receive unsafe payload"),
+                        Ok(payload) => info!("Received unsafe payload: {:?}", payload.payload_hash),
+                        Err(e) => debug!("Failed to receive unsafe payload: {:?}", e),
                     }
                 }
                 _ = interval.tick() => {

--- a/crates/node/p2p/src/gossip/behaviour.rs
+++ b/crates/node/p2p/src/gossip/behaviour.rs
@@ -94,7 +94,7 @@ mod tests {
     fn test_behaviour_with_handlers() {
         let cfg = config::default_config();
         let (_, recv) = tokio::sync::watch::channel(Address::default());
-        let (block_handler, _) = BlockHandler::new(0, recv);
+        let block_handler = BlockHandler::new(0, recv);
         let handlers: Vec<Box<dyn Handler>> = vec![Box::new(block_handler)];
         let behaviour = Behaviour::new(cfg, &handlers).unwrap();
         let mut topics = behaviour.gossipsub.topics().cloned().collect::<Vec<TopicHash>>();

--- a/crates/node/p2p/src/gossip/builder.rs
+++ b/crates/node/p2p/src/gossip/builder.rs
@@ -71,7 +71,7 @@ impl GossipDriverBuilder {
         let signer_recv = self.signer.ok_or(GossipDriverBuilderError::MissingUnsafeBlockSigner)?;
 
         // Block Handler setup
-        let (handler, unsafe_block_recv) = BlockHandler::new(chain_id, signer_recv);
+        let handler = BlockHandler::new(chain_id, signer_recv);
 
         // Construct the gossip behaviour
         let config = crate::default_config();
@@ -95,8 +95,6 @@ impl GossipDriverBuilder {
             .with_swarm_config(|c| c.with_idle_connection_timeout(timeout))
             .build();
 
-        let mut driver = GossipDriver::new(swarm, addr, handler.clone());
-        driver.set_payload_receiver(unsafe_block_recv);
-        Ok(driver)
+        Ok(GossipDriver::new(swarm, addr, handler.clone()))
     }
 }

--- a/crates/node/p2p/tests/common/mod.rs
+++ b/crates/node/p2p/tests/common/mod.rs
@@ -19,7 +19,7 @@ pub fn gossip_driver(port: u16) -> GossipDriver {
     // Construct a Behaviour instance
     let unsafe_block_signer = Address::default();
     let (_, unsafe_block_signer_recv) = tokio::sync::watch::channel(unsafe_block_signer);
-    let (handler, _unsafe_block_recv) = BlockHandler::new(chain_id, unsafe_block_signer_recv);
+    let handler = BlockHandler::new(chain_id, unsafe_block_signer_recv);
     let behaviour =
         Behaviour::new(config, &[Box::new(handler.clone())]).expect("creates behaviour");
 

--- a/examples/gossip/src/main.rs
+++ b/examples/gossip/src/main.rs
@@ -74,17 +74,16 @@ impl GossipCommand {
             .with_unsafe_block_signer(signer)
             .build()?;
 
-        let mut recv =
-            network.take_unsafe_block_recv().ok_or(anyhow::anyhow!("No unsafe block receiver"))?;
+        let mut recv = network.unsafe_block_recv();
         network.start()?;
         tracing::info!("Gossip driver started, receiving blocks.");
         loop {
             match recv.recv().await {
-                Some(block) => {
+                Ok(block) => {
                     tracing::info!("Received unsafe block: {:?}", block);
                 }
-                None => {
-                    tracing::warn!("Failed to receive unsafe block");
+                Err(e) => {
+                    tracing::warn!("Failed to receive unsafe block: {:?}", e);
                 }
             }
         }


### PR DESCRIPTION
### Description

Fixes unsafe payload sending in kona's P2P stack by using a queue at the top-level.

This splits the fallible block sending logic out of the `BlockHandler`, letting the block handling solely perform validation.

Closes #1365.