### PR TITLE
feat(bin/node): also advertise udp port

### DIFF
--- a/bin/node/src/commands/discover.rs
+++ b/bin/node/src/commands/discover.rs
@@ -5,7 +5,7 @@
 use crate::flags::{GlobalArgs, MetricsArgs};
 use clap::Parser;
 use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind};
-use kona_p2p::{BootStore, Discv5Builder};
+use kona_p2p::{AdvertisedIpAndPort, BootStore, Discv5Builder};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use tokio_stream::StreamExt;
 use tracing_appender::{non_blocking, non_blocking::WorkerGuard};
@@ -106,11 +106,12 @@ impl Discovery {
 
     /// Runs the main app.
     pub async fn run(mut self, mut terminal: DefaultTerminal) -> anyhow::Result<()> {
-        let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), self.port);
-        tracing::info!("Starting discovery service on {:?}", socket);
+        let ip_and_port =
+            AdvertisedIpAndPort::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), self.port, self.port);
+        tracing::info!("Starting discovery service on {:?}", ip_and_port);
 
         let discovery_builder =
-            Discv5Builder::new().with_address(socket).with_chain_id(self.l2_chain_id);
+            Discv5Builder::new().with_address(ip_and_port).with_chain_id(self.l2_chain_id);
         let mut discovery = discovery_builder.build()?;
         discovery.interval = std::time::Duration::from_secs(2);
         discovery.forward = false;

--- a/bin/node/src/flags/p2p.rs
+++ b/bin/node/src/flags/p2p.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 use clap::Parser;
 use discv5::Enr;
 use kona_genesis::RollupConfig;
-use kona_p2p::{Config, PeerMonitoring, PeerScoreLevel};
+use kona_p2p::{AdvertisedIpAndPort, Config, PeerMonitoring, PeerScoreLevel};
 use libp2p::identity::Keypair;
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -311,7 +311,14 @@ impl P2PArgs {
             self.listen_tcp_port
         };
 
-        let discovery_address = SocketAddr::new(advertise_ip, advertise_tcp_port);
+        let advertise_udp_port = if self.advertise_udp_port != 0 {
+            self.advertise_udp_port
+        } else {
+            self.listen_udp_port
+        };
+
+        let discovery_address =
+            AdvertisedIpAndPort::new(advertise_ip, advertise_tcp_port, advertise_udp_port);
         let gossip_config = kona_p2p::default_config_builder()
             .mesh_n(self.gossip_mesh_d)
             .mesh_n_low(self.gossip_mesh_dlo)

