### PR TITLE
chore(ci): Add action to free up disk space in action test job

### DIFF
--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          large-packages: false
       - uses: taiki-e/install-action@just
       - uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
## Overview

We're still seeing issues with the action tests job running out of disk space, even after #1428. This is another step to mitigate the issue.

[`free-disk-space-ubuntu`](https://github.com/marketplace/actions/free-disk-space-ubuntu) removes a lot of the pre-installed tools that aren't necessary for the job to run.