### PR TITLE
feat(docker): Reproducible `cannon` prestate

### DIFF
--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -29,6 +29,19 @@ variable "ASTERISC_TAG" {
   default = "v1.2.0"
 }
 
+variable "CANNON_TAG" {
+  // The tag of `cannon` to use in the `kona-cannon-prestate` target.
+  //
+  // You can override this if you'd like to use a different tag to generate the prestate.
+  // https://github.com/ethereum-optimism/optimism/releases
+  //
+  // NOTE: This version of cannon will not run `kona-client`. This is just a stub tag.
+  // https://github.com/ethereum-optimism/optimism/pull/14454 must be merged and included
+  // in order for `kona-client` to run on cannon. Once this tag is updated to a version that
+  // does support kona, remove this comment.
+  default = "cannon/v1.4.0"
+}
+
 // Special target: https://github.com/docker/metadata-action#bake-definition
 target "docker-metadata-action" {
   tags = ["${DEFAULT_TAG}"]
@@ -65,6 +78,18 @@ target "kona-asterisc-prestate" {
   args = {
     CLIENT_TAG = "${GIT_REF_NAME}"
     ASTERISC_TAG = "${ASTERISC_TAG}"
+  }
+  # Only build on linux/amd64 for reproducibility.
+  platforms = ["linux/amd64"]
+}
+
+target "kona-cannon-prestate" {
+  inherits = ["docker-metadata-action"]
+  context = "."
+  dockerfile = "docker/fpvm-prestates/cannon-repro.dockerfile"
+  args = {
+    CLIENT_TAG = "${GIT_REF_NAME}"
+    CANNON_TAG = "${CANNON_TAG}"
   }
   # Only build on linux/amd64 for reproducibility.
   platforms = ["linux/amd64"]

--- a/docker/fpvm-prestates/README.md
+++ b/docker/fpvm-prestates/README.md
@@ -10,3 +10,10 @@ Images for creating reproducible prestate builds for various fault proof virtual
 # Produce the prestate artifacts for `kona-client` running on `asterisc` (version specified by `asterisc_tag`)
 just asterisc <kona_tag> <asterisc_tag>
 ```
+
+### `kona-client` + `cannon` prestate artifacts
+
+```sh
+# Produce the prestate artifacts for `kona-client` running on `cannon` (version specified by `cannon_tag`)
+just cannon <kona_tag> <cannon_tag>
+```

--- a/docker/fpvm-prestates/cannon-repro.dockerfile
+++ b/docker/fpvm-prestates/cannon-repro.dockerfile
@@ -1,0 +1,95 @@
+################################################################
+#                  Build Cannon @ `CANNON_TAG`                 #
+################################################################
+
+FROM ubuntu:22.04 AS cannon-build
+SHELL ["/bin/bash", "-c"]
+
+ARG TARGETARCH
+ARG CANNON_TAG
+
+# Install deps
+RUN apt-get update && apt-get install -y --no-install-recommends git curl ca-certificates make
+
+ENV GO_VERSION=1.22.7
+
+# Fetch go manually, rather than using a Go base image, so we can copy the installation into the final stage
+RUN curl -sL https://go.dev/dl/go$GO_VERSION.linux-$TARGETARCH.tar.gz -o go$GO_VERSION.linux-$TARGETARCH.tar.gz && \
+  tar -C /usr/local/ -xzf go$GO_VERSION.linux-$TARGETARCH.tar.gz
+ENV GOPATH=/go
+ENV PATH=/usr/local/go/bin:$GOPATH/bin:$PATH
+
+# Clone and build Cannon @ `CANNON_TAG`
+RUN git clone https://github.com/ethereum-optimism/optimism && \
+  cd optimism/cannon && \
+  git checkout $CANNON_TAG && \
+  make && \
+  cp bin/cannon /cannon-bin
+
+################################################################
+#               Build kona-client @ `CLIENT_TAG`               #
+################################################################
+
+FROM ghcr.io/op-rs/kona/cannon-builder:0.1.0 AS client-build
+SHELL ["/bin/bash", "-c"]
+
+ARG CLIENT_TAG
+
+# Install deps
+RUN apt-get update && apt-get install -y --no-install-recommends git
+
+# Clone kona at the specified tag
+RUN git clone https://github.com/op-rs/kona
+
+# Build kona-client on the selected tag
+RUN cd kona && \
+  git checkout $CLIENT_TAG && \
+  cargo build -Zbuild-std=core,alloc -p kona-client --bin kona --locked --profile release-client-lto && \
+  mv ./target/mips64-unknown-none/release-client-lto/kona /kona-client-elf
+
+################################################################
+#      Create `prestate.bin.gz` + `prestate-proof.json`        #
+################################################################
+
+FROM ubuntu:22.04 AS prestate-build
+SHELL ["/bin/bash", "-c"]
+
+# Set env
+ENV CANNON_BIN_PATH="/cannon"
+ENV CLIENT_BIN_PATH="/kona-client-elf"
+ENV PRESTATE_OUT_PATH="/prestate.bin.gz"
+ENV PROOF_OUT_PATH="/prestate-proof.json"
+
+# Copy cannon binary
+COPY --from=cannon-build /cannon-bin $CANNON_BIN_PATH
+
+# Copy kona-client binary
+COPY --from=client-build /kona-client-elf $CLIENT_BIN_PATH
+
+# Create `prestate.bin.gz`
+# TODO: update `--type` once cannon supports `DCLO` / `DCLZ`.
+RUN $CANNON_BIN_PATH load-elf \
+  --path=$CLIENT_BIN_PATH \
+  --out=$PRESTATE_OUT_PATH \
+  --type multithreaded64-3
+
+# Create `prestate-proof.json`
+RUN $CANNON_BIN_PATH run \
+  --proof-at "=0" \
+  --stop-at "=1" \
+  --input $PRESTATE_OUT_PATH \
+  --meta ./meta.json \
+  --proof-fmt "./%d.json" \
+  --output "" && \
+  mv 0.json $PROOF_OUT_PATH
+
+################################################################
+#                       Export Artifacts                       #
+################################################################
+
+FROM scratch AS export-stage
+
+COPY --from=prestate-build /cannon .
+COPY --from=prestate-build /kona-client-elf .
+COPY --from=prestate-build /prestate.bin.gz .
+COPY --from=prestate-build /prestate-proof.json .

--- a/docker/fpvm-prestates/justfile
+++ b/docker/fpvm-prestates/justfile
@@ -1,17 +1,26 @@
 set positional-arguments
+alias all := build-client-prestate-artifacts
+alias cannon := build-client-prestate-cannon-artifacts
 alias asterisc := build-client-prestate-asterisc-artifacts
 
 # default recipe to display help information
 default:
   @just --list
 
-# Build the `kona-client` prestate artifacts for the latest release.
+# Build the `kona-client` prestate artifacts for the specified tags (asterisc + cannon).
+build-client-prestate-artifacts kona_tag asterisc_tag cannon_tag:
+  #!/bin/bash
+  just build-client-prestate-asterisc-artifacts {{kona_tag}} {{asterisc_tag}}
+  just build-client-prestate-cannon-artifacts {{kona_tag}} {{cannon_tag}}
+
+# Build the `kona-client` prestate artifacts for the latest release (asterisc).
 build-client-prestate-asterisc-artifacts kona_tag asterisc_tag out='./prestate-artifacts-asterisc':
   #!/bin/bash
   OUTPUT_DIR={{out}}
 
   # Docker bake env
   export GIT_REF_NAME="{{kona_tag}}"
+  export ASTERISC_TAG="{{asterisc_tag}}"
   export DEFAULT_TAG="kona-asterisc-prestate:local"
 
   # Navigate to workspace root
@@ -25,3 +34,25 @@ build-client-prestate-asterisc-artifacts kona_tag asterisc_tag out='./prestate-a
     --set "*.output=$OUTPUT_DIR" \
     -f docker/docker-bake.hcl \
     kona-asterisc-prestate
+
+# Build the `kona-client` prestate artifacts for the latest release (cannon).
+build-client-prestate-cannon-artifacts kona_tag cannon_tag out='./prestate-artifacts-cannon':
+  #!/bin/bash
+  OUTPUT_DIR={{out}}
+
+  # Docker bake env
+  export GIT_REF_NAME="{{kona_tag}}"
+  export CANNON_TAG="{{cannon_tag}}"
+  export DEFAULT_TAG="kona-cannon-prestate:local"
+
+  # Navigate to workspace root
+  cd ../..
+
+  # Create the output directory
+  mkdir -p $OUTPUT_DIR
+
+  echo "Building kona-client prestate artifacts for the cannon target. 🐚 Kona Tag: {{kona_tag}} | 🔫 Cannon Tag: {{cannon_tag}}"
+  docker buildx bake \
+    --set "*.output=$OUTPUT_DIR" \
+    -f docker/docker-bake.hcl \
+    kona-cannon-prestate


### PR DESCRIPTION
## Overview

Adds a dockerfile for reproducible builds of the `cannon` prestate with `kona-client`.

Note that `cannon` does not yet support `kona`. https://github.com/ethereum-optimism/optimism/pull/14454 must be merged before this can be used. This PR just adds the route to build the artifacts, but we will need to follow up with #1388  once the new instructions are supported and a new `cannon` tag has been released.