### PR TITLE
feat: add info subcommand to kona-node

### DIFF
--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -1,7 +1,7 @@
 //! Contains the node CLI.
 
 use crate::{
-    commands::{NetCommand, NodeCommand, RegistryCommand},
+    commands::{InfoCommand, NetCommand, NodeCommand, RegistryCommand},
     flags::{GlobalArgs, MetricsArgs},
 };
 use anyhow::Result;
@@ -18,6 +18,8 @@ pub enum Commands {
     Net(NetCommand),
     /// Lists the OP Stack chains available in the superchain-registry.
     Registry(RegistryCommand),
+    /// Get info about op chain.
+    Info(InfoCommand),
 }
 
 /// The node CLI.
@@ -45,6 +47,7 @@ impl Cli {
             Commands::Registry(ref registry) => {
                 registry.init_telemetry(&self.global, &self.metrics)?
             }
+            Commands::Info(ref info) => info.init_telemetry(&self.global, &self.metrics)?,
         }
 
         // Run the subcommand.
@@ -52,6 +55,7 @@ impl Cli {
             Commands::Node(node) => Self::run_until_ctrl_c(node.run(&self.global)),
             Commands::Net(net) => Self::run_until_ctrl_c(net.run(&self.global)),
             Commands::Registry(registry) => registry.run(&self.global),
+            Commands::Info(info) => info.run(&self.global),
         }
     }
 

--- a/bin/node/src/commands/info.rs
+++ b/bin/node/src/commands/info.rs
@@ -1,0 +1,52 @@
+//! Info Subcommand
+
+use crate::flags::{GlobalArgs, MetricsArgs};
+use clap::Parser;
+use kona_registry::{OPCHAINS, ROLLUP_CONFIGS};
+use tracing::info;
+
+/// The `info` Subcommand
+///
+/// The `info` subcommand is used to run the information stack for the `kona-node`.
+///
+/// # Usage
+///
+/// ```sh
+/// kona-node info
+/// ```
+
+#[derive(Parser, Debug, Clone)]
+#[command(about = "Runs the information stack for the kona-node.")]
+pub struct InfoCommand;
+
+impl InfoCommand {
+    /// Initializes the telemetry stack and Prometheus metrics recorder.
+    pub fn init_telemetry(&self, args: &GlobalArgs, metrics: &MetricsArgs) -> anyhow::Result<()> {
+        args.init_tracing(None)?;
+        metrics.init_metrics()
+    }
+
+    pub fn run(&self, args: &GlobalArgs) -> anyhow::Result<()> {
+        info!("Running info command");
+
+        let op_chain_config = OPCHAINS.get(&args.l2_chain_id).expect("No Chain config found");
+        let op_rollup_config =
+            ROLLUP_CONFIGS.get(&args.l2_chain_id).expect("No Rollup config found");
+
+        println!("-------------");
+        println!("CHAIN ID: {}", args.l2_chain_id);
+        println!("-------------");
+        println!("--> Block Time: {}", op_chain_config.block_time);
+        println!("--> Name: {}", op_chain_config.name);
+        println!("--> Identifier: {}", op_chain_config.chain_id);
+        println!("--> Public RPC - {}", op_chain_config.public_rpc);
+        println!("--> Sequencer RPC - {}", op_chain_config.sequencer_rpc);
+        println!("--> Explorer - {}", op_chain_config.explorer);
+
+        println!("--> Hardforks: {}", op_rollup_config.hardforks);
+
+        println!("-------------");
+
+        Ok(())
+    }
+}

--- a/bin/node/src/commands/info.rs
+++ b/bin/node/src/commands/info.rs
@@ -33,18 +33,13 @@ impl InfoCommand {
         let op_rollup_config =
             ROLLUP_CONFIGS.get(&args.l2_chain_id).expect("No Rollup config found");
 
-        println!("-------------");
-        println!("CHAIN ID: {}", args.l2_chain_id);
-        println!("-------------");
-        println!("--> Block Time: {}", op_chain_config.block_time);
-        println!("--> Name: {}", op_chain_config.name);
-        println!("--> Identifier: {}", op_chain_config.chain_id);
-        println!("--> Public RPC - {}", op_chain_config.public_rpc);
-        println!("--> Sequencer RPC - {}", op_chain_config.sequencer_rpc);
-        println!("--> Explorer - {}", op_chain_config.explorer);
-
-        println!("--> Hardforks: {}", op_rollup_config.hardforks);
-
+        println!("Name: {}", op_chain_config.name);
+        println!("Block Time: {}", op_chain_config.block_time);
+        println!("Identifier: {}", op_chain_config.chain_id);
+        println!("Public RPC - {}", op_chain_config.public_rpc);
+        println!("Sequencer RPC - {}", op_chain_config.sequencer_rpc);
+        println!("Explorer - {}", op_chain_config.explorer);
+        println!("Hardforks: {}", op_rollup_config.hardforks);
         println!("-------------");
 
         Ok(())

--- a/bin/node/src/commands/mod.rs
+++ b/bin/node/src/commands/mod.rs
@@ -1,5 +1,8 @@
 //! Contains subcommands for the kona node.
 
+mod info;
+pub use info::InfoCommand;
+
 mod node;
 pub use node::NodeCommand;
 


### PR DESCRIPTION
Closes #1393 

To run:
```
cargo run --bin kona-node info
```

Currently it prints:
```
-------------
CHAIN ID: 10
-------------
--> Block Time: 2
--> Name: OP Mainnet
--> Identifier: 10
--> Public RPC - https://mainnet.optimism.io
--> Sequencer RPC - https://mainnet-sequencer.optimism.io
--> Explorer - https://explorer.optimism.io
--> Hardforks: 🍴 Scheduled Hardforks:
-> Regolith Activation Time: Not scheduled
-> Canyon Activation Time: 1704992401
-> Delta Activation Time: 1708560000
-> Ecotone Activation Time: 1710374401
-> Fjord Activation Time: 1720627201
-> Granite Activation Time: 1726070401
-> Holocene Activation Time: 1736445601
-> Pectra Blob Schedule Activation Time (Sepolia Superchain Only): Not scheduled
-> Isthmus Activation Time: 1746806401
-> Interop Activation Time: Not scheduled
```