### PR TITLE
feat(executor): Add example + docs for generating new test fixtures

### DIFF
--- a/.github/workflows/rust_ci.yaml
+++ b/.github/workflows/rust_ci.yaml
@@ -141,6 +141,8 @@ jobs:
         with:
           submodules: true
       - uses: ./.github/actions/setup
+      - name: Install clang
+        run: sudo apt install clang libclang-dev
       - uses: taiki-e/install-action@cargo-hack
       - name: cargo hack
         run: just hack

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2681,6 +2681,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "execution-fixture"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "kona-cli",
+ "kona-executor",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.19",
+ "url",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4219,6 +4233,7 @@ dependencies = [
  "alloy-transport",
  "alloy-transport-http",
  "alloy-trie",
+ "kona-executor",
  "kona-genesis",
  "kona-mpt",
  "kona-registry",

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -33,6 +33,7 @@
   - [Transform Frames to a Batch](./examples/frames-to-batch.md)
   - [Transform a Batch into Frames](./examples/batch-to-frames.md)
   - [Create a new L1BlockInfoTx Hardfork Variant](./examples/new-l1-block-info-tx-hardfork.md)
+  - [Create a new `kona-executor` test fixture](./examples/executor-test-fixtures.md)
 - [RFC](./rfc/intro.md)
   - [Umbrellas](./rfc/umbrellas.md)
 - [Archives](./archives/intro.md)

--- a/book/src/examples/executor-test-fixtures.md
+++ b/book/src/examples/executor-test-fixtures.md
@@ -1,0 +1,21 @@
+# `kona-executor` test fixtures
+
+The `StatelessL2Builder` type uses static test data fixtures to run stateless execution of certain blocks offline. The
+test data fixtures include:
+* The `RollupConfig` of the chain that the block belongs to.
+* The parent block header, which we apply state on top of.
+* The payload attributes for building the new block.
+* A `rocksdb` database containing the witness data for stateless execution of the block building job.
+
+Sometimes, updates in the block building code can add new state accesses, requiring these fixtures to be re-generated.
+
+To generate a new fixture and add it to the test suite, run:
+
+```sh
+cargo r -p execution-fixture \
+    --l2-rpc <archival_l2_el_rpc> \
+    --block-number <l2_block_number_to_execute>
+```
+
+this command will add a new compressed test fixture for the given L2 block into `kona-executor`'s `testdata` directory.
+The test suite will automatically pick this new test fixture up, and no further action is needed to register it.

--- a/book/src/examples/intro.md
+++ b/book/src/examples/intro.md
@@ -6,3 +6,4 @@ Examples for working with `kona` crates.
 - [Create a new L1BlockInfoTx Hardfork Variant](./new-l1-block-info-tx-hardfork.md)
 - [Transform Frames to a Batch](./frames-to-batch.md)
 - [Transform a Batch to Frames](./batch-to-frames.md)
+- [Create a new `kona-executor` test fixture](./executor-test-fixtures.md)

--- a/crates/proof/executor/Cargo.toml
+++ b/crates/proof/executor/Cargo.toml
@@ -40,18 +40,42 @@ alloy-op-evm.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
+# `test-utils` feature
+rand = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive"], optional = true }
+tokio = { workspace = true, features = ["full"], optional = true }
+rstest = { workspace = true, optional = true }
+kona-registry = { workspace = true, optional = true }
+rocksdb = { workspace = true, features = ["snappy"], optional = true }
+tempfile = { workspace = true, optional = true }
+alloy-rpc-types-engine = { workspace = true, optional = true }
+alloy-provider = { workspace = true, features = ["reqwest"], optional = true }
+alloy-rpc-client = { workspace = true, optional = true }
+alloy-transport = { workspace = true, optional = true }
+alloy-transport-http = { workspace = true, optional = true }
+
 [dev-dependencies]
-rand.workspace = true
-serde_json.workspace = true
-serde = { workspace = true, features = ["derive"] }
-tokio = { workspace = true, features = ["full"] }
-rstest.workspace = true
-kona-registry.workspace = true
-rocksdb = { workspace = true, features = ["snappy"] }
-tempfile.workspace = true
-alloy-rpc-types-engine.workspace = true
-alloy-rlp.workspace = true
-alloy-provider = { workspace = true, features = ["reqwest"] }
-alloy-rpc-client.workspace = true
-alloy-transport.workspace = true
-alloy-transport-http.workspace = true
+kona-executor = { workspace = true, features = ["test-utils"] }
+
+[features]
+test-utils = [
+  "dep:rand",
+  "dep:serde_json",
+  "dep:serde",
+  "dep:tokio",
+  "dep:rstest",
+  "dep:kona-registry",
+  "dep:rocksdb",
+  "dep:tempfile",
+  "dep:alloy-rpc-types-engine",
+  "dep:alloy-provider",
+  "dep:alloy-rpc-client",
+  "dep:alloy-transport",
+  "dep:alloy-transport-http",
+]
+
+[package.metadata.cargo-udeps.ignore]
+# `kona-executor` is self-referenced in dev-dependencies to always enable the `test-utils` feature in `cfg(test)`.
+# this is a false-positive.
+development = ["kona-executor"]

--- a/crates/proof/executor/src/builder/core.rs
+++ b/crates/proof/executor/src/builder/core.rs
@@ -167,33 +167,13 @@ mod test {
     use rstest::rstest;
     use std::path::PathBuf;
 
-    // To create new test fixtures, uncomment the following test and run it with parameters filled.
-    // #[tokio::test(flavor = "multi_thread")]
-    // async fn create_fixture() {
-    //     let fixture_creator = crate::test_utils::ExecutorTestFixtureCreator::new(
-    //         "<rpc_url>",
-    //         <block_number>,
-    //         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("testdata"),
-    //     );
-    //     fixture_creator.create_static_fixture().await;
-    // }
-
     #[rstest]
-    #[case::small_block(26207960)] // OP Sepolia
-    #[case::small_block_2(26207961)] // OP Sepolia
-    #[case::medium_block(26207962)] // OP Sepolia
-    #[case::medium_block_2(26207963)] // OP Sepolia
-    #[case::medium_block_3(26208927)] // OP Sepolia
-    #[case::medium_block_4(26208858)] // OP Sepolia
-    #[case::big_block(26208858)] // OP Sepolia
-    #[case::big_block_2(26208384)] // OP Sepolia
-    #[case::big_block_3(26211680)] // OP Sepolia
     #[tokio::test]
-    async fn test_statelessly_execute_block(#[case] block_number: u64) {
-        let fixture_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("testdata")
-            .join(format!("block-{block_number}.tar.gz"));
-
-        run_test_fixture(fixture_dir).await;
+    async fn test_statelessly_execute_block(
+        #[base_dir = "./testdata"]
+        #[files("*.tar.gz")]
+        path: PathBuf,
+    ) {
+        run_test_fixture(path).await;
     }
 }

--- a/crates/proof/executor/src/lib.rs
+++ b/crates/proof/executor/src/lib.rs
@@ -5,7 +5,7 @@
     issue_tracker_base_url = "https://github.com/op-rs/kona/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(feature = "test-utils"), no_std)]
 
 extern crate alloc;
 
@@ -25,5 +25,5 @@ pub(crate) mod util;
 
 pub(crate) mod constants;
 
-#[cfg(test)]
-mod test_utils;
+#[cfg(feature = "test-utils")]
+pub mod test_utils;

--- a/examples/execution-fixture/Cargo.toml
+++ b/examples/execution-fixture/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "execution-fixture"
+version = "0.0.0"
+publish = false
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+url.workspace = true
+tracing.workspace = true
+kona-cli.workspace = true
+kona-executor = { workspace = true, features = ["test-utils"] }
+clap = { workspace = true, features = ["derive", "env"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }

--- a/examples/execution-fixture/src/main.rs
+++ b/examples/execution-fixture/src/main.rs
@@ -1,0 +1,75 @@
+//! Example for creating a static test fixture for `kona-executor` from a live chain
+//!
+//! ## Usage
+//!
+//! ```sh
+//! cargo run --release -p execution-fixture
+//! ```
+//!
+//! ## Inputs
+//!
+//! The test fixture creator takes the following inputs:
+//!
+//! - `-v` or `--verbosity`: Verbosity level (0-2)
+//! - `-r` or `--l2-rpc`: The L2 execution layer RPC URL to use. Must be archival.
+//! - `-b` or `--block-number`: L2 block number to execute for the fixture.
+//! - `-o` or `--output-dir`: (Optional) The output directory for the fixture. If not provided,
+//!   defaults to `kona-executor`'s `testdata` directory.
+
+use anyhow::{Result, anyhow};
+use clap::{ArgAction, Parser};
+use kona_cli::init_tracing_subscriber;
+use kona_executor::test_utils::ExecutorTestFixtureCreator;
+use std::path::PathBuf;
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+use url::Url;
+
+/// The execution fixture creation command.
+#[derive(Parser, Debug, Clone)]
+#[command(about = "Creates a static test fixture for `kona-executor` from a live chain")]
+pub struct ExecutionFixtureCommand {
+    /// Verbosity level (0-2)
+    #[arg(long, short, action = ArgAction::Count)]
+    pub v: u8,
+    /// The L2 archive EL to use.
+    #[arg(long, short = 'r')]
+    pub l2_rpc: Url,
+    /// L2 block number to execute.
+    #[arg(long, short = 'b')]
+    pub block_number: u64,
+    /// The output directory for the fixture.
+    #[arg(long, short = 'o')]
+    pub output_dir: Option<PathBuf>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = ExecutionFixtureCommand::parse();
+    init_tracing_subscriber(cli.v, None::<EnvFilter>)?;
+
+    let output_dir = if let Some(output_dir) = cli.output_dir {
+        output_dir
+    } else {
+        // Default to `crates/proof/executor/testdata`
+        let output = std::process::Command::new(env!("CARGO"))
+            .arg("locate-project")
+            .arg("--workspace")
+            .arg("--message-format=plain")
+            .output()?
+            .stdout;
+        let workspace_root: PathBuf = String::from_utf8(output)?.trim().into();
+
+        workspace_root
+            .parent()
+            .ok_or(anyhow!("Failed to locate workspace root"))?
+            .join("crates/proof/executor/testdata")
+    };
+
+    ExecutorTestFixtureCreator::new(cli.l2_rpc.as_str(), cli.block_number, output_dir)
+        .create_static_fixture()
+        .await;
+
+    info!(block_number = cli.block_number, "Successfully created static test fixture");
+    Ok(())
+}


### PR DESCRIPTION
## Overview

Adds some documentation and a new example binary for generating new static test fixtures for the `StatelessL2Builder` in `kona-executor`. Also improves the test to automatically pick up on the test fixtures in `kona-executor`'s `testdata` directory, rather than having to manually specify which ones to run.