### PR TITLE
fix(proof): Blob preimage keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4087,7 +4087,7 @@ dependencies = [
  "kona-registry",
  "kona-std-fpvm",
  "kona-std-fpvm-proc",
- "lru 0.13.0",
+ "lru 0.14.0",
  "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
  "op-revm",
@@ -4302,6 +4302,7 @@ dependencies = [
  "alloy-transport",
  "alloy-transport-http",
  "anyhow",
+ "ark-ff 0.5.0",
  "async-trait",
  "clap",
  "kona-cli",
@@ -4499,7 +4500,10 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
+ "ark-bls12-381",
+ "ark-ff 0.5.0",
  "async-trait",
+ "c-kzg",
  "kona-derive",
  "kona-driver",
  "kona-executor",
@@ -4509,10 +4513,13 @@ dependencies = [
  "kona-protocol",
  "kona-registry",
  "kona-rpc",
- "lru 0.13.0",
+ "lazy_static",
+ "lru 0.14.0",
  "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
  "op-revm",
+ "rand 0.9.0",
+ "rayon",
  "rstest",
  "serde",
  "serde_json",
@@ -4602,7 +4609,7 @@ dependencies = [
  "kona-genesis",
  "kona-protocol",
  "kona-rpc",
- "lru 0.13.0",
+ "lru 0.14.0",
  "op-alloy-consensus",
  "op-alloy-network",
  "reqwest",
@@ -5216,6 +5223,15 @@ name = "lru"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+dependencies = [
+ "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "lru"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f8cc7106155f10bdf99a6f379688f543ad6596a415375b36a59a054ceda1198"
 dependencies = [
  "hashbrown 0.15.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,12 +140,13 @@ alloy-op-evm = { version = "0.5.0", default-features = false }
 
 # General
 url = "2.5.4"
-lru = "0.13.0"
+lru = "0.14.0"
 dirs = "6.0.0"
 spin = "0.10.0"
 clap = "4.5.32"
 tower = "0.5.2"
 tokio = "1.44.2"
+rayon = "1.10.0"
 cfg-if = "1.0.0"
 rstest = "0.25.0"
 futures = "0.3.31"
@@ -162,8 +163,6 @@ unsigned-varint = "0.8.0"
 linked_list_allocator = "0.10.5"
 
 rand = { version = "0.9.0", default-features = false }
-sha2 = { version = "0.10.8", default-features = false }
-c-kzg = { version = "2.0.0", default-features = false }
 tabled = { version = "0.18", default-features = false }
 anyhow = { version = "1.0.97", default-features = false }
 thiserror = { version = "2.0.12", default-features = false }
@@ -205,5 +204,8 @@ serde_json = { version = "1.0.140", default-features = false }
 rocksdb = { version = "0.23.0", default-features = false }
 
 # Cryptography
-# The same library that is used by reth.
+sha2 = { version = "0.10.8", default-features = false }
+c-kzg = { version = "2.0.0", default-features = false }
+ark-ff = { version = "0.5.0", default-features = false }
 secp256k1 = { version = "0.30", default-features = false }
+ark-bls12-381 = { version = "0.5.0", default-features = false }

--- a/bin/host/Cargo.toml
+++ b/bin/host/Cargo.toml
@@ -67,6 +67,9 @@ clap = { workspace = true, features = ["derive", "env"] }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 thiserror.workspace = true
 
+# KZG
+ark-ff.workspace = true
+
 [dev-dependencies]
 proptest.workspace = true
 

--- a/crates/proof/proof/Cargo.toml
+++ b/crates/proof/proof/Cargo.toml
@@ -47,6 +47,11 @@ tracing.workspace = true
 serde_json.workspace = true
 async-trait.workspace = true
 thiserror.workspace = true
+lazy_static.workspace = true
+
+# KZG
+ark-ff.workspace = true
+ark-bls12-381.workspace = true
 
 # `std` feature dependencies
 tokio = { workspace = true, features = ["full"], optional = true }
@@ -54,6 +59,9 @@ tokio = { workspace = true, features = ["full"], optional = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
 rstest.workspace = true
+rand.workspace = true
+c-kzg.workspace = true
+rayon.workspace = true
 
 [features]
 std = ["dep:tokio"]

--- a/crates/proof/proof/src/l1/blob_provider.rs
+++ b/crates/proof/proof/src/l1/blob_provider.rs
@@ -5,10 +5,14 @@ use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use alloy_consensus::Blob;
 use alloy_eips::eip4844::{FIELD_ELEMENTS_PER_BLOB, IndexedBlobHash};
 use alloy_primitives::keccak256;
+use ark_bls12_381::Fr;
+use ark_ff::{AdditiveGroup, BigInteger, BigInteger256, Field, PrimeField};
 use async_trait::async_trait;
+use core::str::FromStr;
 use kona_derive::traits::BlobProvider;
 use kona_preimage::{CommsClient, PreimageKey, PreimageKeyType};
 use kona_protocol::BlockInfo;
+use spin::Lazy;
 
 /// An oracle-backed blob provider.
 #[derive(Debug, Clone)]
@@ -56,7 +60,8 @@ impl<T: CommsClient> OracleBlobProvider<T> {
         let mut field_element_key = [0u8; 80];
         field_element_key[..48].copy_from_slice(commitment.as_ref());
         for i in 0..FIELD_ELEMENTS_PER_BLOB {
-            field_element_key[72..].copy_from_slice(i.to_be_bytes().as_ref());
+            field_element_key[48..]
+                .copy_from_slice(ROOTS_OF_UNITY[i as usize].into_bigint().to_bytes_be().as_ref());
 
             let mut field_element = [0u8; 32];
             self.oracle
@@ -89,5 +94,116 @@ impl<T: CommsClient + Sync + Send> BlobProvider for OracleBlobProvider<T> {
             blobs.push(Box::new(self.get_blob(block_ref, hash).await?));
         }
         Ok(blobs)
+    }
+}
+
+/// The 4096th bit-reversed roots of unity used in EIP-4844 as predefined evaluation points.
+///
+/// See `generate_roots_of_unity` for details on how these roots of unity are generated.
+pub static ROOTS_OF_UNITY: Lazy<[Fr; FIELD_ELEMENTS_PER_BLOB as usize]> =
+    Lazy::new(generate_roots_of_unity);
+
+/// Generates the 4096th bit-reversed roots of unity used in EIP-4844 as predefined evaluation
+/// points. To compute the field element at index i in a blob, the blob polynomial is evaluated at
+/// the i'th root of unity. Based on go-kzg-4844: <https://github.com/crate-crypto/go-kzg-4844/blob/8bcf6163d3987313a3194595cf1f33fd45d7301a/internal/kzg/domain.go#L44-L98>
+/// Also, see the consensus specs:
+///   - compute_roots_of_unity <https://github.com/ethereum/consensus-specs/blob/bf09edef17e2900258f7e37631e9452941c26e86/specs/deneb/polynomial-commitments.md#compute_roots_of_unity>
+///   - bit-reversal permutation: <https://github.com/ethereum/consensus-specs/blob/bf09edef17e2900258f7e37631e9452941c26e86/specs/deneb/polynomial-commitments.md#bit-reversal-permutation>
+fn generate_roots_of_unity() -> [Fr; FIELD_ELEMENTS_PER_BLOB as usize] {
+    const MAX_ORDER_ROOT: u64 = 32;
+
+    let mut roots_of_unity = [Fr::ZERO; FIELD_ELEMENTS_PER_BLOB as usize];
+
+    // Generator of the largest 2-adic subgroup of order 2^32.
+    let root_of_unity = Fr::new(
+        BigInteger256::from_str(
+            "10238227357739495823651030575849232062558860180284477541189508159991286009131",
+        )
+        .expect("Failed to initialize root of unity"),
+    );
+
+    // Find generator subgroup of order x.
+    // This can be constructed by powering a generator of the largest 2-adic subgroup of order 2^32
+    // by an exponent of (2^32)/x, provided x is <= 2^32.
+    let log_x = FIELD_ELEMENTS_PER_BLOB.trailing_zeros() as u64;
+    let expo = 1u64 << (MAX_ORDER_ROOT - log_x);
+
+    // Generator has order x now
+    let generator = root_of_unity.pow([expo]);
+
+    // Compute all relevant roots of unity, i.e. the multiplicative subgroup of size x
+    let mut current = Fr::ONE;
+    (0..FIELD_ELEMENTS_PER_BLOB).for_each(|i| {
+        roots_of_unity[i as usize] = current;
+        current *= generator;
+    });
+
+    let shift_correction = 64 - FIELD_ELEMENTS_PER_BLOB.trailing_zeros();
+    (0..FIELD_ELEMENTS_PER_BLOB).for_each(|i| {
+        // Find index irev, such that i and irev get swapped
+        let irev = i.reverse_bits() >> shift_correction;
+        if irev > i {
+            roots_of_unity.swap(i as usize, irev as usize);
+        }
+    });
+
+    roots_of_unity
+}
+
+#[cfg(test)]
+mod test {
+    use super::ROOTS_OF_UNITY;
+    use alloy_eips::eip4844::{FIELD_ELEMENTS_PER_BLOB, env_settings::EnvKzgSettings};
+    use ark_ff::{BigInteger, PrimeField};
+    use c_kzg::{BYTES_PER_BLOB, Blob, Bytes32, Bytes48};
+    use rand::Rng;
+    use rayon::iter::{IntoParallelIterator, ParallelIterator};
+
+    #[test]
+    fn test_roots_of_unity() {
+        // Initiate the default Ethereum KZG settings.
+        let kzg = EnvKzgSettings::default();
+
+        // Create a blob with random data
+        let mut bytes = [0u8; BYTES_PER_BLOB];
+        rand::rng().fill(bytes.as_mut_slice());
+
+        // Ensure the blob is valid by keeping each field element within range.
+        (0..FIELD_ELEMENTS_PER_BLOB).for_each(|i| {
+            bytes[(i as usize) << 5] = 0;
+        });
+
+        let blob = Blob::new(bytes);
+        let blob_commitment = {
+            let raw = kzg.get().blob_to_kzg_commitment(&blob).unwrap();
+            Bytes48::new(raw.as_slice().try_into().unwrap())
+        };
+
+        // Validate each field element in the blob
+        (0..FIELD_ELEMENTS_PER_BLOB).into_par_iter().for_each(|i| {
+            let field_element = {
+                let mut fe = [0u8; 32];
+                fe.copy_from_slice(&blob[(i as usize) << 5..(i as usize + 1) << 5]);
+                Bytes32::new(fe)
+            };
+
+            let z_bytes = Bytes32::new(ROOTS_OF_UNITY[i as usize].into_bigint().to_bytes_be().try_into().unwrap());
+            let (proof, fe) = kzg.get().compute_kzg_proof(&blob, &z_bytes).unwrap();
+
+            // Ensure the field element matches the expected value
+            assert_eq!(
+                fe.as_slice(),
+                field_element.as_slice(),
+                "Field element {i} does not match the expected value. Expected: {field_element:?}, Got: {fe:?}"
+            );
+
+            // Ensure the proof can be verified
+            let proof_bytes = Bytes48::new(proof.as_slice().try_into().unwrap());
+            let is_valid = kzg.get().verify_kzg_proof(&blob_commitment, &z_bytes, &field_element, &proof_bytes).unwrap();
+            assert!(
+                is_valid,
+                "KZG proof verification failed for field element {i}. Commitment: {blob_commitment:?}, Z: {z_bytes:?}, Field Element: {field_element:?}, Proof: {proof_bytes:?}"
+            );
+        });
     }
 }

--- a/crates/proof/proof/src/l1/mod.rs
+++ b/crates/proof/proof/src/l1/mod.rs
@@ -6,7 +6,7 @@ pub use pipeline::{
 };
 
 mod blob_provider;
-pub use blob_provider::OracleBlobProvider;
+pub use blob_provider::{OracleBlobProvider, ROOTS_OF_UNITY};
 
 mod chain_provider;
 pub use chain_provider::OracleL1ChainProvider;


### PR DESCRIPTION
## Overview

Implements a fix for a bug recently found in `op-program` by @imtei that `kona-proof` shares. Our old blob preimage key seeded the field element index, rather than the corresponding bit-reversed root of unity.

The fix for this issue is to alter the blob field element preimage key construction to consist of `kzg_commitment ++ brp_root_of_unity[i]`, rather than `kzg_commitment ++ i`.

For users such as `op-succinct` + `kailua`, which use the full KZG proof to verify the entire blob at once, the preimage key @ `i = 4096` containing the full KZG proof is retained under the legacy key format. No action should be needed from these users. This issue should only affect users that run `kona-proof` in a fault proof environment, of which there currently are none to my knowledge.

A more in-depth overview of this issue can be found [in the `op-program` fix PR within the OP monorepo](https://github.com/ethereum-optimism/optimism/pull/15354), as well as a disclosure of the bug [here](https://gov.optimism.io/t/vulnerability-disclosure-incorrect-blob-preimages/9833).