### PR TITLE
docs(providers-alloy): Doc touchups

### DIFF
--- a/crates/providers/providers-alloy/src/chain_provider.rs
+++ b/crates/providers/providers-alloy/src/chain_provider.rs
@@ -16,10 +16,6 @@ use std::{boxed::Box, num::NonZeroUsize, vec::Vec};
 
 /// The [AlloyChainProvider] is a concrete implementation of the [ChainProvider] trait, providing
 /// data over Ethereum JSON-RPC using an alloy provider as the backend.
-///
-/// **Note**:
-/// This provider fetches data using the `debug_getRawHeader`, `debug_getRawReceipts`, and
-/// `debug_getRawBlock` methods. The RPC must support this namespace.
 #[derive(Debug, Clone)]
 pub struct AlloyChainProvider {
     /// The inner Ethereum JSON-RPC provider.

--- a/crates/providers/providers-alloy/src/l2_chain_provider.rs
+++ b/crates/providers/providers-alloy/src/l2_chain_provider.rs
@@ -26,10 +26,6 @@ use tower::ServiceBuilder;
 
 /// The [AlloyL2ChainProvider] is a concrete implementation of the [L2ChainProvider] trait,
 /// providing data over Ethereum JSON-RPC using an alloy provider as the backend.
-///
-/// **Note**:
-/// This provider fetches data using the `debug_getRawBlock` method. The RPC must support this
-/// namespace.
 #[derive(Debug, Clone)]
 pub struct AlloyL2ChainProvider {
     /// The inner Ethereum JSON-RPC provider.


### PR DESCRIPTION
## Overview

Removes the mention of the `debug_*` namespace requirements in `kona-providers-alloy`. This was refactored out a while back, and these providers now operate off of the more widely used `eth_*` namespace methods.