### PR TITLE
bug(node/p2p): fix bootstrapping for enode addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4138,6 +4138,7 @@ dependencies = [
  "multihash",
  "op-alloy-rpc-types-engine",
  "openssl",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "snap",
@@ -6403,7 +6404,7 @@ dependencies = [
  "p256",
  "revm-primitives",
  "ripemd",
- "secp256k1",
+ "secp256k1 0.29.1",
  "sha2 0.10.8",
  "substrate-bn",
 ]
@@ -6868,6 +6869,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "rand 0.8.5",
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+dependencies = [
  "secp256k1-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,3 +198,7 @@ serde_json = { version = "1.0.140", default-features = false }
 
 # K/V database
 rocksdb = { version = "0.23.0", default-features = false }
+
+# Cryptography
+# The same library that is used by reth.
+secp256k1 = { version = "0.30", default-features = false }

--- a/crates/node/p2p/Cargo.toml
+++ b/crates/node/p2p/Cargo.toml
@@ -31,6 +31,9 @@ discv5 = { workspace = true, features = ["libp2p"] }
 libp2p = { workspace = true, features = ["macros", "tokio", "tcp", "noise", "gossipsub", "ping", "yamux"] }
 openssl = { workspace = true, features = ["vendored"] }
 
+# Cryptography
+secp256k1.workspace = true
+
 # Misc
 url.workspace = true
 dirs.workspace = true

--- a/crates/node/p2p/src/peers/utils.rs
+++ b/crates/node/p2p/src/peers/utils.rs
@@ -3,6 +3,8 @@
 use discv5::{Enr, multiaddr::Protocol};
 use libp2p::Multiaddr;
 
+use super::PeerId;
+
 /// Converts an [`Enr`] into a [`Multiaddr`].
 pub fn enr_to_multiaddr(enr: &Enr) -> Option<Multiaddr> {
     if let Some(socket) = enr.tcp4_socket() {
@@ -16,4 +18,89 @@ pub fn enr_to_multiaddr(enr: &Enr) -> Option<Multiaddr> {
         return Some(addr);
     }
     None
+}
+
+/// Converts an uncompressed [`PeerId`] to a [`secp256k1::PublicKey`] by prepending the [`PeerId`]
+/// bytes with the `SECP256K1_TAG_PUBKEY_UNCOMPRESSED` tag.
+pub fn peer_id_to_secp256k1_pubkey(id: PeerId) -> Result<secp256k1::PublicKey, secp256k1::Error> {
+    /// Tags the public key as uncompressed.
+    ///
+    /// See: <https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1.h#L211>
+    const SECP256K1_TAG_PUBKEY_UNCOMPRESSED: u8 = 4;
+
+    let mut full_pubkey = [0u8; secp256k1::constants::UNCOMPRESSED_PUBLIC_KEY_SIZE];
+    full_pubkey[0] = SECP256K1_TAG_PUBKEY_UNCOMPRESSED;
+    full_pubkey[1..].copy_from_slice(id.as_slice());
+    secp256k1::PublicKey::from_slice(&full_pubkey)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PeerIdConversionError {
+    /// The peer id is not valid and cannot be converted to a secp256k1 public key.
+    #[error("Invalid peer id: {0}")]
+    InvalidPeerId(secp256k1::Error),
+    /// The secp256k1 public key cannot be converted to a libp2p peer id. This is a bug.
+    #[error("Invalid conversion from secp256k1 public key to libp2p peer id: {0}. This is a bug.")]
+    InvalidPublicKey(#[from] discv5::libp2p_identity::DecodingError),
+}
+
+/// Converts an uncoded [`PeerId`] to a [`libp2p::PeerId`]. These two types represent the same
+/// underlying concept (secp256k1 public key) but using different encodings (the local [`PeerId`] is
+/// the uncompressed representation of the public key, while the "p2plib" [`libp2p::PeerId`] is a
+/// more complex representation, involving protobuf encoding and bitcoin encoding,  defined here: <https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md>).
+pub fn local_id_to_p2p_id(peer_id: PeerId) -> Result<libp2p::PeerId, PeerIdConversionError> {
+    // The libp2p library works with compressed public keys.
+    let encoded_pk_bytes = peer_id_to_secp256k1_pubkey(peer_id)
+        .map_err(PeerIdConversionError::InvalidPeerId)?
+        .serialize();
+    let pk: discv5::libp2p_identity::PublicKey =
+        discv5::libp2p_identity::secp256k1::PublicKey::try_from_bytes(&encoded_pk_bytes)?.into();
+
+    Ok(pk.to_peer_id())
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::hex::FromHex;
+
+    use crate::{PeerId, peers::utils::peer_id_to_secp256k1_pubkey};
+
+    use super::*;
+
+    #[test]
+    fn test_convert_local_peer_id_to_multi_peer_id() {
+        let p2p_keypair = discv5::libp2p_identity::secp256k1::Keypair::generate();
+        let uncompressed = p2p_keypair.public().to_bytes_uncompressed();
+        let local_peer_id = PeerId::from_slice(&uncompressed[1..]);
+
+        // We need to convert the local peer id (uncompressed secp256k1 public key) to a libp2p
+        // peer id (protocol buffer encoded public key).
+        let peer_id = local_id_to_p2p_id(local_peer_id).unwrap();
+
+        let p2p_public_key: discv5::libp2p_identity::PublicKey =
+            p2p_keypair.public().clone().into();
+
+        assert_eq!(peer_id, p2p_public_key.to_peer_id());
+    }
+
+    #[test]
+    fn test_hardcoded_peer_id() {
+        const PUB_KEY_STR: &str = "548f715f3fc388a7c917ba644a2f16270f1ede48a5d88a4d14ea287cc916068363f3092e39936f1a3e7885198bef0e5af951f1d7b1041ce8ba4010917777e71f";
+        let pub_key = PeerId::from_hex(PUB_KEY_STR).unwrap();
+
+        // We need to convert the local peer id (uncompressed secp256k1 public key) to a libp2p
+        // peer id (protocol buffer encoded public key).
+        let peer_id = local_id_to_p2p_id(pub_key).unwrap();
+
+        let uncompressed_pub_key = peer_id_to_secp256k1_pubkey(pub_key).unwrap();
+
+        let p2p_public_key: discv5::libp2p_identity::PublicKey =
+            discv5::libp2p_identity::secp256k1::PublicKey::try_from_bytes(
+                &uncompressed_pub_key.serialize(),
+            )
+            .unwrap()
+            .into();
+
+        assert_eq!(peer_id, p2p_public_key.to_peer_id());
+    }
 }


### PR DESCRIPTION
## Description
This PR provides a fix for the bootstrapping of nodes given an enode address. 
In particular:
- it fixes the conversion from "local" `PeerId` to "p2plib" `PeerId`. These two types represent the same underlying concept (secp256k1 public key) but using different encodings (the local `PeerId` is the uncompressed representation of the public key, while the "p2plib" `PeerId` is a more complex representation, involving protobuf encoding and bitcoin encoding, defined here: https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md).
- It slightly changes the logic of the `bootstrap` method to ensure that both enode and enr encoded bootstrap nodes are added.
- It adds util methods for the conversion from local representation to "p2plib" representation of `PeerId`. 
- It adds unit testing to highlight the difference of format and ensure the conversion works.

As a follow-up, we should probably try and rename the "local" `PeerId`, or add type-safety/newtypes to ensure that we limit the likelihood of doing wrongful conversions in the future.

## Associated issue
Merging this PR will close #1413 