--- a/crates/node/p2p/README.md
+++ b/crates/node/p2p/README.md
@@ -16,7 +16,7 @@ Contains a gossipsub driver to run discv5 peer discovery and block gossip.
 ```rust,no_run
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use alloy_primitives::address;
-use kona_p2p::Network;
+use kona_p2p::{AdvertisedIpAndPort, Network};
 use libp2p::Multiaddr;
 
 // Construct the Network
@@ -24,7 +24,8 @@ let signer = address!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
 let gossip = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9099);
 let mut gossip_addr = Multiaddr::from(gossip.ip());
 gossip_addr.push(libp2p::multiaddr::Protocol::Tcp(gossip.port()));
-let disc = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9099);
+let advertise_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+let disc = AdvertisedIpAndPort::new(advertise_ip, 9097, 9098);
 let network = Network::builder()
     .with_chain_id(10) // op mainnet chain id
     .with_unsafe_block_signer(signer)

--- a/crates/node/p2p/src/discv5/builder.rs
+++ b/crates/node/p2p/src/discv5/builder.rs
@@ -1,22 +1,61 @@
 //! Contains a builder for the discovery service.
 
-use discv5::{Config, Discv5, Enr, ListenConfig, enr::CombinedKey};
-use std::{net::SocketAddr, path::PathBuf};
+use discv5::{Config, Discv5, Enr, enr::CombinedKey};
+use std::{net::IpAddr, path::PathBuf};
 use tokio::time::Duration;
 
 use crate::{Discv5BuilderError, Discv5Driver, OpStackEnr};
+
+#[derive(Debug, Clone)]
+pub struct AdvertisedIpAndPort {
+    pub ip: IpAddr,
+    pub tcp_port: u16,
+    /// Fallback UDP port.
+    pub udp_port: u16,
+}
+
+impl AdvertisedIpAndPort {
+    /// Creates a new [`AdvertisedIpAndPort`] instance.
+    pub fn new(ip: IpAddr, tcp_port: u16, udp_port: u16) -> Self {
+        Self { ip, tcp_port, udp_port }
+    }
+}
+
+impl AdvertisedIpAndPort {
+    /// Build the local node ENR. This should contain the information we wish to
+    /// broadcast to the other nodes in the network. See
+    /// [the op-node implementation](https://github.com/ethereum-optimism/optimism/blob/174e55f0a1e73b49b80a561fd3fedd4fea5770c6/op-node/p2p/discovery.go#L61-L97)
+    /// for the go equivalent
+    fn build_enr(&self, key: &CombinedKey, chain_id: u64) -> Result<Enr, discv5::enr::Error> {
+        let opstack = OpStackEnr::from_chain_id(chain_id);
+        let mut opstack_data = Vec::new();
+        use alloy_rlp::Encodable;
+        opstack.encode(&mut opstack_data);
+
+        let mut enr_builder = Enr::builder();
+        enr_builder.add_value_rlp(OpStackEnr::OP_CL_KEY, opstack_data.into());
+        match self.ip {
+            IpAddr::V4(addr) => {
+                enr_builder.ip4(addr).tcp4(self.tcp_port).udp4(self.udp_port);
+            }
+            IpAddr::V6(addr) => {
+                enr_builder.ip6(addr).tcp6(self.tcp_port).udp6(self.udp_port);
+            }
+        }
+
+        enr_builder.build(key)
+    }
+}
 
 /// Discovery service builder.
 #[derive(Debug, Default, Clone)]
 pub struct Discv5Builder {
     /// The discovery service advertised address.
-    advertised_address: Option<SocketAddr>,
+    advertised_address: Option<AdvertisedIpAndPort>,
     /// The chain ID of the network.
     chain_id: Option<u64>,
     /// The interval to find peers.
     interval: Option<Duration>,
-    /// The listen config for the discovery service.
-    listen_config: Option<ListenConfig>,
     /// The discovery config for the discovery service.
     discovery_config: Option<Config>,
     /// An optional path to the bootstore.
@@ -32,7 +71,6 @@ impl Discv5Builder {
             advertised_address: None,
             chain_id: None,
             interval: None,
-            listen_config: None,
             discovery_config: None,
             bootstore: None,
             bootnodes: Vec::new(),
@@ -51,8 +89,8 @@ impl Discv5Builder {
         self
     }
 
-    /// Sets the discovery service address.
-    pub fn with_address(mut self, address: SocketAddr) -> Self {
+    /// Sets the discovery service advertised address and ports.
+    pub fn with_address(mut self, address: AdvertisedIpAndPort) -> Self {
         self.advertised_address = Some(address);
         self
     }
@@ -69,12 +107,6 @@ impl Discv5Builder {
         self
     }
 
-    /// Sets the listen config for the discovery service.
-    pub fn with_listen_config(mut self, listen_config: ListenConfig) -> Self {
-        self.listen_config = Some(listen_config);
-        self
-    }
-
     /// Sets the discovery config for the discovery service.
     pub fn with_discovery_config(mut self, config: Config) -> Self {
         self.discovery_config = Some(config);
@@ -84,29 +116,16 @@ impl Discv5Builder {
     /// Builds a [`Discv5Driver`].
     pub fn build(self) -> Result<Discv5Driver, Discv5BuilderError> {
         let chain_id = self.chain_id.ok_or(Discv5BuilderError::ChainIdNotSet)?;
-        let opstack = OpStackEnr::from_chain_id(chain_id);
-        let mut opstack_data = Vec::new();
-        use alloy_rlp::Encodable;
-        opstack.encode(&mut opstack_data);
 
         let config = self.discovery_config.ok_or(Discv5BuilderError::DiscoveryConfigNotSet)?;
 
-        // Build the local node ENR. This should contain the information we wish to
-        // broadcast to the other nodes in the network. See
-        // [the op-node implementation](https://github.com/ethereum-optimism/optimism/blob/174e55f0a1e73b49b80a561fd3fedd4fea5770c6/op-node/p2p/discovery.go#L61-L97)
-        // for the go equivalent
         let key = CombinedKey::generate_secp256k1();
-        let mut enr_builder = Enr::builder();
-        enr_builder.add_value_rlp(OpStackEnr::OP_CL_KEY, opstack_data.into());
-        match self.advertised_address.ok_or(Discv5BuilderError::AdvertisedAddrNotSet)? {
-            SocketAddr::V4(addr) => {
-                enr_builder.ip4(*addr.ip()).tcp4(addr.port());
-            }
-            SocketAddr::V6(addr) => {
-                enr_builder.ip6(*addr.ip()).tcp6(addr.port());
-            }
-        }
-        let enr = enr_builder.build(&key).map_err(|_| Discv5BuilderError::EnrBuildFailed)?;
+
+        let enr = self
+            .advertised_address
+            .ok_or(Discv5BuilderError::AdvertisedAddrNotSet)?
+            .build_enr(&key, chain_id)
+            .map_err(|_| Discv5BuilderError::EnrBuildFailed)?;
 
         let interval = self.interval.unwrap_or(Duration::from_secs(5));
         let disc =
@@ -124,18 +143,21 @@ impl Discv5Builder {
 
 #[cfg(test)]
 mod tests {
-    use discv5::ConfigBuilder;
+    use discv5::{ConfigBuilder, ListenConfig};
 
     use super::*;
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::net::{IpAddr, Ipv4Addr};
 
     #[test]
     fn test_builds_valid_enr() {
-        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9099);
+        let addr = AdvertisedIpAndPort::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9099, 9099);
         let mut builder = Discv5Builder::new();
         builder = builder.with_address(addr);
         builder = builder.with_chain_id(10);
-        builder = builder.with_discovery_config(ConfigBuilder::new(addr.into()).build());
+        builder = builder.with_discovery_config(
+            ConfigBuilder::new(ListenConfig::Ipv4 { ip: Ipv4Addr::UNSPECIFIED, port: 9099 })
+                .build(),
+        );
         let driver = builder.build().unwrap();
         let enr = driver.disc.local_enr();
         assert!(OpStackEnr::is_valid_node(&enr, 10));

--- a/crates/node/p2p/src/discv5/driver.rs
+++ b/crates/node/p2p/src/discv5/driver.rs
@@ -32,14 +32,15 @@ use crate::{
 /// ## Example
 ///
 /// ```no_run
