### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/crates/node/engine/src/attributes.rs
+++ b/crates/node/engine/src/attributes.rs
@@ -598,7 +598,7 @@ mod tests {
         assert!(check.is_mismatch());
     }
 
-    /// Checks the edge case where the the attributes array is empty.
+    /// Checks the edge case where the attributes array is empty.
     #[test]
     fn test_attributes_mismatch_empty_tx_attributes() {
         let cfg = default_rollup_config();
@@ -614,7 +614,7 @@ mod tests {
         assert!(check.is_mismatch());
     }
 
-    /// Checks the edge case where the the transactions contained in the block have the wrong
+    /// Checks the edge case where the transactions contained in the block have the wrong
     /// format.
     #[test]
     fn test_block_transactions_wrong_format() {
@@ -629,7 +629,7 @@ mod tests {
         assert!(check.is_mismatch());
     }
 
-    /// Checks the edge case where the the transactions contained in the attributes have the wrong
+    /// Checks the edge case where the transactions contained in the attributes have the wrong
     /// format.
     #[test]
     fn test_attributes_transactions_wrong_format() {

--- a/crates/node/service/src/sync_start.rs
+++ b/crates/node/service/src/sync_start.rs
@@ -359,7 +359,7 @@ fn validate_l1_origin_relationship(
     Ok(())
 }
 
-/// An unsafe, safe, and finalized [L2BlockInfo] returned by the the [find_starting_forkchoice]
+/// An unsafe, safe, and finalized [L2BlockInfo] returned by the [find_starting_forkchoice]
 /// function.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct L2ForkchoiceState {

--- a/crates/protocol/protocol/src/deposits.rs
+++ b/crates/protocol/protocol/src/deposits.rs
@@ -118,7 +118,7 @@ pub fn decode_deposit(block_hash: B256, index: usize, log: &Log) -> Result<Bytes
     // abi.encode(abi.encodPacked(uint256 mint, uint256 value, uint64 gasLimit, uint8 isCreation, bytes data))
     // ```
     //
-    // The the opaqueData will be packed as shown below:
+    // The opaqueData will be packed as shown below:
     //
     // ------------------------------------------------------------
     // | offset | 256 byte content                                |


### PR DESCRIPTION
remove redundant word in comment