### PR TITLE
feat(bin/node): implement peer banning

### DIFF
--- a/crates/node/p2p/src/discv5/handler.rs
+++ b/crates/node/p2p/src/discv5/handler.rs
@@ -1,7 +1,8 @@
 //! Handler to the [`discv5::Discv5`] service spawned in a thread.
 
 use discv5::{Enr, Event, metrics::Metrics};
-use std::string::String;
+use libp2p::Multiaddr;
+use std::{collections::HashSet, string::String, sync::Arc, time::Duration};
 use tokio::sync::mpsc::{Receiver, Sender};
 
 /// A request from the [`Discv5Handler`] to the spawned [`discv5::Discv5`] service.
@@ -21,6 +22,8 @@ pub enum HandlerRequest {
     LocalEnr,
     /// Requests the table ENRs.
     TableEnrs,
+    /// Bans the nodes matching the given set of [`Multiaddr`] for the given duration.
+    BanAddrs { addrs_to_ban: Arc<HashSet<Multiaddr>>, ban_duration: Duration },
 }
 
 /// A response from the spawned [`discv5::Discv5`] service thread to the [`Discv5Handler`].

--- a/crates/node/p2p/src/gossip/builder.rs
+++ b/crates/node/p2p/src/gossip/builder.rs
@@ -8,7 +8,10 @@ use libp2p::{
 use std::time::Duration;
 use tokio::sync::watch::Receiver;
 
-use crate::{Behaviour, BlockHandler, GossipDriver, GossipDriverBuilderError, PeerScoreLevel};
+use crate::{
+    Behaviour, BlockHandler, GossipDriver, GossipDriverBuilderError, PeerScoreLevel,
+    peers::PeerMonitoring,
+};
 
 /// A builder for the [`GossipDriver`].
 #[derive(Debug, Default)]
@@ -29,6 +32,9 @@ pub struct GossipDriverBuilder {
     config: Option<Config>,
     /// Sets the block time for the peer scoring.
     block_time: Option<u64>,
+    /// If set, the gossip layer will monitor peer scores and ban peers that are below a given
+    /// threshold.
+    peer_monitoring: Option<PeerMonitoring>,
 }
 
 impl GossipDriverBuilder {
@@ -43,6 +49,7 @@ impl GossipDriverBuilder {
             scoring: None,
             config: None,
             block_time: None,
+            peer_monitoring: None,
         }
     }
 
@@ -61,6 +68,12 @@ impl GossipDriverBuilder {
     /// Sets the [`PeerScoreLevel`] for the [`Behaviour`].
     pub fn with_peer_scoring(mut self, level: PeerScoreLevel) -> Self {
         self.scoring = Some(level);
+        self
+    }
+
+    /// Sets the [`PeerMonitoring`] configuration for the gossip driver.
+    pub fn with_peer_monitoring(mut self, peer_monitoring: Option<PeerMonitoring>) -> Self {
+        self.peer_monitoring = peer_monitoring;
         self
     }
 

--- a/crates/node/p2p/src/gossip/driver.rs
+++ b/crates/node/p2p/src/gossip/driver.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 
 use crate::{
     Behaviour, BlockHandler, Event, GossipDriverBuilder, Handler, OpStackEnr, PublishError,
-    enr_to_multiaddr,
+    enr_to_multiaddr, peers::PeerMonitoring,
 };
 
 /// A driver for a [`Swarm`] instance.
@@ -33,6 +33,9 @@ pub struct GossipDriver {
     pub dialed_peers: HashMap<Multiaddr, bool>,
     /// A mapping from [`PeerId`] to [`Multiaddr`].
     pub peerstore: HashMap<PeerId, Multiaddr>,
+    /// If set, the gossip layer will monitor peer scores and ban peers that are below a given
+    /// threshold.
+    pub peer_monitoring: Option<PeerMonitoring>,
 }
 
 impl GossipDriver {
@@ -49,6 +52,7 @@ impl GossipDriver {
             handler,
             dialed_peers: Default::default(),
             peerstore: Default::default(),
+            peer_monitoring: None,
         }
     }
 

--- a/crates/node/p2p/src/gossip/handler.rs
+++ b/crates/node/p2p/src/gossip/handler.rs
@@ -54,7 +54,7 @@ impl Handler for BlockHandler {
             OpNetworkPayloadEnvelope::decode_v4(&msg.data)
         } else {
             warn!("Received block with unknown topic: {:?}", msg.topic);
-            return (MessageAcceptance::Reject, None)
+            return (MessageAcceptance::Reject, None);
         };
 
         match decoded {

--- a/crates/node/p2p/src/lib.rs
+++ b/crates/node/p2p/src/lib.rs
@@ -28,7 +28,7 @@ pub use gossip::{
 mod peers;
 pub use peers::{
     AnyNode, BootNode, BootNodes, BootStore, NodeRecord, NodeRecordParseError, OP_RAW_BOOTNODES,
-    OP_RAW_TESTNET_BOOTNODES, OpStackEnr, PeerId, PeerScoreLevel, enr_to_multiaddr,
+    OP_RAW_TESTNET_BOOTNODES, OpStackEnr, PeerId, PeerMonitoring, PeerScoreLevel, enr_to_multiaddr,
 };
 
 mod discv5;

--- a/crates/node/p2p/src/net/builder.rs
+++ b/crates/node/p2p/src/net/builder.rs
@@ -10,7 +10,7 @@ use tokio::sync::broadcast::Sender as BroadcastSender;
 
 use crate::{
     Config, Discv5Builder, GossipDriverBuilder, NetRpcRequest, Network, NetworkBuilderError,
-    PeerScoreLevel,
+    PeerMonitoring, PeerScoreLevel,
 };
 
 /// Constructs a [`Network`] for the OP Stack Consensus Layer.
@@ -67,6 +67,10 @@ impl NetworkBuilder {
     /// Sets the peer scoring based on the given [`PeerScoreLevel`].
     pub fn with_peer_scoring(self, level: PeerScoreLevel) -> Self {
         Self { gossip: self.gossip.with_peer_scoring(level), ..self }
+    }
+
+    pub fn with_peer_monitoring(self, peer_monitoring: Option<PeerMonitoring>) -> Self {
+        Self { gossip: self.gossip.with_peer_monitoring(peer_monitoring), ..self }
     }
 
     /// Sets the address for the [`crate::Discv5Driver`].

--- a/crates/node/p2p/src/net/config.rs
+++ b/crates/node/p2p/src/net/config.rs
@@ -1,6 +1,6 @@
 //! Configuration for the `Network`.
 
-use crate::PeerScoreLevel;
+use crate::{PeerScoreLevel, peers::PeerMonitoring};
 use alloy_primitives::Address;
 use libp2p::identity::Keypair;
 use std::net::SocketAddr;
@@ -20,6 +20,8 @@ pub struct Config {
     pub gossip_config: libp2p::gossipsub::Config,
     /// The peer score level.
     pub scoring: PeerScoreLevel,
+    /// Peer score monitoring config.
+    pub monitor_peers: Option<PeerMonitoring>,
     /// The L2 Block Time.
     pub block_time: u64,
 }

--- a/crates/node/p2p/src/peers/mod.rs
+++ b/crates/node/p2p/src/peers/mod.rs
@@ -62,3 +62,6 @@ pub use record::{NodeRecord, NodeRecordParseError};
 
 mod utils;
 pub use utils::enr_to_multiaddr;
+
+mod monitoring;
+pub use monitoring::PeerMonitoring;

--- a/crates/node/p2p/src/peers/monitoring.rs
+++ b/crates/node/p2p/src/peers/monitoring.rs
@@ -1,0 +1,12 @@
+//! Specifies peer monitoring configuration.
+
+use std::time::Duration;
+
+/// Specifies how to monitor peer scores and ban poorly performing peers.
+#[derive(Debug, Clone)]
+pub struct PeerMonitoring {
+    /// The threshold under which a peer should be banned.
+    pub ban_threshold: f64,
+    /// The duration of a peer's ban.
+    pub ban_duration: Duration,
+}

--- a/crates/node/p2p/src/peers/record.rs
+++ b/crates/node/p2p/src/peers/record.rs
@@ -40,7 +40,7 @@ impl NodeRecord {
         if let IpAddr::V6(v6) = self.address {
             if let Some(v4) = v6.to_ipv4_mapped() {
                 self.address = v4.into();
-                return true
+                return true;
             }
         }
         false

--- a/crates/node/p2p/src/peers/utils.rs
+++ b/crates/node/p2p/src/peers/utils.rs
@@ -13,7 +13,7 @@ pub fn enr_to_multiaddr(enr: &Enr) -> Option<Multiaddr> {
     if let Some(socket) = enr.tcp6_socket() {
         let mut addr = Multiaddr::from(*socket.ip());
         addr.push(Protocol::Tcp(socket.port()));
-        return Some(addr)
+        return Some(addr);
     }
     None
 }

--- a/crates/proof/executor/src/syscalls/eip2935.rs
+++ b/crates/proof/executor/src/syscalls/eip2935.rs
@@ -82,7 +82,7 @@ where
     // If the block number is zero (genesis block) then no system
     // transaction may occur as per EIP-2935.
     if block_number == 0 {
-        return Ok(())
+        return Ok(());
     }
 
     // Get the previous environment

--- a/crates/protocol/derive/src/stages/batch/batch_stream.rs
+++ b/crates/protocol/derive/src/stages/batch/batch_stream.rs
@@ -170,7 +170,7 @@ where
                             return Err(PipelineError::NotEnoughData.temp());
                         }
                         BatchValidity::Undecided | BatchValidity::Future => {
-                            return Err(PipelineError::NotEnoughData.temp())
+                            return Err(PipelineError::NotEnoughData.temp());
                         }
                     }
                 }

--- a/crates/protocol/driver/src/pipeline.rs
+++ b/crates/protocol/driver/src/pipeline.rs
@@ -46,7 +46,7 @@ where
                     match e {
                         PipelineErrorKind::Temporary(_) => {
                             trace!(target: "client_derivation_driver", "Failed to step derivation pipeline temporarily: {:?}", e);
-                            continue
+                            continue;
                         }
                         PipelineErrorKind::Reset(e) => {
                             warn!(target: "client_derivation_driver", "Failed to step derivation pipeline due to reset: {:?}", e);
@@ -89,7 +89,7 @@ where
                         }
                         PipelineErrorKind::Critical(_) => {
                             warn!(target: "client_derivation_driver", "Failed to step derivation pipeline: {:?}", e);
-                            return Err(e)
+                            return Err(e);
                         }
                     }
                 }

--- a/crates/protocol/interop/src/errors.rs
+++ b/crates/protocol/interop/src/errors.rs
@@ -98,7 +98,7 @@ impl InvalidInboxEntry {
             if let Ok(chain_id) =
                 err_msg.split(' ').last().expect("message contains chain id").parse::<u64>()
             {
-                return Some(Self::UnknownChain(chain_id))
+                return Some(Self::UnknownChain(chain_id));
             }
         // Check if it's `does not meet the minimum safety` error, message example:
         // `message {0x4200000000000000000000000000000000000023 4 1 1728507701 901}
@@ -116,7 +116,7 @@ impl InvalidInboxEntry {
                 SafetyLevel::Invalid
             } else {
                 // Unexpected level name
-                return None
+                return None;
             };
             let expected_safety = if err_msg.contains("safety finalized") {
                 SafetyLevel::Finalized
@@ -130,10 +130,10 @@ impl InvalidInboxEntry {
                 SafetyLevel::Unsafe
             } else {
                 // Unexpected level name
-                return None
+                return None;
             };
 
-            return Some(Self::MinimumSafety { expected: expected_safety, got: message_safety })
+            return Some(Self::MinimumSafety { expected: expected_safety, got: message_safety });
         }
 
         None

--- a/crates/protocol/protocol/src/batch/transactions.rs
+++ b/crates/protocol/protocol/src/batch/transactions.rs
@@ -311,7 +311,7 @@ impl SpanBatchTransactions {
                     (sig, tx.to(), tx.nonce(), tx.gas_limit(), tx.chain_id())
                 }
                 _ => {
-                    return Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData))
+                    return Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData));
                 }
             };
 

