### PR TITLE
chore(workspace): Convert all tracing targets to `snake_case` format

### DIFF
--- a/bin/host/src/backend/online.rs
+++ b/bin/host/src/backend/online.rs
@@ -95,12 +95,12 @@ where
 {
     /// Set the last hint to be received.
     async fn route_hint(&self, hint: String) -> PreimageOracleResult<()> {
-        trace!(target: "host-backend", "Received hint: {hint}");
+        trace!(target: "host_backend", "Received hint: {hint}");
 
         let parsed_hint =
             hint.parse::<Hint<C::HintType>>().map_err(|_| PreimageOracleError::KeyNotFound)?;
         if self.proactive_hints.contains(&parsed_hint.ty) {
-            debug!(target: "host-backend", "Proactive hint received; Immediately fetching {hint}");
+            debug!(target: "host_backend", "Proactive hint received; Immediately fetching {hint}");
             H::fetch_hint(parsed_hint, &self.cfg, &self.providers, self.kv.clone())
                 .await
                 .map_err(|e| PreimageOracleError::Other(e.to_string()))?;
@@ -121,7 +121,7 @@ where
 {
     /// Get the preimage for the given key.
     async fn get_preimage(&self, key: PreimageKey) -> PreimageOracleResult<Vec<u8>> {
-        trace!(target: "host-backend", "Pre-image requested. Key: {key}");
+        trace!(target: "host_backend", "Pre-image requested. Key: {key}");
 
         // Acquire a read lock on the key-value store.
         let kv_lock = self.kv.read().await;
@@ -137,7 +137,7 @@ where
                     H::fetch_hint(hint.clone(), &self.cfg, &self.providers, self.kv.clone()).await;
 
                 if let Err(e) = value {
-                    error!(target: "host-backend", "Failed to prefetch hint: {e}");
+                    error!(target: "host_backend", "Failed to prefetch hint: {e}");
                     continue;
                 }
 

--- a/bin/host/src/server.rs
+++ b/bin/host/src/server.rs
@@ -64,7 +64,7 @@ where
         oracle_server: P,
         backend: Arc<B>,
     ) -> Result<(), PreimageServerError> {
-        info!(target: "host-server", "Starting oracle server");
+        info!(target: "host_server", "Starting oracle server");
         loop {
             // Serve the next preimage request. This `await` will yield to the runtime
             // if no progress can be made.
@@ -82,7 +82,7 @@ where
     /// Starts the hint router, which waits for incoming hints and routes them to the appropriate
     /// handler.
     async fn start_hint_router(hint_reader: H, backend: Arc<B>) -> Result<(), PreimageServerError> {
-        info!(target: "host-server", "Starting hint router");
+        info!(target: "host_server", "Starting hint router");
         loop {
             // Route the next hint. This `await` will yield to the runtime if no progress can be
             // made.

--- a/crates/proof/executor/src/builder/assemble.rs
+++ b/crates/proof/executor/src/builder/assemble.rs
@@ -122,7 +122,7 @@ where
         let parent_number = self.trie_db.parent_block_header().number;
 
         info!(
-            target: "block-builder",
+            target: "block_builder",
             version = OUTPUT_ROOT_VERSION,
             state_root = ?self.trie_db.parent_block_header().state_root,
             block_number = parent_number,
@@ -141,7 +141,7 @@ where
         let output_root = keccak256(raw_output);
 
         info!(
-            target: "block-builder",
+            target: "block_builder",
             block_number = parent_number,
             output_root = ?output_root,
             "Computed output root",

--- a/crates/proof/executor/src/builder/core.rs
+++ b/crates/proof/executor/src/builder/core.rs
@@ -85,7 +85,7 @@ where
             .map_err(|e| TrieDBError::Provider(e.to_string()))?;
 
         info!(
-            target: "block-builder",
+            target: "block_builder",
             block_number = block_env.number,
             block_timestamp = block_env.timestamp,
             block_gas_limit = block_env.gas_limit,
@@ -116,7 +116,7 @@ where
         let ex_result = executor.execute_block(transactions.iter())?;
 
         info!(
-            target: "block-builder",
+            target: "block_builder",
             gas_used = ex_result.gas_used,
             gas_limit = block_env.gas_limit,
             "Finished block building. Beginning sealing job."
@@ -128,7 +128,7 @@ where
         let header = self.seal_block(&attrs, parent_hash, &block_env, &ex_result, bundle)?;
 
         info!(
-            target: "block-builder",
+            target: "block_builder",
             number = header.number,
             hash = ?header.seal(),
             state_root = ?header.state_root,

--- a/crates/proof/proof-interop/src/boot.rs
+++ b/crates/proof/proof-interop/src/boot.rs
@@ -92,7 +92,7 @@ impl BootInfo {
         let raw_pre_state = read_raw_pre_state(oracle, l2_pre).await?;
         if raw_pre_state == INVALID_TRANSITION {
             warn!(
-                target: "boot-loader",
+                target: "boot_loader",
                 "Invalid pre-state, short-circuiting to check post-state claim."
             );
 
@@ -121,7 +121,7 @@ impl BootInfo {
             chain_ids.iter().map(|id| (*id, ROLLUP_CONFIGS[id].clone())).collect()
         } else {
             warn!(
-                target: "boot-loader",
+                target: "boot_loader",
                 "No rollup config found for chain IDs {:?}, falling back to preimage oracle. This is insecure in production without additional validation!",
                 chain_ids
             );

--- a/crates/proof/proof/src/boot.rs
+++ b/crates/proof/proof/src/boot.rs
@@ -109,7 +109,7 @@ impl BootInfo {
             config.clone()
         } else {
             warn!(
-                target: "boot-loader",
+                target: "boot_loader",
                 "No rollup config found for chain ID {}, falling back to preimage oracle. This is insecure in production without additional validation!",
                 chain_id
             );

--- a/crates/proof/proof/src/l1/blob_provider.rs
+++ b/crates/proof/proof/src/l1/blob_provider.rs
@@ -75,7 +75,7 @@ impl<T: CommsClient> OracleBlobProvider<T> {
         }
 
         tracing::info!(
-            target: "client-blob-oracle",
+            target: "client_blob_oracle",
             index = blob_hash.index,
             hash = ?blob_hash.hash,
             "Retrieved blob"

--- a/crates/protocol/derive/src/sources/blobs.rs
+++ b/crates/protocol/derive/src/sources/blobs.rs
@@ -89,7 +89,7 @@ where
                     TxEnvelope::Eip4844(blob_tx_wrapper) => Some(blob_tx_wrapper.hash()),
                     _ => None,
                 };
-                warn!(target: "blob-source", "Blob tx has calldata, which will be ignored: {hash:?}");
+                warn!(target: "blob_source", "Blob tx has calldata, which will be ignored: {hash:?}");
             }
             let blob_hashes = if let Some(b) = blob_hashes {
                 b
@@ -132,7 +132,7 @@ where
         }
 
         let blobs = self.blob_fetcher.get_blobs(block_ref, &blob_hashes).await.map_err(|e| {
-            warn!(target: "blob-source", "Failed to fetch blobs: {e}");
+            warn!(target: "blob_source", "Failed to fetch blobs: {e}");
             BlobProviderError::Backend(e.to_string())
         })?;
 
@@ -194,7 +194,7 @@ where
         match next_data.decode() {
             Ok(d) => Ok(d),
             Err(_) => {
-                warn!(target: "blob-source", "Failed to decode blob data, skipping");
+                warn!(target: "blob_source", "Failed to decode blob data, skipping");
                 self.next(block_ref, batcher_address).await
             }
         }

--- a/crates/protocol/derive/src/stages/attributes_queue.rs
+++ b/crates/protocol/derive/src/stages/attributes_queue.rs
@@ -127,7 +127,7 @@ where
         }
 
         info!(
-            target: "attributes-queue",
+            target: "attributes_queue",
             txs = tx_count,
             timestamp = batch.timestamp,
             "generated attributes in payload queue",

--- a/crates/protocol/derive/src/stages/batch/batch_stream.rs
+++ b/crates/protocol/derive/src/stages/batch/batch_stream.rs
@@ -163,7 +163,7 @@ where
                         }
                         BatchValidity::Past => {
                             if !self.is_active()? {
-                                error!(target: "batch-stream", "BatchValidity::Past is not allowed pre-holocene");
+                                error!(target: "batch_stream", "BatchValidity::Past is not allowed pre-holocene");
                                 return Err(PipelineError::InvalidBatchValidity.crit());
                             }
 

--- a/crates/protocol/derive/src/stages/batch/batch_validator.rs
+++ b/crates/protocol/derive/src/stages/batch/batch_validator.rs
@@ -89,7 +89,7 @@ where
                 self.l1_blocks.clear();
             }
             debug!(
-                target: "batch-validator",
+                target: "batch_validator",
                 "Advancing batch validator origin to L1 block #{}.{}",
                 self.origin.map(|b| b.number).unwrap_or_default(),
                 origin_behind.then_some(" (origin behind)").unwrap_or_default()
@@ -105,7 +105,7 @@ where
             for (i, block) in self.l1_blocks.iter().enumerate() {
                 if parent.l1_origin.number == block.number {
                     self.l1_blocks.drain(0..i);
-                    debug!(target: "batch-validator", "Advancing internal L1 epoch");
+                    debug!(target: "batch_validator", "Advancing internal L1 epoch");
                     break;
                 }
             }
@@ -155,7 +155,7 @@ where
         // to preserve that L2 time >= L1 time. If this is the first block of the epoch, always
         // generate a batch to ensure that we at least have one batch per epoch.
         if next_timestamp < next_epoch.timestamp || first_of_epoch {
-            info!(target: "batch-validator", "Generating empty batch for epoch #{}", epoch.number);
+            info!(target: "batch_validator", "Generating empty batch for epoch #{}", epoch.number);
             return Ok(SingleBatch {
                 parent_hash: parent.block_info.hash,
                 epoch_num: epoch.number,
@@ -168,7 +168,7 @@ where
         // At this point we have auto generated every batch for the current epoch
         // that we can, so we can advance to the next epoch.
         debug!(
-            target: "batch-validator",
+            target: "batch_validator",
             "Advancing batch validator epoch: {}, timestamp: {}, epoch timestamp: {}",
             next_epoch.number, next_timestamp, next_epoch.timestamp
         );
@@ -224,7 +224,7 @@ where
         // The batch must be a single batch - this stage does not support span batches.
         let Batch::Single(mut next_batch) = next_batch else {
             error!(
-                target: "batch-validator",
+                target: "batch_validator",
                 "BatchValidator received a batch that is not a SingleBatch"
             );
             return Err(PipelineError::InvalidBatchType.crit());
@@ -239,21 +239,21 @@ where
             &stage_origin,
         ) {
             BatchValidity::Accept => {
-                info!(target: "batch-validator", "Found next batch (epoch #{})", next_batch.epoch_num);
+                info!(target: "batch_validator", "Found next batch (epoch #{})", next_batch.epoch_num);
                 Ok(next_batch)
             }
             BatchValidity::Past => {
-                warn!(target: "batch-validator", "Dropping old batch");
+                warn!(target: "batch_validator", "Dropping old batch");
                 Err(PipelineError::NotEnoughData.temp())
             }
             BatchValidity::Drop => {
-                warn!(target: "batch-validator", "Invalid singular batch, flushing current channel.");
+                warn!(target: "batch_validator", "Invalid singular batch, flushing current channel.");
                 self.prev.flush();
                 Err(PipelineError::NotEnoughData.temp())
             }
             BatchValidity::Undecided => Err(PipelineError::NotEnoughData.temp()),
             BatchValidity::Future => {
-                error!(target: "batch-validator", "Future batch detected in BatchValidator.");
+                error!(target: "batch_validator", "Future batch detected in BatchValidator.");
                 Err(PipelineError::InvalidBatchValidity.crit())
             }
         }

--- a/crates/protocol/derive/src/stages/channel/channel_assembler.rs
+++ b/crates/protocol/derive/src/stages/channel/channel_assembler.rs
@@ -70,7 +70,7 @@ where
         if let Some(channel) = self.channel.as_ref() {
             if self.is_timed_out()? {
                 warn!(
-                    target: "channel-assembler",
+                    target: "channel_assembler",
                     "Channel (ID: {}) timed out at L1 origin #{}, open block #{}. Discarding channel.",
                     hex::encode(channel.id()),
                     origin.number,
@@ -86,7 +86,7 @@ where
         // Start a new channel if the frame number is 0.
         if next_frame.number == 0 {
             info!(
-                target: "channel-assembler",
+                target: "channel_assembler",
                 "Starting new channel (ID: {}) at L1 origin #{}",
                 hex::encode(next_frame.id),
                 origin.number
@@ -98,7 +98,7 @@ where
             // Add the frame to the channel. If this fails, return NotEnoughData and discard the
             // frame.
             debug!(
-                target: "channel-assembler",
+                target: "channel_assembler",
                 "Adding frame #{} to channel (ID: {}) at L1 origin #{}",
                 next_frame.number,
                 hex::encode(channel.id()),
@@ -106,7 +106,7 @@ where
             );
             if channel.add_frame(next_frame, origin).is_err() {
                 error!(
-                    target: "channel-assembler",
+                    target: "channel_assembler",
                     "Failed to add frame to channel (ID: {}) at L1 origin #{}",
                     hex::encode(channel.id()),
                     origin.number
@@ -121,7 +121,7 @@ where
             };
             if channel.size() > max_rlp_bytes_per_channel as usize {
                 warn!(
-                    target: "channel-assembler",
+                    target: "channel_assembler",
                     "Compressed channel size exceeded max RLP bytes per channel, dropping channel (ID: {}) with {} bytes",
                     hex::encode(channel.id()),
                     channel.size()
@@ -136,7 +136,7 @@ where
                     channel.frame_data().ok_or(PipelineError::ChannelNotFound.crit())?;
 
                 info!(
-                    target: "channel-assembler",
+                    target: "channel_assembler",
                     "Channel (ID: {}) ready for decompression.",
                     hex::encode(channel.id()),
                 );

--- a/crates/protocol/derive/src/stages/channel/channel_bank.rs
+++ b/crates/protocol/derive/src/stages/channel/channel_bank.rs
@@ -99,7 +99,7 @@ where
             origin.number
         {
             warn!(
-                target: "channel-bank",
+                target: "channel_bank",
                 "Channel (ID: {}) timed out", hex::encode(frame.id)
             );
             return Ok(());
@@ -108,7 +108,7 @@ where
         // Ingest the frame. If it fails, ignore the frame.
         let frame_id = frame.id;
         if current_channel.add_frame(frame, origin).is_err() {
-            warn!(target: "channel-bank", "Failed to add frame to channel: {:?}", frame_id);
+            warn!(target: "channel_bank", "Failed to add frame to channel: {:?}", frame_id);
             return Ok(());
         }
 
@@ -121,7 +121,7 @@ where
     pub fn read(&mut self) -> PipelineResult<Option<Bytes>> {
         // Bail if there are no channels to read from.
         if self.channel_queue.is_empty() {
-            trace!(target: "channel-bank", "No channels to read from");
+            trace!(target: "channel_bank", "No channels to read from");
             return Err(PipelineError::Eof.temp());
         }
 
@@ -134,7 +134,7 @@ where
         if channel.open_block_number() + self.cfg.channel_timeout(origin.timestamp) < origin.number
         {
             warn!(
-                target: "channel-bank",
+                target: "channel_bank",
                 "Channel (ID: {}) timed out", hex::encode(first)
             );
             self.channels.remove(&first);

--- a/crates/protocol/derive/src/stages/channel/channel_reader.rs
+++ b/crates/protocol/derive/src/stages/channel/channel_reader.rs
@@ -105,13 +105,13 @@ where
     ///
     /// SAFETY: Only called post-holocene activation.
     fn flush(&mut self) {
-        debug!(target: "channel-reader", "[POST-HOLOCENE] Flushing channel");
+        debug!(target: "channel_reader", "[POST-HOLOCENE] Flushing channel");
         self.next_channel();
     }
 
     async fn next_batch(&mut self) -> PipelineResult<Batch> {
         if let Err(e) = self.set_batch_reader().await {
-            debug!(target: "channel-reader", "Failed to set batch reader: {:?}", e);
+            debug!(target: "channel_reader", "Failed to set batch reader: {:?}", e);
             self.next_channel();
             return Err(e);
         }
@@ -149,7 +149,7 @@ where
         match signal {
             Signal::FlushChannel => {
                 // Drop the current in-progress channel.
-                warn!(target: "channel-reader", "Flushed channel");
+                warn!(target: "channel_reader", "Flushed channel");
                 self.next_batch = None;
             }
             s => {

--- a/crates/protocol/derive/src/stages/frame_queue.rs
+++ b/crates/protocol/derive/src/stages/frame_queue.rs
@@ -117,7 +117,7 @@ where
         let data = match self.prev.next_data().await {
             Ok(data) => data,
             Err(e) => {
-                debug!(target: "frame-queue", "Failed to retrieve data: {:?}", e);
+                debug!(target: "frame_queue", "Failed to retrieve data: {:?}", e);
                 // SAFETY: Bubble up potential EOF error without wrapping.
                 return Err(e);
             }
@@ -126,7 +126,7 @@ where
         let Ok(frames) = Frame::parse_frames(&data.into()) else {
             // There may be more frames in the queue for the
             // pipeline to advance, so don't return an error here.
-            error!(target: "frame-queue", "Failed to parse frames from data.");
+            error!(target: "frame_queue", "Failed to parse frames from data.");
             return Ok(());
         };
 
@@ -161,7 +161,7 @@ where
 
         // If we did not add more frames but still have more data, retry this function.
         if self.queue.is_empty() {
-            trace!(target: "frame-queue", "Queue is empty after fetching data. Retrying next_frame.");
+            trace!(target: "frame_queue", "Queue is empty after fetching data. Retrying next_frame.");
             return Err(PipelineError::NotEnoughData.temp());
         }
 

--- a/crates/protocol/derive/src/stages/l1_traversal.rs
+++ b/crates/protocol/derive/src/stages/l1_traversal.rs
@@ -73,7 +73,7 @@ impl<F: ChainProvider + Send> OriginAdvancer for L1Traversal<F> {
         let block = match self.block {
             Some(block) => block,
             None => {
-                warn!(target: "l1-traversal",  "Missing current block, can't advance origin with no reference.");
+                warn!(target: "l1_traversal",  "Missing current block, can't advance origin with no reference.");
                 return Err(PipelineError::Eof.temp());
             }
         };

--- a/crates/protocol/driver/src/pipeline.rs
+++ b/crates/protocol/driver/src/pipeline.rs
@@ -34,11 +34,11 @@ where
         loop {
             match self.step(l2_safe_head).await {
                 StepResult::PreparedAttributes => {
-                    info!(target: "client-derivation-driver", "Stepped derivation pipeline")
+                    info!(target: "client_derivation_driver", "Stepped derivation pipeline")
                 }
                 StepResult::AdvancedOrigin => {
                     info!(
-                        target: "client-derivation-driver",
+                        target: "client_derivation_driver",
                         l1_block_number = self.origin().map(|o| o.number).ok_or(PipelineError::MissingOrigin.crit())?,
                         "Advanced origin"
                     )
@@ -49,11 +49,11 @@ where
                     // stages can make progress.
                     match e {
                         PipelineErrorKind::Temporary(_) => {
-                            trace!(target: "client-derivation-driver", "Failed to step derivation pipeline temporarily: {:?}", e);
+                            trace!(target: "client_derivation_driver", "Failed to step derivation pipeline temporarily: {:?}", e);
                             continue;
                         }
                         PipelineErrorKind::Reset(e) => {
-                            warn!(target: "client-derivation-driver", "Failed to step derivation pipeline due to reset: {:?}", e);
+                            warn!(target: "client_derivation_driver", "Failed to step derivation pipeline due to reset: {:?}", e);
                             let system_config = self
                                 .system_config_by_number(l2_safe_head.block_info.number)
                                 .await?;
@@ -92,7 +92,7 @@ where
                             }
                         }
                         PipelineErrorKind::Critical(_) => {
-                            warn!(target: "client-derivation-driver", "Failed to step derivation pipeline: {:?}", e);
+                            warn!(target: "client_derivation_driver", "Failed to step derivation pipeline: {:?}", e);
                             return Err(e);
                         }
                     }

--- a/crates/protocol/interop/src/graph.rs
+++ b/crates/protocol/interop/src/graph.rs
@@ -52,7 +52,7 @@ where
         rollup_configs: &'a HashMap<u64, RollupConfig>,
     ) -> MessageGraphResult<Self, P> {
         info!(
-            target: "message-graph",
+            target: "message_graph",
             "Deriving message graph from {} blocks.",
             blocks.len()
         );
@@ -68,7 +68,7 @@ where
         }
 
         info!(
-            target: "message-graph",
+            target: "message_graph",
             "Derived {} executing messages from {} blocks.",
             messages.len(),
             blocks.len()
@@ -79,7 +79,7 @@ where
     /// Checks the validity of all messages within the graph.
     pub async fn resolve(mut self) -> MessageGraphResult<(), P> {
         info!(
-            target: "message-graph",
+            target: "message_graph",
             "Checking the message graph for invalid messages."
         );
 
@@ -94,7 +94,7 @@ where
             bad_block_chain_ids.dedup_by(|a, b| a == b);
 
             warn!(
-                target: "message-graph",
+                target: "message_graph",
                 "Failed to reduce the message graph entirely. Invalid messages found in chains {}",
                 bad_block_chain_ids
                     .iter()
@@ -121,7 +121,7 @@ where
         for message in core::mem::take(&mut self.messages) {
             if let Err(e) = self.check_single_dependency(&message).await {
                 warn!(
-                    target: "message-graph",
+                    target: "message_graph",
                     "Invalid ExecutingMessage found - relayed on chain {} with message hash {}.",
                     message.executing_chain_id,
                     hex::encode(message.inner.payloadHash)
@@ -132,7 +132,7 @@ where
         }
 
         info!(
-            target: "message-graph",
+            target: "message_graph",
             "Successfully reduced the message graph. {} invalid messages found.",
             invalid_messages.len()
         );


### PR DESCRIPTION
## Overview

Converts all `kebab-case` tracing targets to `snake_case` to standardize. There's quite a mix in the codebase at the moment.

Validate that none remain with `rg "target:\s*\"([a-z0-9]+(?:-[a-z0-9]+)*)\""`