### PR TITLE
feat(bin/node): add custom bootnode list CLI arg

### DIFF
--- a/bin/node/src/commands/bootstore.rs
+++ b/bin/node/src/commands/bootstore.rs
@@ -58,7 +58,7 @@ impl BootstoreCommand {
             .get(&chain_id)
             .ok_or(anyhow::anyhow!("Chain ID {} not found in the registry", chain_id))?;
         println!("{} Bootstore (Chain ID: {})", chain.name, chain_id);
-        let bootstore = BootStore::from_chain_id(chain_id, self.bootstore.clone());
+        let bootstore = BootStore::from_chain_id(chain_id, self.bootstore.clone(), vec![]);
         println!("Path: {}", bootstore.path.display());
         println!("Peer Count: {}", bootstore.peers.len());
         println!("Valid peers: {}", bootstore.valid_peers_with_chain_id(chain_id).len());

--- a/bin/node/src/commands/discover.rs
+++ b/bin/node/src/commands/discover.rs
@@ -119,7 +119,7 @@ impl Discovery {
         let (handler, mut enr_receiver) = discovery.start();
         tracing::info!("Discovery service started, receiving peers.");
 
-        let mut bootstore = BootStore::from_chain_id(self.l2_chain_id, None);
+        let mut bootstore = BootStore::from_chain_id(self.l2_chain_id, None, vec![]);
 
         // Receive events from crossterm.
         let mut events = EventStream::new();

--- a/bin/node/src/flags/p2p.rs
+++ b/bin/node/src/flags/p2p.rs
@@ -8,6 +8,7 @@ use crate::flags::GlobalArgs;
 use alloy_primitives::B256;
 use anyhow::Result;
 use clap::Parser;
+use discv5::Enr;
 use kona_p2p::{Config, PeerMonitoring, PeerScoreLevel};
 use libp2p::identity::Keypair;
 use std::{
@@ -130,6 +131,10 @@ pub struct P2PArgs {
     /// redialed indefinitely.
     #[arg(long = "p2p.redial", env = "KONA_NODE_P2P_REDIAL")]
     pub peer_redial: Option<u64>,
+
+    /// An optional list of bootnode ENRs to start the node with.
+    #[arg(long = "p2p.bootnodes", value_delimiter = ',', env = "KONA_NODE_P2P_BOOTNODES")]
+    pub bootnodes: Vec<Enr>,
 }
 
 impl Default for P2PArgs {
@@ -155,6 +160,7 @@ impl Default for P2PArgs {
             ban_threshold: 0,
             ban_duration: 30,
             discovery_interval: 5,
+            bootnodes: Vec::new(),
             bootstore: None,
             peer_redial: None,
         }
@@ -247,6 +253,10 @@ impl P2PArgs {
             monitor_peers,
             bootstore: self.bootstore.clone(),
             redial: self.peer_redial,
+            // It is ok to clone here since the config only happens at startup
+            // and that we assume the number of bootnodes explicitly specified
+            // through the CLI is small.
+            bootnodes: self.bootnodes.clone(),
         })
     }
 

--- a/crates/node/p2p/src/discv5/driver.rs
+++ b/crates/node/p2p/src/discv5/driver.rs
@@ -85,8 +85,9 @@ impl Discv5Driver {
         interval: Duration,
         chain_id: u64,
         bootstore: Option<PathBuf>,
+        bootnodes: Vec<Enr>,
     ) -> Self {
-        let store = BootStore::from_chain_id(chain_id, bootstore);
+        let store = BootStore::from_chain_id(chain_id, bootstore, bootnodes);
         Self {
             disc,
             chain_id,

--- a/crates/node/p2p/src/net/builder.rs
+++ b/crates/node/p2p/src/net/builder.rs
@@ -1,7 +1,7 @@
 //! Network Builder Module.
 
 use alloy_primitives::Address;
-use discv5::{Config as Discv5Config, ListenConfig};
+use discv5::{Config as Discv5Config, Enr, ListenConfig};
 use kona_genesis::RollupConfig;
 use libp2p::{Multiaddr, identity::Keypair};
 use op_alloy_rpc_types_engine::OpNetworkPayloadEnvelope;
@@ -37,6 +37,7 @@ impl From<Config> for NetworkBuilder {
         Self::new()
             .with_discovery_config(config.discovery_config)
             .with_bootstore(config.bootstore)
+            .with_bootnodes(config.bootnodes)
             .with_discovery_interval(config.discovery_interval)
             .with_discovery_address(config.discovery_address)
             .with_gossip_address(config.gossip_address)
@@ -74,6 +75,10 @@ impl NetworkBuilder {
             return Self { discovery: self.discovery.with_bootstore(bootstore), ..self };
         }
         self
+    }
+
+    pub fn with_bootnodes(self, bootnodes: Vec<Enr>) -> Self {
+        Self { discovery: self.discovery.with_bootnodes(bootnodes), ..self }
     }
 
     /// Sets the block time used by peer scoring.

--- a/crates/node/p2p/src/net/config.rs
+++ b/crates/node/p2p/src/net/config.rs
@@ -2,6 +2,7 @@
 
 use crate::{PeerScoreLevel, peers::PeerMonitoring};
 use alloy_primitives::Address;
+use discv5::Enr;
 use libp2p::identity::Keypair;
 use std::{net::SocketAddr, path::PathBuf};
 use tokio::time::Duration;
@@ -33,4 +34,6 @@ pub struct Config {
     pub bootstore: Option<PathBuf>,
     /// The optional number of times to redial a peer.
     pub redial: Option<u64>,
+    /// An optional list of bootnode ENRs to start the node with.
+    pub bootnodes: Vec<Enr>,
 }

--- a/crates/node/p2p/src/peers/store.rs
+++ b/crates/node/p2p/src/peers/store.rs
@@ -21,7 +21,7 @@ pub struct BootStore {
     pub peers: Vec<Enr>,
 }
 
-// This custom implementation of `Deserialize` allows us to avignore
+// This custom implementation of `Deserialize` allows us to ignore
 // enrs that have an invalid string format in the store.
 impl<'de> serde::Deserialize<'de> for BootStore {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
@@ -155,9 +155,14 @@ impl BootStore {
     /// Reads a new [`BootStore`] from the given chain id and data directory.
     ///
     /// If the file cannot be read, an empty [`BootStore`] is returned.
-    pub fn from_chain_id(chain_id: u64, datadir: Option<PathBuf>) -> Self {
+    pub fn from_chain_id(chain_id: u64, datadir: Option<PathBuf>, bootnodes: Vec<Enr>) -> Self {
         let path = Self::path(chain_id, datadir);
-        Self::from_file(&path)
+        let mut store = Self::from_file(&path);
+
+        // Add the bootnodes to the bootstore.
+        store.merge(bootnodes);
+
+        store
     }
 
     /// Reads a new [`BootStore`] from the given chain id and data directory.


### PR DESCRIPTION
## Description
This PR adds a new CLI flag to allow manually defining a custom list of initial bootnodes to be added to the p2p discovery layer at startup. This change will allow us to add local network addresses inside Kurtosis.