--- a/crates/utilities/cli/src/sigsegv_handler.rs
+++ b/crates/utilities/cli/src/sigsegv_handler.rs
@@ -47,7 +47,7 @@ extern "C" fn print_stack_trace(_: libc::c_int) {
         // Collect return addresses
         let depth = libc::backtrace(stack_trace.as_mut_ptr(), MAX_FRAMES as i32);
         if depth == 0 {
-            return
+            return;
         }
         &stack_trace[0..depth as usize]
     };
@@ -65,7 +65,7 @@ extern "C" fn print_stack_trace(_: libc::c_int) {
         let period = period.saturating_add(1); // avoid "what if wrapped?" branches
         let Some(offset) = stack.iter().skip(period).zip(stack).position(cycled) else {
             // impossible.
-            return
+            return;
         };
 
         // Count matching trace slices, else we could miscount "biphasic cycles"


### PR DESCRIPTION
## Description
Allows nodes to ban poorly performing peers, similarly to https://github.com/ethereum-optimism/optimism/blob/b4070c5244c8c7ba6d37b9e31fa7d43ada25070d/op-node/flags/p2p_flags.go#L20C2-L26.

This PR:
- Adds CLI flags to allow banning nodes, specify a banning threshold and a banning duration
- Incorporates the P2P flag configuration to the gossip config/driver
- Adds banning logic to the network thread. Ban checks happen every 1 sec by default.

To ban peers on the network thread we:
- Scan the gossip layer for poorly performing peers
- Remove the peers from the gossip layer
- Scan the gossip layer and detect peers to ban. Ban the peers for a given duration.

If merged, this PR completes #1371 

Small note: I have ran clippy so there might be some semi-colons added to unrelated parts of the code. That is minor, can rebase if that's an issue