### PR TITLE
feat(bin/node): ensure genesis matches the rollup config before fetching to the known network params list.

### DIFF
--- a/bin/node/src/commands/net.rs
+++ b/bin/node/src/commands/net.rs
@@ -58,7 +58,7 @@ impl NetCommand {
 
         // Start the Network Stack
         self.p2p.check_ports()?;
-        let p2p_config = self.p2p.config(args)?;
+        let p2p_config = self.p2p.config(&rollup_config, args)?;
         let mut network = NetworkBuilder::from(p2p_config)
             .with_chain_id(args.l2_chain_id)
             .with_rpc_receiver(rx)

--- a/bin/node/src/commands/node.rs
+++ b/bin/node/src/commands/node.rs
@@ -8,7 +8,7 @@ use kona_genesis::RollupConfig;
 use kona_node_service::{RollupNode, RollupNodeService};
 use op_alloy_provider::ext::engine::OpEngineApi;
 use serde_json::from_reader;
-use std::{fs::File, path::PathBuf};
+use std::{fs::File, path::PathBuf, sync::Arc};
 use tracing::{debug, error};
 use url::Url;
 
@@ -73,15 +73,12 @@ impl NodeCommand {
     /// Validate the jwt secret if specified by exchanging capabilities with the engine.
     /// Since the engine client will fail if the jwt token is invalid, this allows to ensure
     /// that the jwt token passed as a cli arg is correct.
-    pub async fn validate_jwt(&self, args: &GlobalArgs) -> anyhow::Result<JwtSecret> {
+    pub async fn validate_jwt(&self, config: &RollupConfig) -> anyhow::Result<JwtSecret> {
         let jwt_secret = self.jwt_secret().ok_or(anyhow::anyhow!("Invalid JWT secret"))?;
         let engine_client = kona_engine::EngineClient::new_http(
             self.l2_engine_rpc.clone(),
             self.l2_provider_rpc.clone(),
-            args.rollup_config().map(std::sync::Arc::new).ok_or(anyhow::anyhow!(
-                "Failed to get rollup config for chain id: {}",
-                args.l2_chain_id
-            ))?,
+            Arc::new(config.clone()),
             jwt_secret,
         );
         match engine_client.exchange_capabilities(vec![]).await {
@@ -106,7 +103,7 @@ impl NodeCommand {
     /// Run the Node subcommand.
     pub async fn run(self, args: &GlobalArgs) -> anyhow::Result<()> {
         let cfg = self.get_l2_config(args)?;
-        let jwt_secret = self.validate_jwt(args).await?;
+        let jwt_secret = self.validate_jwt(&cfg).await?;
         let kind = self.l2_engine_kind;
         let sync_config = SyncConfig {
             sync_mode: SyncMode::ExecutionLayer,

--- a/bin/node/src/commands/node.rs
+++ b/bin/node/src/commands/node.rs
@@ -114,7 +114,7 @@ impl NodeCommand {
         };
 
         self.p2p_flags.check_ports()?;
-        let p2p_config = self.p2p_flags.config(args)?;
+        let p2p_config = self.p2p_flags.config(&cfg, args)?;
         let rpc_config = self.rpc_flags.into();
 
         RollupNode::builder(cfg)

--- a/bin/node/src/flags/globals.rs
+++ b/bin/node/src/flags/globals.rs
@@ -20,15 +20,6 @@ pub struct GlobalArgs {
 }
 
 impl GlobalArgs {
-    /// Returns the block time for the L2 chain.
-    pub fn block_time(&self) -> anyhow::Result<u64> {
-        let id = self.l2_chain_id;
-        Ok(OPCHAINS
-            .get(&id)
-            .ok_or(anyhow::anyhow!("No chain config found for chain ID: {id}"))?
-            .block_time)
-    }
-
     pub fn init_tracing(&self, filter: Option<EnvFilter>) -> anyhow::Result<()> {
         Ok(init_tracing_subscriber(self.v, filter)?)
     }

--- a/bin/node/src/flags/globals.rs
+++ b/bin/node/src/flags/globals.rs
@@ -10,8 +10,9 @@ use tracing_subscriber::EnvFilter;
 /// Global arguments for the CLI.
 #[derive(Parser, Default, Clone, Debug)]
 pub struct GlobalArgs {
-    /// Verbosity level (0-2)
-    #[arg(long, short, global=true, action = ArgAction::Count)]
+    /// Verbosity level (0-4)
+    /// If set to 0, no logs are printed.
+    #[arg(long, short, global=true, default_value = "3", action = ArgAction::Count)]
     pub v: u8,
     /// The L2 chain ID to use.
     #[arg(long, short = 'c', global = true, default_value = "10", help = "The L2 chain ID to use")]

--- a/bin/node/src/flags/p2p.rs
+++ b/bin/node/src/flags/p2p.rs
@@ -9,6 +9,7 @@ use alloy_primitives::B256;
 use anyhow::Result;
 use clap::Parser;
 use discv5::Enr;
+use kona_genesis::RollupConfig;
 use kona_p2p::{Config, PeerMonitoring, PeerScoreLevel};
 use libp2p::identity::Keypair;
 use std::{
@@ -218,7 +219,7 @@ impl P2PArgs {
     /// - [`GlobalArgs`]: required to fetch the genesis unsafe block signer.
     ///
     /// Errors if the genesis unsafe block signer isn't available for the specified L2 Chain ID.
-    pub fn config(&self, args: &GlobalArgs) -> anyhow::Result<Config> {
+    pub fn config(&self, config: &RollupConfig, args: &GlobalArgs) -> anyhow::Result<Config> {
         let mut multiaddr = libp2p::Multiaddr::from(self.listen_ip);
         multiaddr.push(libp2p::multiaddr::Protocol::Tcp(self.listen_tcp_port));
         let gossip_config = kona_p2p::default_config_builder()
@@ -228,7 +229,7 @@ impl P2PArgs {
             .gossip_lazy(self.gossip_mesh_dlazy)
             .flood_publish(self.gossip_flood_publish)
             .build()?;
-        let block_time = args.block_time()?;
+        let block_time = config.block_time;
 
         let monitor_peers = if self.ban_enabled {
             Some(PeerMonitoring {
@@ -246,7 +247,11 @@ impl P2PArgs {
             discovery_address: SocketAddr::new(self.listen_ip, self.listen_udp_port),
             gossip_address: multiaddr,
             keypair: self.keypair().unwrap_or_else(|_| Keypair::generate_secp256k1()),
-            unsafe_block_signer: args.genesis_signer()?,
+            unsafe_block_signer: config
+                .genesis
+                .system_config
+                .map(|config| Ok(config.batcher_address))
+                .unwrap_or_else(|| args.genesis_signer())?,
             gossip_config,
             scoring: self.scoring,
             block_time,

--- a/crates/utilities/cli/src/tracing.rs
+++ b/crates/utilities/cli/src/tracing.rs
@@ -16,8 +16,10 @@ pub fn init_tracing_subscriber(
     env_filter: Option<impl Into<EnvFilter>>,
 ) -> Result<(), SetGlobalDefaultError> {
     let level = match verbosity_level {
-        0 => Level::INFO,
-        1 => Level::DEBUG,
+        1 => Level::ERROR,
+        2 => Level::WARN,
+        3 => Level::INFO,
+        4 => Level::DEBUG,
         _ => Level::TRACE,
     };
     let filter = env_filter.map(|e| e.into()).unwrap_or(EnvFilter::from_default_env());


### PR DESCRIPTION
## Description
This PR ensures that we can fully configure the rollup with a custom `rollup_config`. Currently, on node startup, some arguments (like the block time or the unsafe block signer) are retrieved from a file containing a list of known network configurations. This prevents us from defining fully custom local networks with an unknown chain ID.

This PR changes the node startup behavior by retrieving the node configuration from the `rollup_config` *first*. If the configuration is unavailable or unspecified, the node tries to retrieve the values from the known network parameters.

This PR will allow us to spin up completely custom networks from Kurtosis.

## Note
This PR depends on #1497 and #1496 