-/// use kona_p2p::Discv5Driver;
-/// use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+/// use kona_p2p::{AdvertisedIpAndPort, Discv5Driver};
+/// use std::net::{IpAddr, Ipv4Addr};
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9099);
+///     let advertise_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+///     let addr = AdvertisedIpAndPort::new(advertise_ip, 9099, 9098);
 ///     let mut disc = Discv5Driver::builder()
-///         .with_address(socket)
+///         .with_address(addr)
 ///         .with_chain_id(10) // OP Mainnet chain id
 ///         .build()
 ///         .expect("Failed to build discovery service");

--- a/crates/node/p2p/src/discv5/driver.rs
+++ b/crates/node/p2p/src/discv5/driver.rs
@@ -374,7 +374,7 @@ impl Discv5Driver {
 
 #[cfg(test)]
 mod tests {
-    use crate::BootNodes;
+    use crate::{BootNodes, discv5::builder::AdvertisedIpAndPort};
     use discv5::{ConfigBuilder, enr::CombinedPublicKey, handler::NodeContact};
     use kona_genesis::{OP_MAINNET_CHAIN_ID, OP_SEPOLIA_CHAIN_ID};
 
@@ -385,7 +385,7 @@ mod tests {
     async fn test_discv5_driver() {
         let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0);
         let discovery = Discv5Driver::builder()
-            .with_address(socket)
+            .with_address(AdvertisedIpAndPort::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0, 0))
             .with_chain_id(OP_SEPOLIA_CHAIN_ID)
             .with_discovery_config(ConfigBuilder::new(socket.into()).build())
             .build()
@@ -403,7 +403,7 @@ mod tests {
 
         let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0);
         let mut discovery = Discv5Driver::builder()
-            .with_address(socket)
+            .with_address(AdvertisedIpAndPort::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0, 0))
             .with_chain_id(OP_SEPOLIA_CHAIN_ID)
             .with_discovery_config(ConfigBuilder::new(socket.into()).build())
             .build()
@@ -487,7 +487,7 @@ mod tests {
 
         let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0);
         let mut discovery = Discv5Driver::builder()
-            .with_address(socket)
+            .with_address(AdvertisedIpAndPort::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0, 0))
             .with_chain_id(OP_MAINNET_CHAIN_ID)
             .with_discovery_config(ConfigBuilder::new(socket.into()).build())
             .build()

