### PR TITLE
chore(node/service): The RPC Launcher is Used

### DIFF
--- a/crates/node/service/src/service/standard/node.rs
+++ b/crates/node/service/src/service/standard/node.rs
@@ -44,7 +44,6 @@ pub struct RollupNode {
     /// TODO: Place L2 Engine API client here once it's ready.
     pub(crate) _l2_engine: (),
     /// The [`RpcLauncher`] for the node.
-    #[allow(unused)]
     pub(crate) rpc_launcher: RpcLauncher,
     /// The P2P [`Config`] for the node.
     pub(crate) p2p_config: Option<Config>,


### PR DESCRIPTION
### Description

Removes the `#[allow(unused)]` attribute since the rpc launcher is used.