### PR TITLE
chore(protocol): Enable `test-utils` feature with `cfg(test)`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4564,6 +4564,7 @@ dependencies = [
  "brotli",
  "derive_more",
  "kona-genesis",
+ "kona-protocol",
  "miniz_oxide",
  "op-alloy-consensus",
  "op-alloy-rpc-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4142,6 +4142,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "async-trait",
+ "kona-derive",
  "kona-genesis",
  "kona-hardforks",
  "kona-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4116,6 +4116,7 @@ dependencies = [
  "arbitrary",
  "async-trait",
  "brotli",
+ "kona-comp",
  "kona-genesis",
  "kona-protocol",
  "miniz_oxide",

--- a/crates/protocol/comp/Cargo.toml
+++ b/crates/protocol/comp/Cargo.toml
@@ -53,6 +53,7 @@ spin = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, features = ["fmt"], optional = true }
 
 [dev-dependencies]
+kona-comp = { workspace = true, features = ["test-utils"] }
 brotli = { workspace = true, features = ["std"] }
 spin.workspace = true
 rand = { workspace = true, features = ["std", "std_rng"] }
@@ -88,3 +89,9 @@ serde = [
   "alloy-primitives/serde",
   "tracing-subscriber?/serde"
 ]
+
+
+[package.metadata.cargo-udeps.ignore]
+# `kona-comp` is self-referenced in dev-dependencies to always enable the `test-utils` feature in `cfg(test)`.
+# this is a false-positive.
+development = ["kona-comp"]

--- a/crates/protocol/comp/src/lib.rs
+++ b/crates/protocol/comp/src/lib.rs
@@ -44,5 +44,5 @@ mod ratio;
 #[cfg(feature = "std")]
 pub use ratio::RatioCompressor;
 
-#[cfg(any(test, feature = "test-utils"))]
+#[cfg(feature = "test-utils")]
 pub mod test_utils;

--- a/crates/protocol/derive/Cargo.toml
+++ b/crates/protocol/derive/Cargo.toml
@@ -41,6 +41,7 @@ tracing-subscriber = { workspace = true, optional = true, features = ["fmt"] }
 op-alloy-consensus = { workspace = true, optional = true, features = ["k256"] }
 
 [dev-dependencies]
+kona-derive = { workspace = true, features = ["test-utils"] }
 spin.workspace = true
 proptest.workspace = true
 serde_json.workspace = true
@@ -65,3 +66,8 @@ test-utils = [
   "dep:tracing-subscriber",
   "dep:op-alloy-consensus",
 ]
+
+[package.metadata.cargo-udeps.ignore]
+# `kona-derive` is self-referenced in dev-dependencies to always enable the `test-utils` feature in `cfg(test)`.
+# this is a false-positive.
+development = ["kona-derive"]

--- a/crates/protocol/derive/src/lib.rs
+++ b/crates/protocol/derive/src/lib.rs
@@ -5,7 +5,7 @@
     issue_tracker_base_url = "https://github.com/op-rs/kona/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-#![cfg_attr(not(test), no_std)]
+#![no_std]
 
 extern crate alloc;
 
@@ -27,5 +27,5 @@ pub mod stages;
 pub mod traits;
 pub mod types;
 
-#[cfg(any(test, feature = "test-utils"))]
+#[cfg(feature = "test-utils")]
 pub mod test_utils;

--- a/crates/protocol/derive/src/sources/blobs.rs
+++ b/crates/protocol/derive/src/sources/blobs.rs
@@ -213,6 +213,7 @@ pub(crate) mod tests {
         errors::PipelineErrorKind,
         test_utils::{TestBlobProvider, TestChainProvider},
     };
+    use alloc::vec;
     use alloy_rlp::Decodable;
 
     pub(crate) fn default_test_blob_source() -> BlobSource<TestChainProvider, TestBlobProvider> {

--- a/crates/protocol/derive/src/sources/ethereum.rs
+++ b/crates/protocol/derive/src/sources/ethereum.rs
@@ -86,6 +86,7 @@ mod tests {
         sources::BlobData,
         test_utils::{TestBlobProvider, TestChainProvider},
     };
+    use alloc::vec;
     use alloy_consensus::TxEnvelope;
     use alloy_eips::eip2718::Decodable2718;
     use alloy_primitives::{Address, address};
@@ -152,7 +153,7 @@ mod tests {
         // load a test batcher transaction
         let raw_batcher_tx = include_bytes!("../../testdata/raw_batcher_tx.hex");
         let tx = TxEnvelope::decode_2718(&mut raw_batcher_tx.as_ref()).unwrap();
-        chain.insert_block_with_transactions(10, block_ref, alloc::vec![tx]);
+        chain.insert_block_with_transactions(10, block_ref, vec![tx]);
 
         // Should successfully retrieve a calldata batch from the block
         let mut data_source = EthereumDataSource::new_from_parts(chain, blob, &cfg);

--- a/crates/protocol/protocol/Cargo.toml
+++ b/crates/protocol/protocol/Cargo.toml
@@ -53,6 +53,7 @@ spin = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, features = ["fmt"], optional = true }
 
 [dev-dependencies]
+kona-protocol = { workspace = true, features = ["test-utils"] }
 brotli = { workspace = true, features = ["std"] }
 spin.workspace = true
 rand = { workspace = true, features = ["std", "std_rng"] }
@@ -106,3 +107,8 @@ serde = [
   "alloy-primitives/serde",
   "tracing-subscriber?/serde"
 ]
+
+[package.metadata.cargo-udeps.ignore]
+# `kona-protocol` is self-referenced in dev-dependencies to always enable the `test-utils` feature in `cfg(test)`.
+# this is a false-positive.
+development = ["kona-protocol"]

--- a/crates/protocol/protocol/src/lib.rs
+++ b/crates/protocol/protocol/src/lib.rs
@@ -61,5 +61,5 @@ pub use info::{
 mod predeploys;
 pub use predeploys::Predeploys;
 
-#[cfg(any(test, feature = "test-utils"))]
+#[cfg(feature = "test-utils")]
 pub mod test_utils;


### PR DESCRIPTION
## Overview

Makes `test-utils` enabled in `cfg(test)` always in `kona-protocol`, removing the need to include the module if either `cfg(test)` or `feature = "test-utils` is enabled.