### PR TITLE
fix(node/service): Error Bubbling and Shutdown

### DIFF
--- a/crates/node/service/src/actors/traits.rs
+++ b/crates/node/service/src/actors/traits.rs
@@ -13,7 +13,7 @@ pub trait NodeActor {
     /// The event type received by the actor.
     type InboundEvent;
     /// The error type for the actor.
-    type Error;
+    type Error: std::fmt::Debug;
 
     /// Starts the actor.
     async fn start(self) -> Result<(), Self::Error>;

--- a/crates/node/service/src/service/util.rs
+++ b/crates/node/service/src/service/util.rs
@@ -17,19 +17,28 @@ macro_rules! spawn_and_wait {
             if let Some(actor) = $actor {
                 task_handles.spawn(async move {
                     if let Err(e) = actor.start().await {
-                        // TODO: Bubble up generic error.
-                        tracing::error!(target: "rollup_node", "{e}");
+                        return Err(format!("{e:?}"));
                     }
+                    Ok(())
                 });
             }
         )*
 
         while let Some(result) = task_handles.join_next().await {
-            if let Err(e) = result {
-                tracing::error!(target: "rollup_node", "Critical error in sub-routine: {e}");
-
-                // Cancel all tasks and gracefully shutdown.
-                $cancellation.cancel();
+            match result {
+                Ok(Ok(())) => {
+                    tracing::info!(target: "rollup_node", "Actor finished.");
+                }
+                Ok(Err(e)) => {
+                    tracing::error!(target: "rollup_node", "Critical error in sub-routine: {e}");
+                    // Cancel all tasks and gracefully shutdown.
+                    $cancellation.cancel();
+                }
+                Err(e) => {
+                    tracing::error!(target: "rollup_node", "Task join error: {e}");
+                    // Cancel all tasks and gracefully shutdown.
+                    $cancellation.cancel();
+                }
             }
         }
     };

--- a/crates/node/service/src/service/validator.rs
+++ b/crates/node/service/src/service/validator.rs
@@ -58,7 +58,7 @@ pub trait ValidatorNodeService {
     /// The type of derivation pipeline to use for the service.
     type DerivationPipeline: Pipeline + SignalReceiver + Send + Sync + 'static;
     /// The type of error for the service's entrypoint.
-    type Error: From<RpcLauncherError> + From<EngineStateBuilderError>;
+    type Error: From<RpcLauncherError> + From<EngineStateBuilderError> + std::fmt::Debug;
 
     /// Returns a reference to the rollup node's [`RollupConfig`].
     fn config(&self) -> &RollupConfig;


### PR DESCRIPTION
### Description

Previously, the `spawn_and_wait` macro was just ignoring if the actor's start method returned an error since the return object was wrapped in a `JoinTask` result.

This PR fixes the macro to correctly shutdown the node on actor startup error as well as bubbling up the error via its `std::fmt::Debug` impl (not the strongest typing but it allows the `NodeActor` and `ValidatorNodeService` error types to be generic with the only restriction of implementing `std::fmt::Debug`).

Closes #1394.