--- a/crates/node/p2p/src/discv5/mod.rs
+++ b/crates/node/p2p/src/discv5/mod.rs
@@ -1,7 +1,7 @@
 //! Discv5 Service for the OP Stack
 
 mod builder;
-pub use builder::Discv5Builder;
+pub use builder::{AdvertisedIpAndPort, Discv5Builder};
 
 mod error;
 pub use error::Discv5BuilderError;

--- a/crates/node/p2p/src/lib.rs
+++ b/crates/node/p2p/src/lib.rs
@@ -33,7 +33,10 @@ pub use peers::{
 };
 
 mod discv5;
-pub use discv5::{Discv5Builder, Discv5BuilderError, Discv5Driver, Discv5Handler, HandlerRequest};
+pub use discv5::{
+    AdvertisedIpAndPort, Discv5Builder, Discv5BuilderError, Discv5Driver, Discv5Handler,
+    HandlerRequest,
+};
 
 mod utils;
 pub use utils::{KeypairError, ParseKeyError, get_keypair, parse_key};

--- a/crates/node/p2p/src/net/config.rs
+++ b/crates/node/p2p/src/net/config.rs
@@ -1,10 +1,10 @@
 //! Configuration for the `Network`.
 
-use crate::{PeerScoreLevel, peers::PeerMonitoring};
+use crate::{PeerScoreLevel, discv5::AdvertisedIpAndPort, peers::PeerMonitoring};
 use alloy_primitives::Address;
 use discv5::Enr;
 use libp2p::identity::Keypair;
-use std::{net::SocketAddr, path::PathBuf};
+use std::path::PathBuf;
 use tokio::time::Duration;
 
 /// Configuration for kona's P2P stack.
@@ -14,7 +14,7 @@ pub struct Config {
     pub discovery_config: discv5::Config,
     /// The local node's advertised address to external peers.
     /// Note: This may be different from the node's discovery listen address.
-    pub discovery_address: SocketAddr,
+    pub discovery_address: AdvertisedIpAndPort,
     /// The interval to find peers.
     pub discovery_interval: Duration,
     /// The gossip address.

--- a/examples/discovery/src/main.rs
+++ b/examples/discovery/src/main.rs
@@ -19,8 +19,8 @@
 
 use clap::{ArgAction, Parser};
 use kona_cli::init_tracing_subscriber;
-use kona_p2p::Discv5Builder;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use kona_p2p::{AdvertisedIpAndPort, Discv5Builder};
+use std::net::{IpAddr, Ipv4Addr};
 
 /// The discovery command.
 #[derive(Parser, Debug, Clone)]
@@ -49,7 +49,11 @@ impl DiscCommand {
             .add_directive("discv5=error".parse()?);
         init_tracing_subscriber(self.v, Some(filter))?;
 
-        let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), self.disc_port);
+        let socket = AdvertisedIpAndPort::new(
+            IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+            self.disc_port,
+            self.disc_port,
+        );
         tracing::info!("Starting discovery service on {:?}", socket);
 
         let discovery_builder =

--- a/examples/gossip/src/main.rs
+++ b/examples/gossip/src/main.rs
@@ -19,7 +19,7 @@
 
 use clap::{ArgAction, Parser};
 use kona_cli::init_tracing_subscriber;
-use kona_p2p::Network;
+use kona_p2p::{AdvertisedIpAndPort, Network};
 use kona_registry::ROLLUP_CONFIGS;
 use libp2p::Multiaddr;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -68,7 +68,11 @@ impl GossipCommand {
 
         let mut gossip_addr = Multiaddr::from(gossip.ip());
         gossip_addr.push(libp2p::multiaddr::Protocol::Tcp(gossip.port()));
-        let disc_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), self.disc_port);
+        let disc_addr = AdvertisedIpAndPort::new(
+            IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+            self.disc_port,
+            self.disc_port,
+        );
         let mut network = Network::builder()
             .with_discovery_address(disc_addr)
             .with_chain_id(self.l2_chain_id)


### PR DESCRIPTION
## Description
Small PR to add the discv5 UDP port to the advertised addresses from the network.
This matches the behavior of `op-node` more closely, see [the op-node codebase](https://github.com/ethereum-optimism/optimism/blob/174e55f0a1e73b49b80a561fd3fedd4fea5770c6/op-node/p2p/discovery.go#L65-L69)