### PR TITLE
chore(bin/node): add jwt startup check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4076,6 +4076,7 @@ dependencies = [
  "kona-registry",
  "kona-rpc",
  "libp2p",
+ "op-alloy-provider",
  "serde_json",
  "tabled",
  "tokio",

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -25,6 +25,9 @@ kona-rpc = { workspace = true, features = ["std"] }
 alloy-primitives.workspace = true
 alloy-rpc-types-engine = { workspace = true, features = ["jwt", "serde"] }
 
+# op-alloy
+op-alloy-provider.workspace = true
+
 # general
 url.workspace = true
 tabled.workspace = true

--- a/bin/node/src/commands/node.rs
+++ b/bin/node/src/commands/node.rs
@@ -6,9 +6,10 @@ use clap::Parser;
 use kona_engine::{EngineKind, SyncConfig, SyncMode};
 use kona_genesis::RollupConfig;
 use kona_node_service::{RollupNode, RollupNodeService};
+use op_alloy_provider::ext::engine::OpEngineApi;
 use serde_json::from_reader;
 use std::{fs::File, path::PathBuf};
-use tracing::debug;
+use tracing::{debug, error};
 use url::Url;
 
 use crate::flags::{GlobalArgs, P2PArgs, RpcArgs};
@@ -65,10 +66,43 @@ impl NodeCommand {
         args.init_telemetry(None)
     }
 
+    /// Validate the jwt secret if specified by exchanging capabilities with the engine.
+    /// Since the engine client will fail if the jwt token is invalid, this allows to ensure
+    /// that the jwt token passed as a cli arg is correct.
+    pub async fn validate_jwt(&self, args: &GlobalArgs) -> anyhow::Result<JwtSecret> {
+        let jwt_secret = self.jwt_secret().ok_or(anyhow::anyhow!("Invalid JWT secret"))?;
+        let engine_client = kona_engine::EngineClient::new_http(
+            self.l2_engine_rpc.clone(),
+            self.l2_provider_rpc.clone(),
+            args.rollup_config().map(std::sync::Arc::new).ok_or(anyhow::anyhow!(
+                "Failed to get rollup config for chain id: {}",
+                args.l2_chain_id
+            ))?,
+            jwt_secret,
+        );
+        match engine_client.exchange_capabilities(vec![]).await {
+            Ok(_) => {
+                debug!("Successfully exchanged capabilities with engine");
+                Ok(jwt_secret)
+            }
+            Err(e) => {
+                if e.to_string().contains("signature invalid") {
+                    error!(
+                        "Engine API JWT secret differs from the one specified by --l2.jwt-secret"
+                    );
+                    error!(
+                        "Ensure that the JWT secret file specified is correct (by default it is `jwt.hex` in the current directory)"
+                    );
+                }
+                bail!("Failed to exchange capabilities with engine: {}", e);
+            }
+        }
+    }
+
     /// Run the Node subcommand.
     pub async fn run(self, args: &GlobalArgs) -> anyhow::Result<()> {
         let cfg = self.get_l2_config(args)?;
-        let jwt_secret = self.jwt_secret().ok_or(anyhow::anyhow!("Invalid JWT secret"))?;
+        let jwt_secret = self.validate_jwt(args).await?;
         let kind = self.l2_engine_kind;
         let sync_config = SyncConfig {
             sync_mode: SyncMode::ExecutionLayer,


### PR DESCRIPTION
## Description
Tiny PR that solves #1416. It adds a check for the validity of the l2 engine jwt *before starting the node*. This PR is merely a copy-paste of the code snippet from the issue with the associated invocation in the node startup.