### PR TITLE
fix: Use Unspecified Ipv4Addr

### DIFF
--- a/bin/node/src/commands/discover.rs
+++ b/bin/node/src/commands/discover.rs
@@ -107,7 +107,7 @@ impl Discovery {
     /// Runs the main app.
     pub async fn run(mut self, mut terminal: DefaultTerminal) -> anyhow::Result<()> {
         let ip_and_port =
-            AdvertisedIpAndPort::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), self.port, self.port);
+            AdvertisedIpAndPort::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), self.port, self.port);
         tracing::info!("Starting discovery service on {:?}", ip_and_port);
 
         let discovery_builder =

--- a/crates/node/p2p/README.md
+++ b/crates/node/p2p/README.md
@@ -21,7 +21,7 @@ use libp2p::Multiaddr;
 
 // Construct the Network
 let signer = address!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
-let gossip = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9099);
+let gossip = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 9099);
 let mut gossip_addr = Multiaddr::from(gossip.ip());
 gossip_addr.push(libp2p::multiaddr::Protocol::Tcp(gossip.port()));
 let advertise_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);

--- a/crates/node/p2p/src/discv5/builder.rs
+++ b/crates/node/p2p/src/discv5/builder.rs
@@ -147,7 +147,7 @@ mod tests {
 
     #[test]
     fn test_builds_valid_enr() {
-        let addr = AdvertisedIpAndPort::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9099, 9099);
+        let addr = AdvertisedIpAndPort::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 9099, 9099);
         let mut builder = Discv5Builder::new();
         builder = builder.with_address(addr);
         builder = builder.with_chain_id(10);

--- a/crates/node/p2p/src/net/builder.rs
+++ b/crates/node/p2p/src/net/builder.rs
@@ -241,9 +241,9 @@ mod tests {
     fn test_build_simple_succeeds() {
         let id = 10;
         let signer = Address::random();
-        let disc_listen = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9097);
-        let disc_enr = AdvertisedIpAndPort::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9098, 9098);
-        let gossip = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9099);
+        let disc_listen = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 9097);
+        let disc_enr = AdvertisedIpAndPort::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 9098, 9098);
+        let gossip = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 9099);
         let mut gossip_addr = Multiaddr::from(gossip.ip());
         gossip_addr.push(libp2p::multiaddr::Protocol::Tcp(gossip.port()));
         let driver = NetworkBuilder::new()
@@ -277,12 +277,12 @@ mod tests {
     fn test_build_network_custom_configs() {
         let id = 10;
         let signer = Address::random();
-        let gossip = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9099);
+        let gossip = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 9099);
         let mut gossip_addr = Multiaddr::from(gossip.ip());
         gossip_addr.push(libp2p::multiaddr::Protocol::Tcp(gossip.port()));
-        let disc = AdvertisedIpAndPort::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9097, 9097);
+        let disc = AdvertisedIpAndPort::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 9097, 9097);
         let discovery_config =
-            ConfigBuilder::new(ListenConfig::from_ip(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9098))
+            ConfigBuilder::new(ListenConfig::from_ip(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 9098))
                 .build();
         let driver = NetworkBuilder::new()
             .with_unsafe_block_signer(signer)

--- a/crates/node/p2p/tests/common/mod.rs
+++ b/crates/node/p2p/tests/common/mod.rs
@@ -10,7 +10,7 @@ pub(crate) fn gossip_driver(port: u16) -> GossipDriver {
     let chain_id = 10;
     let timeout = std::time::Duration::from_secs(60);
     let mut addr = Multiaddr::empty();
-    addr.push(Protocol::Ip4(Ipv4Addr::new(0, 0, 0, 0)));
+    addr.push(Protocol::Ip4(Ipv4Addr::UNSPECIFIED));
     addr.push(Protocol::Tcp(port));
 
     // Use the default `kona_p2p` config for the gossipsub protocol.

--- a/crates/node/service/src/actors/network.rs
+++ b/crates/node/service/src/actors/network.rs
@@ -28,7 +28,7 @@ use tokio_util::sync::CancellationToken;
 ///
 /// let chain_id = 10;
 /// let signer = Address::random();
-/// let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9099);
+/// let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 9099);
 ///
 /// // Construct the `Network` using the builder.
 /// // let mut driver = Network::builder()

--- a/examples/discovery/src/main.rs
+++ b/examples/discovery/src/main.rs
@@ -50,7 +50,7 @@ impl DiscCommand {
         init_tracing_subscriber(self.v, Some(filter))?;
 
         let socket = AdvertisedIpAndPort::new(
-            IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
             self.disc_port,
             self.disc_port,
         );

--- a/examples/gossip/src/main.rs
+++ b/examples/gossip/src/main.rs
@@ -63,13 +63,13 @@ impl GossipCommand {
             .batcher_address;
         tracing::info!("Gossip configured with signer: {:?}", signer);
 
-        let gossip = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), self.gossip_port);
+        let gossip = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), self.gossip_port);
         tracing::info!("Starting gossip driver on {:?}", gossip);
 
         let mut gossip_addr = Multiaddr::from(gossip.ip());
         gossip_addr.push(libp2p::multiaddr::Protocol::Tcp(gossip.port()));
         let disc_addr = AdvertisedIpAndPort::new(
-            IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
             self.disc_port,
             self.disc_port,
         );


### PR DESCRIPTION
### Description

Uses the `Ipv4Addr::UNSPECIFIED` const over manual magic number instantiation.