### PR TITLE
fix(node/p2p): Peer Score Level Off

### DIFF
--- a/crates/node/p2p/src/peers/score.rs
+++ b/crates/node/p2p/src/peers/score.rs
@@ -9,7 +9,7 @@ use libp2p::gossipsub::{PeerScoreParams, PeerScoreThresholds, TopicHash, TopicSc
 pub enum PeerScoreLevel {
     /// No peer scoring is applied.
     #[default]
-    r#None,
+    Off,
     /// Light peer scoring is applied.
     Light,
 }
@@ -100,7 +100,7 @@ impl PeerScoreLevel {
             topic_scores.insert(topic, Self::topic_score_params(block_time));
         }
         match self {
-            Self::r#None => None,
+            Self::Off => None,
             Self::Light => Some(PeerScoreParams {
                 topics: topic_scores,
                 topic_score_cap: 34.0,


### PR DESCRIPTION
### Description

Currently, setting the `PeerScoreLevel` to `None` isn't possible via clap since it seems to be interpreted as an option variant.

In other words, if you pass `--p2p.scoring none` to the `kona-node` it will error on parsing `none` as a variant of `PeerScoreLevel`.

This PR changes the `r#None` variant to `Off` so peer scoring can be disabled with `--p2p.scoring off`.

> [!NOTE]
>
> Notice, this creates a diff in the api of the `--p2p.scoring` cli flag between the `kona-node` and `op-node`.