### PR TITLE
feat(interop): Add message expiry check

### DIFF
--- a/crates/protocol/interop/src/constants.rs
+++ b/crates/protocol/interop/src/constants.rs
@@ -7,7 +7,7 @@ pub const CROSS_L2_INBOX_ADDRESS: Address = address!("42000000000000000000000000
 
 /// The expiry window for relaying an initiating message (in seconds).
 /// <https://specs.optimism.io/interop/messaging.html#message-expiry-invariant>
-pub const MESSAGE_EXPIRY_WINDOW: u64 = 180 * 24 * 60 * 60;
+pub const MESSAGE_EXPIRY_WINDOW: u64 = 30 * 24 * 60 * 60;
 
 /// The current version of the [SuperRoot] encoding format.
 ///

--- a/crates/protocol/interop/src/errors.rs
+++ b/crates/protocol/interop/src/errors.rs
@@ -35,6 +35,9 @@ pub enum MessageGraphError<E> {
     /// Message is in the future
     #[error("Message is in the future. Expected timestamp to be <= {0}, got {1}")]
     MessageInFuture(u64, u64),
+    /// Message has exceeded the expiry window.
+    #[error("Message has exceeded the expiry window. Timestamp: {0}")]
+    MessageExpired(u64),
     /// Invalid messages were found
     #[error("Invalid messages found on chains: {0:?}")]
     InvalidMessages(Vec<u64>),


### PR DESCRIPTION
## Overview

Adds a new check to the `MessageGraph` for the message expiry window.

spec ref: https://github.com/ethereum-optimism/specs/pull/671
