### PR TITLE
fix(bin/node): Global Argument Positioning

### DIFF
--- a/bin/node/src/flags/globals.rs
+++ b/bin/node/src/flags/globals.rs
@@ -11,10 +11,10 @@ use tracing_subscriber::EnvFilter;
 #[derive(Parser, Default, Clone, Debug)]
 pub struct GlobalArgs {
     /// Verbosity level (0-2)
-    #[arg(long, short, action = ArgAction::Count)]
+    #[arg(long, short, global=true, action = ArgAction::Count)]
     pub v: u8,
     /// The L2 chain ID to use.
-    #[arg(long, short = 'c', default_value = "10", help = "The L2 chain ID to use")]
+    #[arg(long, short = 'c', global = true, default_value = "10", help = "The L2 chain ID to use")]
     pub l2_chain_id: u64,
 }
 

--- a/bin/node/src/flags/metrics.rs
+++ b/bin/node/src/flags/metrics.rs
@@ -12,13 +12,28 @@ use kona_cli::init_prometheus_server;
 pub struct MetricsArgs {
     /// Controls whether prometheus metrics are enabled.
     /// Disabled by default.
-    #[arg(long = "metrics.enabled", default_value_t = false, env = "KONA_NODE_METRICS_ENABLED")]
+    #[arg(
+        long = "metrics.enabled",
+        global = true,
+        default_value_t = false,
+        env = "KONA_NODE_METRICS_ENABLED"
+    )]
     pub enabled: bool,
     /// The port to serve prometheus metrics on
-    #[arg(long = "metrics.port", default_value = "9090", env = "KONA_NODE_METRICS_PORT")]
+    #[arg(
+        long = "metrics.port",
+        global = true,
+        default_value = "9090",
+        env = "KONA_NODE_METRICS_PORT"
+    )]
     pub port: u16,
     /// The ip address to use to emit prometheus metrics.
-    #[arg(long = "metrics.address", default_value = "0.0.0.0", env = "KONA_NODE_METRICS_ADDR")]
+    #[arg(
+        long = "metrics.address",
+        global = true,
+        default_value = "0.0.0.0",
+        env = "KONA_NODE_METRICS_ADDR"
+    )]
     pub addr: IpAddr,
 }
 


### PR DESCRIPTION
### Description

Previously, global and metrics arguments were not global. Meaning, when running `kona-node`, the global and metrics args had to be specified _prior_ to the subcommand.

For example, when running the `node` subcommand the global `--l2-chain-id` argument had to be specified prior to the `node` subcommand.

This made for a weird UX as follows.

```sh
$ kona-node --l2-chain-id 11155420 node ...
```

Now, the global args are marked as `global=true` so Clap is able to parse them both before *and* _after_ the subcommand like so.

```sh
$ kona-node node --l2-chain-id 11155420 ...
```