### PR TITLE
test(node/p2p): add extensive testing for block decoding validation

### DIFF
--- a/crates/node/p2p/src/gossip/mod.rs
+++ b/crates/node/p2p/src/gossip/mod.rs
@@ -27,3 +27,6 @@ mod driver;
 pub use driver::GossipDriver;
 
 mod block_validity;
+
+#[cfg(test)]
+pub(crate) use block_validity::tests::*;


### PR DESCRIPTION
## Description
This PR, built on top of #1451, adds a couple of unit test to ensure the block decoding operations are performed correctly and help enforce some of the validations rules from [the optimism spec](https://specs.optimism.io/protocol/rollup-node-p2p.html#block-validation).

## Note
Merging this PR will make progress towards #1340. It should be reviewed after #1451 