### PR TITLE
fix(proof-interop): Operate provider off of `local-safe` heads

### DIFF
--- a/bin/client/src/interop/consolidate.rs
+++ b/bin/client/src/interop/consolidate.rs
@@ -2,8 +2,9 @@
 
 use super::FaultProofProgramError;
 use crate::interop::util::fetch_output_block_hash;
-use alloc::{sync::Arc, vec::Vec};
+use alloc::sync::Arc;
 use core::fmt::Debug;
+use kona_executor::TrieDBProvider;
 use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use kona_proof::{CachingOracle, l2::OracleL2ChainProvider};
 use kona_proof_interop::{
@@ -27,65 +28,79 @@ where
     P: PreimageOracleClient + Send + Sync + Debug + Clone,
     H: HintWriterClient + Send + Sync + Debug + Clone,
 {
-    let provider = OracleInteropProvider::new(oracle.clone(), boot.clone());
-
     info!(target: "client_interop", "Deriving local-safe headers from prestate");
 
-    // Ensure that the pre-state is a transition state.
+    // Ensure that the pre-state is a transition state. It is invalid to pass a non-transition state
+    // to this function, as it will not have the required information to derive the local-safe
+    // headers for the next super root.
     let PreState::TransitionState(ref transition_state) = boot.agreed_pre_state else {
         return Err(FaultProofProgramError::StateTransitionFailed);
     };
 
-    let block_hashes = transition_state
+    // Collect the cross-safe output roots and local-safe block hashes from the transition state.
+    let transition_meta = transition_state
         .pending_progress
         .iter()
         .zip(transition_state.pre_state.output_roots.iter())
         .map(|(optimistic_block, pre_state)| (pre_state, optimistic_block.block_hash))
         .collect::<HashMap<_, _>>();
 
-    let mut headers = Vec::with_capacity(block_hashes.len());
+    let mut headers = HashMap::default();
     let mut l2_providers = HashMap::default();
-    for (pre, block_hash) in block_hashes {
-        // Fetch the safe head's block hash for the given L2 chain ID.
-        let safe_head_hash =
-            fetch_output_block_hash(oracle.as_ref(), pre.output_root, pre.chain_id).await?;
+    for (cross_safe_output, local_safe_block_hash) in transition_meta {
+        // Fetch the cross-safe head's block hash for the given L2 chain ID.
+        let cross_safe_head_hash = fetch_output_block_hash(
+            oracle.as_ref(),
+            cross_safe_output.output_root,
+            cross_safe_output.chain_id,
+        )
+        .await?;
+
+        // Fetch the rollup config for the given L2 chain ID.
+        let rollup_config = ROLLUP_CONFIGS
+            .get(&cross_safe_output.chain_id)
+            .or_else(|| boot.rollup_configs.get(&cross_safe_output.chain_id))
+            .ok_or(FaultProofProgramError::MissingRollupConfig(cross_safe_output.chain_id))?;
+
+        // Initialize the local provider for the current L2 chain.
+        let mut local_provider = OracleL2ChainProvider::new(
+            cross_safe_head_hash,
+            Arc::new(rollup_config.clone()),
+            oracle.clone(),
+        );
+        local_provider.set_chain_id(Some(cross_safe_output.chain_id));
 
         // Send hints for the L2 block data in the pending progress. This is an important step,
         // because non-canonical blocks within the pending progress will not be able to be fetched
-        // by the host through the traditional means. If the block is determined to not be canonical
-        // by the host, it will re-execute it and store the required preimages to complete
+        // by the host through traditional means. If the block is determined to not be canonical
+        // by the host, it will derive + build it and store the required preimages to complete
         // deposit-only re-execution. If the block is determined to be canonical, the host will
-        // no-op, and fetch preimages through the traditional route as needed.
+        // no-op, and preimages will be fetched through the traditional route as needed.
         HintType::L2BlockData
             .with_data(&[
-                safe_head_hash.as_slice(),
-                block_hash.as_slice(),
-                pre.chain_id.to_be_bytes().as_slice(),
+                cross_safe_head_hash.as_slice(),
+                local_safe_block_hash.as_slice(),
+                cross_safe_output.chain_id.to_be_bytes().as_slice(),
             ])
             .send(oracle.as_ref())
             .await?;
 
-        let header = provider.header_by_hash(pre.chain_id, block_hash).await?;
-        headers.push((pre.chain_id, header.seal(block_hash)));
+        // Fetch the header for the local-safe head of the current L2 chain.
+        let header = local_provider.header_by_hash(local_safe_block_hash)?;
 
-        let rollup_config = ROLLUP_CONFIGS
-            .get(&pre.chain_id)
-            .or_else(|| boot.rollup_configs.get(&pre.chain_id))
-            .ok_or(FaultProofProgramError::MissingRollupConfig(pre.chain_id))?;
-
-        let mut provider = OracleL2ChainProvider::new(
-            safe_head_hash,
-            Arc::new(rollup_config.clone()),
-            oracle.clone(),
-        );
-        provider.set_chain_id(Some(pre.chain_id));
-        l2_providers.insert(pre.chain_id, provider);
+        headers.insert(cross_safe_output.chain_id, header.seal(local_safe_block_hash));
+        l2_providers.insert(cross_safe_output.chain_id, local_provider);
     }
 
-    info!(target: "client_interop", "Loaded {} local-safe headers", headers.len());
+    info!(
+        target: "client_interop",
+        num_blocks = headers.len(),
+        "Loaded local-safe headers",
+    );
 
     // Consolidate the superchain
-    SuperchainConsolidator::new(&mut boot, provider, l2_providers, headers).consolidate().await?;
+    let global_provider = OracleInteropProvider::new(oracle.clone(), boot.clone(), headers);
+    SuperchainConsolidator::new(&mut boot, global_provider, l2_providers).consolidate().await?;
 
     // Transition to the Super Root at the next timestamp.
     let post = boot

--- a/crates/protocol/interop/src/graph.rs
+++ b/crates/protocol/interop/src/graph.rs
@@ -8,9 +8,9 @@ use crate::{
 };
 use alloc::vec::Vec;
 use alloy_consensus::{Header, Sealed};
-use alloy_primitives::{hex, keccak256, map::HashMap};
+use alloy_primitives::{hex, keccak256};
 use kona_genesis::RollupConfig;
-use kona_registry::ROLLUP_CONFIGS;
+use kona_registry::{HashMap, ROLLUP_CONFIGS};
 use tracing::{info, warn};
 
 /// The message graph represents a set of blocks at a given timestamp and the interop
@@ -47,7 +47,7 @@ where
     ///
     /// [ExecutingMessage]: crate::ExecutingMessage
     pub async fn derive(
-        blocks: &[(u64, Sealed<Header>)],
+        blocks: &HashMap<u64, Sealed<Header>>,
         provider: &'a P,
         rollup_configs: &'a HashMap<u64, RollupConfig>,
     ) -> MessageGraphResult<Self, P> {
@@ -261,7 +261,7 @@ mod test {
         let (headers, provider) = superchain.build();
 
         let cfgs = HashMap::default();
-        let graph = MessageGraph::derive(headers.as_slice(), &provider, &cfgs).await.unwrap();
+        let graph = MessageGraph::derive(&headers, &provider, &cfgs).await.unwrap();
         graph.resolve().await.unwrap();
     }
 
@@ -283,7 +283,7 @@ mod test {
         let (headers, provider) = superchain.build();
 
         let cfgs = HashMap::default();
-        let graph = MessageGraph::derive(headers.as_slice(), &provider, &cfgs).await.unwrap();
+        let graph = MessageGraph::derive(&headers, &provider, &cfgs).await.unwrap();
         graph.resolve().await.unwrap();
     }
 
@@ -302,7 +302,7 @@ mod test {
         let (headers, provider) = superchain.build();
 
         let cfgs = HashMap::default();
-        let graph = MessageGraph::derive(headers.as_slice(), &provider, &cfgs).await.unwrap();
+        let graph = MessageGraph::derive(&headers, &provider, &cfgs).await.unwrap();
         assert_eq!(
             graph.resolve().await.unwrap_err(),
             MessageGraphError::InvalidMessages(vec![BASE_CHAIN_ID])
@@ -324,7 +324,7 @@ mod test {
         let (headers, provider) = superchain.build();
 
         let cfgs = HashMap::default();
-        let graph = MessageGraph::derive(headers.as_slice(), &provider, &cfgs).await.unwrap();
+        let graph = MessageGraph::derive(&headers, &provider, &cfgs).await.unwrap();
         assert_eq!(
             graph.resolve().await.unwrap_err(),
             MessageGraphError::InvalidMessages(vec![BASE_CHAIN_ID])
@@ -348,7 +348,7 @@ mod test {
                 ..Default::default()
             },
         );
-        let graph = MessageGraph::derive(headers.as_slice(), &provider, &cfgs).await.unwrap();
+        let graph = MessageGraph::derive(&headers, &provider, &cfgs).await.unwrap();
         assert_eq!(
             graph.resolve().await.unwrap_err(),
             MessageGraphError::InvalidMessages(vec![BASE_CHAIN_ID])
@@ -370,7 +370,7 @@ mod test {
         let (headers, provider) = superchain.build();
 
         let cfgs = HashMap::default();
-        let graph = MessageGraph::derive(headers.as_slice(), &provider, &cfgs).await.unwrap();
+        let graph = MessageGraph::derive(&headers, &provider, &cfgs).await.unwrap();
         assert_eq!(
             graph.resolve().await.unwrap_err(),
             MessageGraphError::InvalidMessages(vec![BASE_CHAIN_ID])
@@ -392,7 +392,7 @@ mod test {
         let (headers, provider) = superchain.build();
 
         let cfgs = HashMap::default();
-        let graph = MessageGraph::derive(headers.as_slice(), &provider, &cfgs).await.unwrap();
+        let graph = MessageGraph::derive(&headers, &provider, &cfgs).await.unwrap();
         assert_eq!(
             graph.resolve().await.unwrap_err(),
             MessageGraphError::InvalidMessages(vec![BASE_CHAIN_ID])
@@ -415,7 +415,7 @@ mod test {
         let (headers, provider) = superchain.build();
 
         let cfgs = HashMap::default();
-        let graph = MessageGraph::derive(headers.as_slice(), &provider, &cfgs).await.unwrap();
+        let graph = MessageGraph::derive(&headers, &provider, &cfgs).await.unwrap();
         assert_eq!(
             graph.resolve().await.unwrap_err(),
             MessageGraphError::InvalidMessages(vec![BASE_CHAIN_ID])

--- a/crates/protocol/interop/src/test_util.rs
+++ b/crates/protocol/interop/src/test_util.rs
@@ -92,10 +92,10 @@ impl SuperchainBuilder {
     }
 
     /// Builds the scenario into the format needed for testing
-    pub fn build(self) -> (Vec<(u64, Sealed<Header>)>, MockInteropProvider) {
+    pub fn build(self) -> (HashMap<u64, Sealed<Header>>, MockInteropProvider) {
         let mut headers_map = HashMap::default();
         let mut receipts_map = HashMap::default();
-        let mut sealed_headers = Vec::new();
+        let mut sealed_headers = HashMap::default();
 
         for (chain_id, chain) in self.chains {
             let header = chain.header;
@@ -110,7 +110,7 @@ impl SuperchainBuilder {
             chain_receipts.insert(0, chain.receipts);
             receipts_map.insert(chain_id, chain_receipts);
 
-            sealed_headers.push((chain_id, sealed_header));
+            sealed_headers.insert(chain_id, sealed_header);
         }
 
         (sealed_headers, MockInteropProvider::new(headers_map, receipts_map))


### PR DESCRIPTION
## Overview

Fixes an issue in the interop client program where the `OracleInteropProvider` was operating off of the `cross-safe` heads, rather than the `local-safe` heads. After this change, the global interop provider is instantiated with the `local-safe` headers that were generated during the runs of the first sub-problem.