### PR TITLE
fix(node): Configurable Bootstore Path

### DIFF
--- a/bin/node/src/flags/p2p.rs
+++ b/bin/node/src/flags/p2p.rs
@@ -122,6 +122,9 @@ pub struct P2PArgs {
         env = "KONA_NODE_P2P_DISCOVERY_INTERVAL"
     )]
     pub discovery_interval: u64,
+    /// The directory to store the bootstore.
+    #[arg(long = "p2p.bootstore", env = "KONA_NODE_P2P_BOOTSTORE")]
+    pub bootstore: Option<PathBuf>,
 }
 
 impl Default for P2PArgs {
@@ -147,6 +150,7 @@ impl Default for P2PArgs {
             ban_threshold: 0,
             ban_duration: 30,
             discovery_interval: 5,
+            bootstore: None,
         }
     }
 }
@@ -224,6 +228,7 @@ impl P2PArgs {
             scoring: self.scoring,
             block_time,
             monitor_peers,
+            bootstore: self.bootstore.clone(),
         })
     }
 

--- a/crates/node/p2p/src/discv5/builder.rs
+++ b/crates/node/p2p/src/discv5/builder.rs
@@ -4,7 +4,7 @@ use discv5::{
     Config, ConfigBuilder, Discv5, ListenConfig,
     enr::{CombinedKey, Enr},
 };
-use std::net::SocketAddr;
+use std::{net::SocketAddr, path::PathBuf};
 use tokio::time::Duration;
 
 use crate::{Discv5BuilderError, Discv5Driver, OpStackEnr};
@@ -22,6 +22,8 @@ pub struct Discv5Builder {
     listen_config: Option<ListenConfig>,
     /// The discovery config for the discovery service.
     discovery_config: Option<Config>,
+    /// An optional path to the bootstore.
+    bootstore: Option<PathBuf>,
 }
 
 impl Discv5Builder {
@@ -33,7 +35,14 @@ impl Discv5Builder {
             interval: None,
             listen_config: None,
             discovery_config: None,
+            bootstore: None,
         }
+    }
+
+    /// Sets the bootstore path.
+    pub fn with_bootstore(mut self, bootstore: PathBuf) -> Self {
+        self.bootstore = Some(bootstore);
+        self
     }
 
     /// Sets the discovery service address.
@@ -109,7 +118,7 @@ impl Discv5Builder {
         let disc =
             Discv5::new(enr, key, config).map_err(|_| Discv5BuilderError::Discv5CreationFailed)?;
 
-        Ok(Discv5Driver::new(disc, interval, chain_id))
+        Ok(Discv5Driver::new(disc, interval, chain_id, self.bootstore.clone()))
     }
 }
 

--- a/crates/node/p2p/src/discv5/driver.rs
+++ b/crates/node/p2p/src/discv5/driver.rs
@@ -3,6 +3,7 @@
 use derive_more::Debug;
 use discv5::{Discv5, Enr, Event, enr::NodeId};
 use libp2p::Multiaddr;
+use std::path::PathBuf;
 use tokio::{
     sync::mpsc::channel,
     time::{Duration, sleep},
@@ -72,8 +73,13 @@ impl Discv5Driver {
     }
 
     /// Instantiates a new [`Discv5Driver`].
-    pub fn new(disc: Discv5, interval: Duration, chain_id: u64) -> Self {
-        let store = BootStore::from_chain_id(chain_id, None);
+    pub fn new(
+        disc: Discv5,
+        interval: Duration,
+        chain_id: u64,
+        bootstore: Option<PathBuf>,
+    ) -> Self {
+        let store = BootStore::from_chain_id(chain_id, bootstore);
         Self { disc, chain_id, store, interval }
     }
 

--- a/crates/node/p2p/src/net/builder.rs
+++ b/crates/node/p2p/src/net/builder.rs
@@ -5,7 +5,7 @@ use discv5::{Config as Discv5Config, ListenConfig};
 use kona_genesis::RollupConfig;
 use libp2p::{Multiaddr, identity::Keypair};
 use op_alloy_rpc_types_engine::OpNetworkPayloadEnvelope;
-use std::{net::SocketAddr, time::Duration};
+use std::{net::SocketAddr, path::PathBuf, time::Duration};
 use tokio::sync::broadcast::Sender as BroadcastSender;
 
 use crate::{
@@ -35,6 +35,7 @@ pub struct NetworkBuilder {
 impl From<Config> for NetworkBuilder {
     fn from(config: Config) -> Self {
         Self::new()
+            .with_bootstore(config.bootstore)
             .with_discovery_interval(config.discovery_interval)
             .with_discovery_address(config.discovery_address)
             .with_gossip_address(config.gossip_address)
@@ -58,6 +59,14 @@ impl NetworkBuilder {
             publish_rx: None,
             cfg: None,
         }
+    }
+
+    /// Sets the bootstore path for the [`crate::Discv5Driver`].
+    pub fn with_bootstore(self, bootstore: Option<PathBuf>) -> Self {
+        if let Some(bootstore) = bootstore {
+            return Self { discovery: self.discovery.with_bootstore(bootstore), ..self };
+        }
+        self
     }
 
     /// Sets the block time used by peer scoring.

--- a/crates/node/p2p/src/net/config.rs
+++ b/crates/node/p2p/src/net/config.rs
@@ -3,7 +3,7 @@
 use crate::{PeerScoreLevel, peers::PeerMonitoring};
 use alloy_primitives::Address;
 use libp2p::identity::Keypair;
-use std::net::SocketAddr;
+use std::{net::SocketAddr, path::PathBuf};
 use tokio::time::Duration;
 
 /// Configuration for kona's P2P stack.
@@ -27,4 +27,6 @@ pub struct Config {
     pub monitor_peers: Option<PeerMonitoring>,
     /// The L2 Block Time.
     pub block_time: u64,
+    /// An optional path to the bootstore.
+    pub bootstore: Option<PathBuf>,
 }


### PR DESCRIPTION
### Description

Updates the `P2PArgs` CLI flags to contain a new `--p2p.bootstore` flag that accepts an optional path.

This CLI flag allows the user to set the path at which `kona-node` should store and read the "bootstore".

Previously, this was set to `None` manually in `kona-p2p` which effectively used the home directory.