### PR TITLE
chore(ci): Hide action test output

### DIFF
--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup gotestsum
         uses: autero1/action-gotestsum@v2.0.0
         with:
-          gotestsum_version: 1.12.0
+          gotestsum_version: 1.12.1
       - name: Setup yq
         uses: dcarbone/install-yq-action@v1
       - name: Extract monorepo forge version

--- a/Justfile
+++ b/Justfile
@@ -44,8 +44,10 @@ action-tests test_name='Test_ProgramAction' *args='':
   echo "Running action tests for the client program on the native target"
   export KONA_HOST_PATH="{{justfile_directory()}}/target/debug/kona-host"
 
+  # GitHub actions patch - do not print logs.
+  # https://github.com/gotestyourself/gotestsum/blob/b4b13345fee56744d80016a20b760d3599c13504/testjson/format.go#L442-L444
   cd monorepo/op-e2e/actions/proofs && \
-    gotestsum --format=testname -- -run "{{test_name}}" {{args}} -count=1 ./...
+    GITHUB_ACTIONS=false gotestsum --format=testname -- -run "{{test_name}}" {{args}} -count=1 ./...
 
 # Clean the action tests directory
 clean-actions:


### PR DESCRIPTION
## Overview

Hides test output in CI for the action tests. Recently we've been seeing quite a few flakes in CI due to the runner running out of disk space. Logs for these tests are usually between 1-1.5 gigabytes.