### PR TITLE
fix(node/p2p): Enr Validation

### DIFF
--- a/crates/node/p2p/src/lib.rs
+++ b/crates/node/p2p/src/lib.rs
@@ -27,8 +27,9 @@ pub use gossip::{
 
 mod peers;
 pub use peers::{
-    AnyNode, BootNode, BootNodes, BootStore, NodeRecord, NodeRecordParseError, OP_RAW_BOOTNODES,
-    OP_RAW_TESTNET_BOOTNODES, OpStackEnr, PeerId, PeerMonitoring, PeerScoreLevel, enr_to_multiaddr,
+    AnyNode, BootNode, BootNodes, BootStore, EnrValidation, NodeRecord, NodeRecordParseError,
+    OP_RAW_BOOTNODES, OP_RAW_TESTNET_BOOTNODES, OpStackEnr, PeerId, PeerMonitoring, PeerScoreLevel,
+    enr_to_multiaddr,
 };
 
 mod discv5;

--- a/crates/node/p2p/src/peers/mod.rs
+++ b/crates/node/p2p/src/peers/mod.rs
@@ -49,7 +49,7 @@ mod score;
 pub use score::PeerScoreLevel;
 
 mod enr;
-pub use enr::OpStackEnr;
+pub use enr::{EnrValidation, OpStackEnr};
 
 mod any;
 pub use any::AnyNode;


### PR DESCRIPTION
### Description

Fixes ENR validation to actually use the op stack enr values to validate the ENR prior to adding the ENR to the discovery table or the libp2p swarm.