### PR TITLE
fix(node/p2p): Discovery Test Fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4490,6 +4490,7 @@ dependencies = [
  "discv5",
  "futures",
  "jsonrpsee",
+ "kona-cli",
  "kona-genesis",
  "kona-rpc",
  "lazy_static",

--- a/crates/node/p2p/Cargo.toml
+++ b/crates/node/p2p/Cargo.toml
@@ -55,6 +55,7 @@ derive_more = { workspace = true, features = ["display", "deref", "debug"] }
 arbitrary = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
+kona-cli.workspace = true
 multihash = "0.19.3"
 tempfile.workspace = true
 arbtest.workspace = true

--- a/crates/node/p2p/src/discv5/driver.rs
+++ b/crates/node/p2p/src/discv5/driver.rs
@@ -443,7 +443,7 @@ mod tests {
             })
             .collect();
 
-        // There should be 8 valid ENRs for the mainnet.
+        // There should be 13 valid ENRs for the mainnet.
         assert_eq!(mainnet.len(), 13);
 
         let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0);

--- a/crates/node/p2p/src/discv5/driver.rs
+++ b/crates/node/p2p/src/discv5/driver.rs
@@ -376,7 +376,7 @@ mod tests {
         // There are no ENRs for `OP_SEPOLIA_CHAIN_ID` in the bootstore.
         // If an ENR is added, this check will fail.
         discovery.bootnode_bootstrap();
-        assert_eq!(discovery.disc.table_entries_enr().len(), 0);
+        assert!(discovery.disc.table_entries_enr().is_empty());
 
         // Now add the ENODEs
         discovery.enode_bootstrap().await;

--- a/crates/node/p2p/src/discv5/driver.rs
+++ b/crates/node/p2p/src/discv5/driver.rs
@@ -123,8 +123,8 @@ impl Discv5Driver {
         Some(enr)
     }
 
-    /// Bootstraps the [`Discv5`] service with the bootnodes.
-    async fn bootstrap(&mut self) {
+    /// Bootstraps the [`Discv5`] table with bootnodes.
+    fn bootnode_bootstrap(&mut self) {
         let nodes = BootNodes::from_chain_id(self.chain_id);
 
         let boot_enrs: Vec<Enr> = nodes
@@ -151,11 +151,22 @@ impl Discv5Driver {
         }
         info!(target: "discovery", "Added {} Bootnode ENRs to discovery table", count);
 
+        // Merge the bootnodes into the bootstore.
+        self.store.merge(boot_enrs);
+        debug!(target: "discovery",
+            new=%count,
+            total=%self.store.len(),
+            "Added new ENRs to discv5 bootstore"
+        );
+    }
+
+    /// Adds ENRs from the bootstore to the discovery table.
+    fn bootstore_bootstrap(&mut self) {
         // Add ENRs in the bootstore to the discovery table.
         //
         // Note, discv5's table may not accept new ENRs above a certain limit.
         // Instead of erroring, we log the failure as a debug log.
-        count = 0;
+        let mut count = 0;
         for enr in self.store.valid_peers() {
             let validation = EnrValidation::validate(enr, self.chain_id);
             if validation.is_invalid() {
@@ -168,14 +179,11 @@ impl Discv5Driver {
             }
         }
         info!(target: "discovery", "Added {} Bootstore ENRs to discovery table", count);
+    }
 
-        // Merge the bootnodes into the bootstore.
-        self.store.merge(boot_enrs);
-        debug!(target: "discovery",
-            new=%count,
-            total=%self.store.len(),
-            "Added new ENRs to discv5 bootstore"
-        );
+    /// Bootstraps the [`Discv5`] service with the enodes from the bootnodes.
+    async fn enode_bootstrap(&mut self) {
+        let nodes = BootNodes::from_chain_id(self.chain_id);
 
         let mut boot_enodes_enrs = Vec::new();
         for node in nodes.0 {
@@ -195,10 +203,16 @@ impl Discv5Driver {
         // Merge the bootnodes into the bootstore.
         self.store.merge(boot_enodes_enrs);
         debug!(target: "discovery",
-            new=%count,
             total=%self.store.len(),
             "Added new ENRs to discv5 bootstore"
         );
+    }
+
+    /// Bootstraps the [`Discv5`] service with the bootnodes.
+    async fn bootstrap(&mut self) {
+        self.bootnode_bootstrap();
+        self.bootstore_bootstrap();
+        self.enode_bootstrap().await;
     }
 
     /// Sends ENRs from the boot store to the enr receiver.
@@ -349,7 +363,7 @@ mod tests {
         let dir = std::env::temp_dir();
         assert!(std::env::set_current_dir(&dir).is_ok());
 
-        let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9099);
+        let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0);
         let mut discovery = Discv5Driver::builder()
             .with_address(socket)
             .with_chain_id(OP_SEPOLIA_CHAIN_ID)
@@ -359,12 +373,14 @@ mod tests {
 
         discovery.init().await;
 
-        discovery.bootstrap().await;
+        // There are no ENRs for `OP_SEPOLIA_CHAIN_ID` in the bootstore.
+        // If an ENR is added, this check will fail.
+        discovery.bootnode_bootstrap();
+        assert_eq!(discovery.disc.table_entries_enr().len(), 0);
 
-        // Verify bootstore has entries.
-        assert!(!discovery.store.is_empty(), "No nodes were added to the bootstore");
-        // Verify discv5 has entries in its enr table.
-        assert!(!discovery.disc.table_entries_enr().is_empty());
+        // Now add the ENODEs
+        discovery.enode_bootstrap().await;
+        assert_eq!(discovery.disc.table_entries_enr().len(), 8);
 
         // It should have the same number of entries as the testnet table.
         let testnet = BootNodes::testnet();
@@ -386,6 +402,10 @@ mod tests {
             })
             .collect();
 
+        // There should be 8 valid ENRs for the testnet.
+        assert_eq!(testnet.len(), 8);
+
+        // Those 8 ENRs should be in the discovery table.
         let disc_enrs = discovery.disc.table_entries_enr();
         for public_key in testnet {
             assert!(

--- a/crates/node/p2p/src/discv5/driver.rs
+++ b/crates/node/p2p/src/discv5/driver.rs
@@ -346,7 +346,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_discv5_driver() {
-        let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0);
+        let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0);
         let discovery = Discv5Driver::builder()
             .with_address(socket)
             .with_chain_id(OP_SEPOLIA_CHAIN_ID)
@@ -363,7 +363,7 @@ mod tests {
         let dir = std::env::temp_dir();
         assert!(std::env::set_current_dir(&dir).is_ok());
 
-        let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0);
+        let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0);
         let mut discovery = Discv5Driver::builder()
             .with_address(socket)
             .with_chain_id(OP_SEPOLIA_CHAIN_ID)
@@ -418,6 +418,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_discv5_driver_bootstrap_mainnet() {
+        kona_cli::init_test_tracing();
+
         // Use a test directory to make sure bootstore
         // doesn't conflict with a local bootstore.
         let dir = std::env::temp_dir();
@@ -444,7 +446,7 @@ mod tests {
         // There should be 8 valid ENRs for the mainnet.
         assert_eq!(mainnet.len(), 13);
 
-        let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0);
+        let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0);
         let mut discovery = Discv5Driver::builder()
             .with_address(socket)
             .with_chain_id(OP_MAINNET_CHAIN_ID)


### PR DESCRIPTION
### Description

Fixes discovery driver tests.

Previously, if you had a local bootstore, the test would pick it up, causing inconsistent test results.

This PR isolates bootstrapping via bootnodes from bootstrapping via the bootstore, making tests repeatable and consistent.