### PR TITLE
fix(bin/node): Break after Receiving Peer Count

### DIFF
--- a/bin/node/src/commands/net.rs
+++ b/bin/node/src/commands/net.rs
@@ -91,6 +91,7 @@ impl NetCommand {
                                 Ok((d, g)) => {
                                     let d = d.unwrap_or_default();
                                     info!("Peer counts: Discovery={} | Swarm={}", d, g);
+                                    break;
                                 }
                                 Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {
                                     /* Keep trying to receive */


### PR DESCRIPTION
### Description

Tiny PR to break after receiving the peer count.