### PR TITLE
chore(bin/node): In-use Port Erroring

### DIFF
--- a/bin/node/src/commands/net.rs
+++ b/bin/node/src/commands/net.rs
@@ -56,6 +56,7 @@ impl NetCommand {
             .ok_or(anyhow::anyhow!("Rollug config not found for chain id: {}", args.l2_chain_id))?;
 
         // Start the Network Stack
+        self.p2p.check_ports()?;
         let p2p_config = self.p2p.config(args)?;
         let mut network = NetworkBuilder::from(p2p_config)
             .with_chain_id(args.l2_chain_id)

--- a/bin/node/src/commands/node.rs
+++ b/bin/node/src/commands/node.rs
@@ -78,6 +78,7 @@ impl NodeCommand {
             supports_post_finalization_elsync: kind.supports_post_finalization_elsync(),
         };
 
+        self.p2p_flags.check_ports()?;
         let p2p_config = self.p2p_flags.config(args)?;
         let rpc_config = self.rpc_flags.into();
 


### PR DESCRIPTION
### Description

Networking crates do a really bad job at providing a useful error message for simple errors like ports already in use.

This PR adds a small check to the node binary to make it really user friendly if a port is used that's already in use.