### PR TITLE
chore(node/p2p): Broadcast Wrapper

### DIFF
--- a/crates/node/p2p/src/lib.rs
+++ b/crates/node/p2p/src/lib.rs
@@ -11,7 +11,7 @@
 extern crate tracing;
 
 mod net;
-pub use net::{Config, Network, NetworkBuilder, NetworkBuilderError};
+pub use net::{Broadcast, Config, Network, NetworkBuilder, NetworkBuilderError};
 
 mod rpc;
 pub use rpc::{NetRpcRequest, NetworkRpc};

--- a/crates/node/p2p/src/net/broadcast.rs
+++ b/crates/node/p2p/src/net/broadcast.rs
@@ -1,0 +1,50 @@
+//! Broadcast handles broadcasting unsafe blocks in-order.
+
+use op_alloy_rpc_types_engine::OpNetworkPayloadEnvelope;
+use std::collections::VecDeque;
+use tokio::sync::broadcast::{Receiver as BroadcastReceiver, Sender as BroadcastSender};
+
+/// The `Broadcast` struct is responsible for broadcasting unsafe blocks in order.
+#[derive(Debug)]
+pub struct Broadcast {
+    /// An in-memory buffer to store blocks.
+    buffer: VecDeque<OpNetworkPayloadEnvelope>,
+    /// The channel to broadcast blocks.
+    channel: BroadcastSender<OpNetworkPayloadEnvelope>,
+}
+
+impl Broadcast {
+    /// Creates a new `Broadcast` instance with the given channel.
+    pub fn new(channel: BroadcastSender<OpNetworkPayloadEnvelope>) -> Self {
+        Self { buffer: VecDeque::new(), channel }
+    }
+
+    /// Pushes a new unsafe block to the buffer.
+    pub fn push(&mut self, block: OpNetworkPayloadEnvelope) {
+        self.buffer.push_back(block);
+    }
+
+    /// Subscribe to the broadcast channel.
+    pub fn subscribe(&self) -> BroadcastReceiver<OpNetworkPayloadEnvelope> {
+        self.channel.subscribe()
+    }
+
+    /// Broadcasts all unsafe blocks **in order** through the channel.
+    ///
+    /// If an error occurs, the function will exit early, maintaining the invariant that unsafe
+    /// blocks are held in order.
+    pub fn broadcast(&mut self) {
+        loop {
+            if self.buffer.is_empty() {
+                break;
+            }
+            if let Some(block) = self.buffer.front() {
+                if let Err(e) = self.channel.send(block.clone()) {
+                    trace!("Failed to send unsafe block through channel: {:?}", e);
+                    break;
+                }
+                self.buffer.pop_front();
+            }
+        }
+    }
+}

--- a/crates/node/p2p/src/net/builder.rs
+++ b/crates/node/p2p/src/net/builder.rs
@@ -9,8 +9,8 @@ use std::{net::SocketAddr, path::PathBuf, time::Duration};
 use tokio::sync::broadcast::Sender as BroadcastSender;
 
 use crate::{
-    Config, Discv5Builder, GossipDriverBuilder, NetRpcRequest, Network, NetworkBuilderError,
-    PeerMonitoring, PeerScoreLevel,
+    Broadcast, Config, Discv5Builder, GossipDriverBuilder, NetRpcRequest, Network,
+    NetworkBuilderError, PeerMonitoring, PeerScoreLevel,
 };
 
 /// Constructs a [`Network`] for the OP Stack Consensus Layer.
@@ -189,7 +189,7 @@ impl NetworkBuilder {
             discovery,
             unsafe_block_signer_sender,
             rpc,
-            payload_tx,
+            broadcast: Broadcast::new(payload_tx),
             publish_rx,
             cfg,
         })

--- a/crates/node/p2p/src/net/mod.rs
+++ b/crates/node/p2p/src/net/mod.rs
@@ -1,5 +1,8 @@
 //! Network driver module.
 
+mod broadcast;
+pub use broadcast::Broadcast;
+
 mod error;
 pub use error::NetworkBuilderError;
 


### PR DESCRIPTION
### Description

Wraps broadcasting to encapsulate the unsafe block buffer.

Improves `kona-p2p` so the unsafe block buffer is better abstracted.