### PR TITLE
chore(bin/node): Subcommand Aliases

### DIFF
--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -13,10 +13,13 @@ use kona_cli::cli_styles;
 #[allow(clippy::large_enum_variant)]
 pub enum Commands {
     /// Runs the consensus node.
+    #[command(alias="n")]
     Node(NodeCommand),
     /// Runs the networking stack for the node.
+    #[command(alias="p2p", alias="network")]
     Net(NetCommand),
     /// Lists the OP Stack chains available in the superchain-registry.
+    #[command(alias="r", alias="scr")]
     Registry(RegistryCommand),
 }
 

--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -13,13 +13,13 @@ use kona_cli::cli_styles;
 #[allow(clippy::large_enum_variant)]
 pub enum Commands {
     /// Runs the consensus node.
-    #[command(alias="n")]
+    #[command(alias = "n")]
     Node(NodeCommand),
     /// Runs the networking stack for the node.
-    #[command(alias="p2p", alias="network")]
+    #[command(alias = "p2p", alias = "network")]
     Net(NetCommand),
     /// Lists the OP Stack chains available in the superchain-registry.
-    #[command(alias="r", alias="scr")]
+    #[command(alias = "r", alias = "scr")]
     Registry(RegistryCommand),
 }
 


### PR DESCRIPTION
### Description

Adds a few intuitive aliases for various `kona-node` subcommands.