### PR TITLE
fix(node/p2p): Metrics Tasks

### DIFF
--- a/crates/node/p2p/src/discv5/driver.rs
+++ b/crates/node/p2p/src/discv5/driver.rs
@@ -1,7 +1,7 @@
 //! Discovery Module.
 
 use derive_more::Debug;
-use discv5::{Discv5, Enr, Event, enr::NodeId};
+use discv5::{Discv5, Enr, enr::NodeId};
 use libp2p::Multiaddr;
 use std::path::PathBuf;
 use tokio::{
@@ -11,7 +11,7 @@ use tokio::{
 
 use crate::{
     BootNode, BootNodes, BootStore, Discv5Builder, Discv5Handler, EnrValidation, HandlerRequest,
-    HandlerResponse, OpStackEnr, enr_to_multiaddr,
+    OpStackEnr, enr_to_multiaddr,
 };
 
 /// The [`Discv5Driver`] drives the discovery service.
@@ -43,10 +43,10 @@ use crate::{
 ///         .with_chain_id(10) // OP Mainnet chain id
 ///         .build()
 ///         .expect("Failed to build discovery service");
-///     let mut handler = disc.start();
+///     let (_, enr_receiver) = disc.start();
 ///
 ///     loop {
-///         if let Some(enr) = handler.enr_receiver.recv().await {
+///         if let Some(enr) = enr_receiver.recv().await {
 ///             println!("Received peer enr: {:?}", enr);
 ///         }
 ///     }
@@ -61,7 +61,6 @@ pub struct Discv5Driver {
     pub store: BootStore,
     /// The chain ID of the network.
     pub chain_id: u64,
-    ///
     /// The interval to discovery random nodes.
     pub interval: Duration,
 }
@@ -214,12 +213,10 @@ impl Discv5Driver {
     /// Spawns a new [`Discv5`] discovery service in a new tokio task.
     ///
     /// Returns a [`Discv5Handler`] to communicate with the spawned task.
-    pub fn start(mut self) -> Discv5Handler {
+    pub fn start(mut self) -> (Discv5Handler, tokio::sync::mpsc::Receiver<Enr>) {
         let chain_id = self.chain_id;
         let (req_sender, mut req_recv) = channel::<HandlerRequest>(1024);
-        let (res_sender, res_recv) = channel::<HandlerResponse>(1024);
         let (enr_sender, enr_recv) = channel::<Enr>(1024);
-        let (_events_sender, events_recv) = channel::<Event>(1024);
 
         tokio::spawn(async move {
             // Step 1: Start the discovery service.
@@ -246,17 +243,23 @@ impl Discv5Driver {
                     msg = req_recv.recv() => {
                         match msg {
                             Some(msg) => match msg {
-                                HandlerRequest::Metrics => {
+                                HandlerRequest::Metrics(tx) => {
                                     let metrics = self.disc.metrics();
-                                    let _ = res_sender.send(HandlerResponse::Metrics(metrics)).await;
+                                    if let Err(e) = tx.send(metrics) {
+                                        warn!(target: "discovery", "Failed to send metrics: {:?}", e);
+                                    }
                                 }
-                                HandlerRequest::PeerCount => {
+                                HandlerRequest::PeerCount(tx) => {
                                     let peers = self.disc.connected_peers();
-                                    let _ = res_sender.send(HandlerResponse::PeerCount(peers)).await;
+                                    if let Err(e) = tx.send(peers) {
+                                        warn!(target: "discovery", "Failed to send peer count: {:?}", e);
+                                    }
                                 }
-                                HandlerRequest::LocalEnr => {
+                                HandlerRequest::LocalEnr(tx) => {
                                     let enr = self.disc.local_enr().clone();
-                                    let _ = res_sender.send(HandlerResponse::LocalEnr(enr)).await;
+                                    if let Err(e) = tx.send(enr.clone()) {
+                                        warn!(target: "discovery", "Failed to send local enr: {:?}", e);
+                                    }
                                 }
                                 HandlerRequest::AddEnr(enr) => {
                                     let _ = self.disc.add_enr(enr);
@@ -264,9 +267,11 @@ impl Discv5Driver {
                                 HandlerRequest::RequestEnr(enode) => {
                                     let _ = self.disc.request_enr(enode).await;
                                 }
-                                HandlerRequest::TableEnrs => {
+                                HandlerRequest::TableEnrs(tx) => {
                                     let enrs = self.disc.table_entries_enr();
-                                    let _ = res_sender.send(HandlerResponse::TableEnrs(enrs)).await;
+                                    if let Err(e) = tx.send(enrs) {
+                                        warn!(target: "discovery", "Failed to send table enrs: {:?}", e);
+                                    }
                                 },
                                 HandlerRequest::BanAddrs{addrs_to_ban, ban_duration} => {
                                     let enrs = self.disc.table_entries_enr();
@@ -312,7 +317,7 @@ impl Discv5Driver {
             }
         });
 
-        Discv5Handler::new(chain_id, req_sender, res_recv, events_recv, enr_recv)
+        (Discv5Handler::new(chain_id, req_sender), enr_recv)
     }
 }
 
@@ -333,7 +338,7 @@ mod tests {
             .with_chain_id(OP_SEPOLIA_CHAIN_ID)
             .build()
             .expect("Failed to build discovery service");
-        let handle = discovery.start();
+        let (handle, _) = discovery.start();
         assert_eq!(handle.chain_id, OP_SEPOLIA_CHAIN_ID);
     }
 

--- a/crates/node/p2p/src/discv5/driver.rs
+++ b/crates/node/p2p/src/discv5/driver.rs
@@ -43,7 +43,7 @@ use crate::{
 ///         .with_chain_id(10) // OP Mainnet chain id
 ///         .build()
 ///         .expect("Failed to build discovery service");
-///     let (_, enr_receiver) = disc.start();
+///     let (_, mut enr_receiver) = disc.start();
 ///
 ///     loop {
 ///         if let Some(enr) = enr_receiver.recv().await {

--- a/crates/node/p2p/src/discv5/mod.rs
+++ b/crates/node/p2p/src/discv5/mod.rs
@@ -10,4 +10,4 @@ mod driver;
 pub use driver::Discv5Driver;
 
 mod handler;
-pub use handler::{Discv5Handler, HandlerRequest, HandlerResponse};
+pub use handler::{Discv5Handler, HandlerRequest};

--- a/crates/node/p2p/src/lib.rs
+++ b/crates/node/p2p/src/lib.rs
@@ -33,9 +33,7 @@ pub use peers::{
 };
 
 mod discv5;
-pub use discv5::{
-    Discv5Builder, Discv5BuilderError, Discv5Driver, Discv5Handler, HandlerRequest, HandlerResponse,
-};
+pub use discv5::{Discv5Builder, Discv5BuilderError, Discv5Driver, Discv5Handler, HandlerRequest};
 
 mod utils;
 pub use utils::{KeypairError, ParseKeyError, get_keypair, parse_key};

--- a/crates/node/p2p/src/net/driver.rs
+++ b/crates/node/p2p/src/net/driver.rs
@@ -14,9 +14,7 @@ use tokio::{
     time::Duration,
 };
 
-use crate::{
-    Discv5Driver, GossipDriver, HandlerRequest, NetRpcRequest, NetworkBuilder, enr_to_multiaddr,
-};
+use crate::{Discv5Driver, GossipDriver, HandlerRequest, NetRpcRequest, NetworkBuilder};
 
 /// Network
 ///
@@ -69,7 +67,7 @@ impl Network {
     pub fn start(mut self) -> Result<(), TransportError<std::io::Error>> {
         let mut rpc = self.rpc.unwrap_or_else(|| tokio::sync::mpsc::channel(1).1);
         let mut publish = self.publish_rx.unwrap_or_else(|| tokio::sync::mpsc::channel(1).1);
-        let mut handler = self.discovery.start();
+        let (handler, mut enr_receiver) = self.discovery.start();
 
         // We are checking the peer scores every [`Self::PEER_SCORE_INSPECT_FREQUENCY`] seconds.
         let mut peer_score_inspector = tokio::time::interval(Self::PEER_SCORE_INSPECT_FREQUENCY);
@@ -113,7 +111,7 @@ impl Network {
                             unsafe_blocks.push_back(payload);
                         }
                     },
-                    enr = handler.enr_receiver.recv() => {
+                    enr = enr_receiver.recv() => {
                         let Some(enr) = enr else {
                             trace!("Receiver `None` peer enr");
                             continue;
@@ -153,7 +151,6 @@ impl Network {
 
                             if let Some(addr) = self.gossip.peerstore.remove(&peer_to_remove){
                                 self.gossip.dialed_peers.remove(&addr);
-
                                 return Some(addr);
                             }
 
@@ -170,46 +167,7 @@ impl Network {
                             trace!("Receiver `None` rpc request");
                             continue;
                         };
-                        match req {
-                            crate::NetRpcRequest::PeerInfo(sender) => {
-                                let peer_id = self.gossip.local_peer_id().to_string();
-                                let chain_id = handler.chain_id;
-                                let enr = handler.local_enr().await.unwrap();
-                                let node_id = handler.local_enr().await.unwrap().id().unwrap_or_default();
-
-                                // We need to add the local multiaddr to the list of known addresses.
-                                let mut addresses = enr_to_multiaddr(&enr).map(|addr| vec![addr.to_string()]).unwrap_or_default();
-
-                                addresses.extend(self.gossip.swarm.external_addresses().map(|a| a.to_string()));
-
-                                let peer_info = kona_rpc::PeerInfo {
-                                    peer_id,
-                                    node_id,
-                                    user_agent: "kona".to_string(),
-                                    protocol_version: "1".to_string(),
-                                    enr: enr.to_string(),
-                                    addresses,
-                                    protocols: None, // TODO: peer supported protocols
-                                    connectedness: kona_rpc::Connectedness::Connected,
-                                    direction: kona_rpc::Direction::Inbound,
-                                    protected: false,
-                                    chain_id,
-                                    latency: 0,
-                                    gossip_blocks: false,
-                                    peer_scores: kona_rpc::PeerScores::default(),
-                                };
-                                if let Err(e) = sender.send(peer_info) {
-                                    warn!("Failed to send peer info through response channel: {:?}", e);
-                                }
-                            }
-                            crate::NetRpcRequest::PeerCount(sender) => {
-                                let disc_pc = handler.peers();
-                                let gossip_pc = self.gossip.connected_peers();
-                                if let Err(e) = sender.send((disc_pc, gossip_pc)) {
-                                    warn!("Failed to send peer count through response channel: {:?}", e);
-                                }
-                            }
-                        }
+                        req.handle(&self.gossip, &handler);
                     },
                 }
             }

--- a/crates/node/p2p/src/rpc/request.rs
+++ b/crates/node/p2p/src/rpc/request.rs
@@ -1,5 +1,6 @@
 //! Contains the network RPC request type.
 
+use crate::{Discv5Handler, GossipDriver};
 use kona_rpc::PeerInfo;
 use tokio::sync::oneshot::Sender;
 
@@ -12,4 +13,87 @@ pub enum NetRpcRequest {
     /// - Discovery Service ([`crate::Discv5Driver`])
     /// - Gossip Service ([`crate::GossipDriver`])
     PeerCount(Sender<(Option<usize>, usize)>),
+}
+
+impl NetRpcRequest {
+    /// Handles the peer count request.
+    pub fn handle(self, gossip: &GossipDriver, disc: &Discv5Handler) {
+        match self {
+            Self::PeerCount(s) => Self::handle_peer_count(s, gossip, disc),
+            Self::PeerInfo(s) => Self::handle_peer_info(s, gossip, disc),
+        }
+    }
+
+    /// Handles a peer info request by spawning a task.
+    fn handle_peer_info(sender: Sender<PeerInfo>, gossip: &GossipDriver, disc: &Discv5Handler) {
+        let peer_id = gossip.local_peer_id().to_string();
+        let chain_id = disc.chain_id;
+        let local_enr = disc.local_enr();
+        let external_addresses =
+            gossip.swarm.external_addresses().map(|a| a.to_string()).collect::<Vec<String>>();
+        tokio::spawn(async move {
+            let enr = match local_enr.await {
+                Ok(enr) => enr,
+                Err(e) => {
+                    warn!("Failed to receive local ENR: {:?}", e);
+                    let key = discv5::enr::CombinedKey::generate_secp256k1();
+                    match discv5::Enr::builder().build(&key) {
+                        Ok(enr) => enr,
+                        Err(e) => {
+                            warn!("Failed to build default ENR: {:?}", e);
+                            return;
+                        }
+                    }
+                }
+            };
+            let node_id = enr.id().unwrap_or_default();
+
+            // We need to add the local multiaddr to the list of known addresses.
+            let mut addresses = crate::enr_to_multiaddr(&enr)
+                .map(|addr| vec![addr.to_string()])
+                .unwrap_or_default();
+            addresses.extend(external_addresses);
+            let peer_info = kona_rpc::PeerInfo {
+                peer_id,
+                node_id,
+                user_agent: "kona".to_string(),
+                protocol_version: "1".to_string(),
+                enr: enr.to_string(),
+                addresses,
+                protocols: None, // TODO: peer supported protocols
+                connectedness: kona_rpc::Connectedness::Connected,
+                direction: kona_rpc::Direction::Inbound,
+                protected: false,
+                chain_id,
+                latency: 0,
+                gossip_blocks: false,
+                peer_scores: kona_rpc::PeerScores::default(),
+            };
+            if let Err(e) = sender.send(peer_info) {
+                warn!("Failed to send peer info through response channel: {:?}", e);
+            }
+        });
+    }
+
+    /// Handles a peer count request by spawning a task.
+    fn handle_peer_count(
+        sender: Sender<(Option<usize>, usize)>,
+        gossip: &GossipDriver,
+        disc: &Discv5Handler,
+    ) {
+        let pc_req = disc.peer_count();
+        let gossip_pc = gossip.connected_peers();
+        tokio::spawn(async move {
+            let pc = match pc_req.await {
+                Ok(pc) => Some(pc),
+                Err(e) => {
+                    warn!("Failed to receive peer count: {:?}", e);
+                    None
+                }
+            };
+            if let Err(e) = sender.send((pc, gossip_pc)) {
+                warn!("Failed to send peer count through response channel: {:?}", e);
+            }
+        });
+    }
 }


### PR DESCRIPTION
### Description

Fixes metrics responses to be spawned in tasks instead of blocking the network driver.