### PR TITLE
chore(bin/node): Allow subcommands to customize telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8649,9 +8649,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
 dependencies = [
  "memchr",
 ]

--- a/bin/node/src/commands/net.rs
+++ b/bin/node/src/commands/net.rs
@@ -27,6 +27,16 @@ pub struct NetCommand {
 }
 
 impl NetCommand {
+    /// Initializes the telemetry stack and Prometheus metrics recorder.
+    pub fn init_telemetry(&self, args: &GlobalArgs) -> anyhow::Result<()> {
+        // Filter out discovery warnings since they're very very noisy.
+        let filter = tracing_subscriber::EnvFilter::from_default_env()
+            .add_directive("discv5=error".parse()?);
+
+        // Initialize the telemetry stack.
+        args.init_telemetry(Some(filter))
+    }
+
     /// Run the Net subcommand.
     pub async fn run(self, args: &GlobalArgs) -> anyhow::Result<()> {
         let signer = args.genesis_signer()?;

--- a/bin/node/src/commands/node.rs
+++ b/bin/node/src/commands/node.rs
@@ -61,6 +61,11 @@ pub struct NodeCommand {
 }
 
 impl NodeCommand {
+    /// Initializes the telemetry stack and Prometheus metrics recorder.
+    pub fn init_telemetry(&self, args: &GlobalArgs) -> anyhow::Result<()> {
+        args.init_telemetry(None)
+    }
+
     /// Run the Node subcommand.
     pub async fn run(self, args: &GlobalArgs) -> anyhow::Result<()> {
         let cfg = self.get_l2_config(args)?;

--- a/bin/node/src/flags/globals.rs
+++ b/bin/node/src/flags/globals.rs
@@ -2,7 +2,9 @@
 
 use alloy_primitives::Address;
 use clap::{ArgAction, Parser};
+use kona_cli::{init_prometheus_server, init_tracing_subscriber};
 use kona_registry::OPCHAINS;
+use tracing_subscriber::EnvFilter;
 
 /// Global arguments for the CLI.
 #[derive(Parser, Default, Clone, Debug)]
@@ -31,6 +33,15 @@ impl GlobalArgs {
             .get(&id)
             .ok_or(anyhow::anyhow!("No chain config found for chain ID: {id}"))?
             .block_time)
+    }
+
+    /// Initialize the tracing stack and Prometheus metrics recorder.
+    ///
+    /// This function should be called at the beginning of the program.
+    pub fn init_telemetry(&self, filter: Option<EnvFilter>) -> anyhow::Result<()> {
+        init_tracing_subscriber(self.v, filter)?;
+        init_prometheus_server(self.metrics_port)?;
+        Ok(())
     }
 
     /// Returns the signer [`Address`] from the rollup config for the given l2 chain id.

--- a/crates/node/p2p/src/gossip/config.rs
+++ b/crates/node/p2p/src/gossip/config.rs
@@ -85,6 +85,7 @@ pub fn default_config_builder() -> ConfigBuilder {
         .history_length(12)
         .history_gossip(3)
         .flood_publish(false)
+        .support_floodsub()
         .max_transmit_size(MAX_GOSSIP_SIZE)
         .duplicate_cache_time(Duration::from_secs(120))
         .validation_mode(libp2p::gossipsub::ValidationMode::None)


### PR DESCRIPTION
### Description

Allows subcommands to configure telemetry how they wish but enforces that telemetry is setup.