### PR TITLE
feat(node): Bootstore Debugging Tool

### DIFF
--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -1,7 +1,7 @@
 //! Contains the node CLI.
 
 use crate::{
-    commands::{NetCommand, NodeCommand, RegistryCommand},
+    commands::{BootstoreCommand, NetCommand, NodeCommand, RegistryCommand},
     flags::{GlobalArgs, MetricsArgs},
 };
 use anyhow::Result;
@@ -18,6 +18,8 @@ pub enum Commands {
     Net(NetCommand),
     /// Lists the OP Stack chains available in the superchain-registry.
     Registry(RegistryCommand),
+    /// Utility tool to interact with local bootstores.
+    Bootstore(BootstoreCommand),
 }
 
 /// The node CLI.
@@ -45,6 +47,9 @@ impl Cli {
             Commands::Registry(ref registry) => {
                 registry.init_telemetry(&self.global, &self.metrics)?
             }
+            Commands::Bootstore(ref bootstore) => {
+                bootstore.init_telemetry(&self.global, &self.metrics)?
+            }
         }
 
         // Run the subcommand.
@@ -52,6 +57,7 @@ impl Cli {
             Commands::Node(node) => Self::run_until_ctrl_c(node.run(&self.global)),
             Commands::Net(net) => Self::run_until_ctrl_c(net.run(&self.global)),
             Commands::Registry(registry) => registry.run(&self.global),
+            Commands::Bootstore(bootstore) => bootstore.run(&self.global),
         }
     }
 

--- a/bin/node/src/commands/bootstore.rs
+++ b/bin/node/src/commands/bootstore.rs
@@ -1,0 +1,68 @@
+//! Bootstore Subcommand
+
+use crate::flags::{GlobalArgs, MetricsArgs};
+use clap::Parser;
+use kona_p2p::BootStore;
+use std::path::PathBuf;
+
+/// The `bootstore` Subcommand
+///
+/// The `bootstore` subcommand can be used to interact with local bootstores.
+///
+/// # Usage
+///
+/// ```sh
+/// kona-node bootstore [FLAGS] [OPTIONS]
+/// ```
+#[derive(Parser, Debug, Clone)]
+#[command(about = "Utility tool to interact with local bootstores")]
+pub struct BootstoreCommand {
+    /// Optionally prints all bootstores.
+    /// This option overrides the chain ID configured with `--l2-chain-id`.
+    #[arg(long = "all")]
+    pub all: bool,
+    /// The directory to store the bootstore.
+    #[arg(long = "p2p.bootstore", env = "KONA_NODE_P2P_BOOTSTORE")]
+    pub bootstore: Option<PathBuf>,
+}
+
+impl BootstoreCommand {
+    /// Initializes the telemetry stack and Prometheus metrics recorder.
+    pub fn init_telemetry(&self, args: &GlobalArgs, metrics: &MetricsArgs) -> anyhow::Result<()> {
+        args.init_tracing(None)?;
+        metrics.init_metrics()
+    }
+
+    /// Runs the subcommand.
+    pub fn run(self, args: &GlobalArgs) -> anyhow::Result<()> {
+        println!("--------------------------");
+        if self.all {
+            self.all()?;
+        } else {
+            self.info(args.l2_chain_id)?;
+        }
+        Ok(())
+    }
+
+    /// Prints all bootstores.
+    pub fn all(&self) -> anyhow::Result<()> {
+        for available in BootStore::available(self.bootstore.clone()) {
+            self.info(available)?;
+        }
+        Ok(())
+    }
+
+    /// Prints information for the bootstore with the given chain ID.
+    pub fn info(&self, chain_id: u64) -> anyhow::Result<()> {
+        let chain = kona_registry::OPCHAINS
+            .get(&chain_id)
+            .ok_or(anyhow::anyhow!("Chain ID {} not found in the registry", chain_id))?;
+        println!("{} Bootstore (Chain ID: {})", chain.name, chain_id);
+        let bootstore = BootStore::from_chain_id(chain_id, self.bootstore.clone());
+        println!("Path: {}", bootstore.path.display());
+        println!("Peer Count: {}", bootstore.peers.len());
+        println!("Valid peers: {}", bootstore.valid_peers_with_chain_id(chain_id).len());
+        println!("--------------------------");
+        Ok(())
+    }
+}

--- a/bin/node/src/commands/mod.rs
+++ b/bin/node/src/commands/mod.rs
@@ -3,6 +3,9 @@
 mod node;
 pub use node::NodeCommand;
 
+mod bootstore;
+pub use bootstore::BootstoreCommand;
+
 mod net;
 pub use net::NetCommand;
 


### PR DESCRIPTION
### Description

Upstreams a simple bootstore debugging cli tool that I've been using locally.

Prints bootstore file info with `kona-node boostore --all` (for all available bootstores).

Info for a single bootstore can be output by specifying the chain id like so.

```
kona-node --l2-chain-id 11155420 bootstore
```