### PR TITLE
chore(comp): Enable `test-utils` feature with `cfg(test)`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4116,6 +4116,7 @@ dependencies = [
  "arbitrary",
  "async-trait",
  "brotli",
+ "kona-comp",
  "kona-genesis",
  "kona-protocol",
  "miniz_oxide",

--- a/crates/protocol/comp/Cargo.toml
+++ b/crates/protocol/comp/Cargo.toml
@@ -53,6 +53,7 @@ spin = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, features = ["fmt"], optional = true }
 
 [dev-dependencies]
+kona-comp = { workspace = true, features = ["test-utils"] }
 brotli = { workspace = true, features = ["std"] }
 spin.workspace = true
 rand = { workspace = true, features = ["std", "std_rng"] }
@@ -88,3 +89,9 @@ serde = [
   "alloy-primitives/serde",
   "tracing-subscriber?/serde"
 ]
+
+
+[package.metadata.cargo-udeps.ignore]
+# `kona-comp` is self-referenced in dev-dependencies to always enable the `test-utils` feature in `cfg(test)`.
+# this is a false-positive.
+development = ["kona-comp"]

--- a/crates/protocol/comp/src/lib.rs
+++ b/crates/protocol/comp/src/lib.rs
@@ -44,5 +44,5 @@ mod ratio;
 #[cfg(feature = "std")]
 pub use ratio::RatioCompressor;
 
-#[cfg(any(test, feature = "test-utils"))]
+#[cfg(feature = "test-utils")]
 pub mod test_utils;


### PR DESCRIPTION
## Overview

Makes `test-utils` enabled in `cfg(test)` always in `kona-comp`, removing the need to include the module if either `cfg(test)` or `feature = "test-utils` is enabled.