### PR TITLE
fix(utilities): CLI Verbosity Level

### DIFF
--- a/bin/host/src/bin/host.rs
+++ b/bin/host/src/bin/host.rs
@@ -23,8 +23,9 @@ primary thread.
 #[derive(Parser, Serialize, Clone, Debug)]
 #[command(about = ABOUT, version, styles = cli_styles())]
 pub struct HostCli {
-    /// Verbosity level (0-4)
+    /// Verbosity level (0-5)
     /// If set to 0, no logs are printed.
+    /// By default, the verbosity level is set to 3 (info level).
     #[arg(long, short, default_value = "3", action = ArgAction::Count)]
     pub v: u8,
     /// Host mode

--- a/bin/host/src/bin/host.rs
+++ b/bin/host/src/bin/host.rs
@@ -23,8 +23,9 @@ primary thread.
 #[derive(Parser, Serialize, Clone, Debug)]
 #[command(about = ABOUT, version, styles = cli_styles())]
 pub struct HostCli {
-    /// Verbosity level (0-2)
-    #[arg(long, short, action = ArgAction::Count)]
+    /// Verbosity level (0-4)
+    /// If set to 0, no logs are printed.
+    #[arg(long, short, default_value = "3", action = ArgAction::Count)]
     pub v: u8,
     /// Host mode
     #[command(subcommand)]

--- a/bin/node/src/flags/globals.rs
+++ b/bin/node/src/flags/globals.rs
@@ -10,8 +10,9 @@ use tracing_subscriber::EnvFilter;
 /// Global arguments for the CLI.
 #[derive(Parser, Default, Clone, Debug)]
 pub struct GlobalArgs {
-    /// Verbosity level (0-4)
+    /// Verbosity level (0-5).
     /// If set to 0, no logs are printed.
+    /// By default, the verbosity level is set to 3 (info level).
     #[arg(long, short, global=true, default_value = "3", action = ArgAction::Count)]
     pub v: u8,
     /// The L2 chain ID to use.

--- a/crates/utilities/cli/src/tracing.rs
+++ b/crates/utilities/cli/src/tracing.rs
@@ -6,7 +6,7 @@ use tracing_subscriber::EnvFilter;
 /// Initializes the tracing subscriber
 ///
 /// # Arguments
-/// * `verbosity_level` - The verbosity level (0-2)
+/// * `verbosity_level` - The verbosity level (0-5). If `0`, no logs are printed.
 /// * `env_filter` - Optional environment filter for the subscriber.
 ///
 /// # Returns
@@ -22,6 +22,9 @@ pub fn init_tracing_subscriber(
         4 => Level::DEBUG,
         _ => Level::TRACE,
     };
+    if verbosity_level == 0 {
+        return tracing::subscriber::set_global_default(tracing_subscriber::fmt().finish());
+    }
     let filter = env_filter.map(|e| e.into()).unwrap_or(EnvFilter::from_default_env());
     let filter = filter.add_directive(level.into());
     let subscriber = tracing_subscriber::fmt().with_max_level(level);
@@ -35,5 +38,5 @@ pub fn init_tracing_subscriber(
 /// - `init_tracing_subscriber`: Initializes the tracing subscriber with a specified verbosity level
 ///   and optional environment filter.
 pub fn init_test_tracing() {
-    let _ = init_tracing_subscriber(2, None::<EnvFilter>);
+    let _ = init_tracing_subscriber(4, None::<EnvFilter>);
 }

--- a/examples/discovery/src/main.rs
+++ b/examples/discovery/src/main.rs
@@ -26,8 +26,9 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 #[derive(Parser, Debug, Clone)]
 #[command(about = "Runs the discovery service")]
 pub struct DiscCommand {
-    /// Verbosity level (0-2)
-    #[arg(long, short, action = ArgAction::Count)]
+    /// Verbosity level (0-4)
+    /// If set to 0, no logs are printed.
+    #[arg(long, short, default_value = "3", action = ArgAction::Count)]
     pub v: u8,
     /// The L2 chain ID to use.
     #[arg(long, short = 'c', default_value = "10", help = "The L2 chain ID to use")]

--- a/examples/discovery/src/main.rs
+++ b/examples/discovery/src/main.rs
@@ -26,8 +26,9 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 #[derive(Parser, Debug, Clone)]
 #[command(about = "Runs the discovery service")]
 pub struct DiscCommand {
-    /// Verbosity level (0-4)
+    /// Verbosity level (0-5).
     /// If set to 0, no logs are printed.
+    /// By default, the verbosity level is set to 3 (info level).
     #[arg(long, short, default_value = "3", action = ArgAction::Count)]
     pub v: u8,
     /// The L2 chain ID to use.

--- a/examples/execution-fixture/src/main.rs
+++ b/examples/execution-fixture/src/main.rs
@@ -29,8 +29,9 @@ use url::Url;
 #[derive(Parser, Debug, Clone)]
 #[command(about = "Creates a static test fixture for `kona-executor` from a live chain")]
 pub struct ExecutionFixtureCommand {
-    /// Verbosity level (0-2)
-    #[arg(long, short, action = ArgAction::Count)]
+    /// Verbosity level (0-4)
+    /// If set to 0, no logs are printed.
+    #[arg(long, short, default_value = "3", action = ArgAction::Count)]
     pub v: u8,
     /// The L2 archive EL to use.
     #[arg(long, short = 'r')]

--- a/examples/execution-fixture/src/main.rs
+++ b/examples/execution-fixture/src/main.rs
@@ -29,8 +29,9 @@ use url::Url;
 #[derive(Parser, Debug, Clone)]
 #[command(about = "Creates a static test fixture for `kona-executor` from a live chain")]
 pub struct ExecutionFixtureCommand {
-    /// Verbosity level (0-4)
+    /// Verbosity level (0-5).
     /// If set to 0, no logs are printed.
+    /// By default, the verbosity level is set to 3 (info level).
     #[arg(long, short, default_value = "3", action = ArgAction::Count)]
     pub v: u8,
     /// The L2 archive EL to use.

--- a/examples/gossip/src/main.rs
+++ b/examples/gossip/src/main.rs
@@ -29,8 +29,9 @@ use tracing_subscriber::EnvFilter;
 #[derive(Parser, Debug, Clone)]
 #[command(about = "Runs the gossip service")]
 pub struct GossipCommand {
-    /// Verbosity level (0-2)
-    #[arg(long, short, action = ArgAction::Count)]
+    /// Verbosity level (0-4)
+    /// If set to 0, no logs are printed.
+    #[arg(long, short, default_value = "3", action = ArgAction::Count)]
     pub v: u8,
     /// The L2 chain ID to use.
     #[arg(long, short = 'c', default_value = "10", help = "The L2 chain ID to use")]

--- a/examples/gossip/src/main.rs
+++ b/examples/gossip/src/main.rs
@@ -29,8 +29,9 @@ use tracing_subscriber::EnvFilter;
 #[derive(Parser, Debug, Clone)]
 #[command(about = "Runs the gossip service")]
 pub struct GossipCommand {
-    /// Verbosity level (0-4)
+    /// Verbosity level (0-5).
     /// If set to 0, no logs are printed.
+    /// By default, the verbosity level is set to 3 (info level).
     #[arg(long, short, default_value = "3", action = ArgAction::Count)]
     pub v: u8,
     /// The L2 chain ID to use.


### PR DESCRIPTION
### Description

#1497 seems to have broke the action tests since the host logs were set to tracing by default and caused too many logs.

This PR fixes the CLI verbosity levels for all binaries that use `init_tracing_subscriber`.