### PR TITLE
fix(node/p2p): ensure that the discovery and the gossip keys match

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2805,6 +2805,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
+ "discv5",
  "kona-cli",
  "kona-p2p",
  "tokio",
@@ -2818,6 +2819,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
+ "discv5",
  "kona-cli",
  "kona-p2p",
  "kona-registry",

--- a/crates/node/p2p/Cargo.toml
+++ b/crates/node/p2p/Cargo.toml
@@ -70,7 +70,6 @@ alloy-consensus = { workspace = true, features = ["arbitrary", "k256"] }
 alloy-eips.workspace = true
 
 op-alloy-consensus = { workspace = true, features = ["arbitrary", "k256"] }
-rand = { workspace = true, features = ["thread_rng"] }
 
 [features]
 default = []

--- a/crates/node/p2p/README.md
+++ b/crates/node/p2p/README.md
@@ -16,8 +16,9 @@ Contains a gossipsub driver to run discv5 peer discovery and block gossip.
 ```rust,no_run
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use alloy_primitives::address;
-use kona_p2p::{AdvertisedIpAndPort, Network};
+use kona_p2p::{LocalNode, Network};
 use libp2p::Multiaddr;
+use discv5::enr::CombinedKey;
 
 // Construct the Network
 let signer = address!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
@@ -25,7 +26,11 @@ let gossip = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 9099);
 let mut gossip_addr = Multiaddr::from(gossip.ip());
 gossip_addr.push(libp2p::multiaddr::Protocol::Tcp(gossip.port()));
 let advertise_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
-let disc = AdvertisedIpAndPort::new(advertise_ip, 9097, 9098);
+
+let CombinedKey::Secp256k1(k256_key) = CombinedKey::generate_secp256k1() else {
+    unreachable!()
+};
+let disc = LocalNode::new(k256_key, advertise_ip, 9097, 9098);
 let network = Network::builder()
     .with_chain_id(10) // op mainnet chain id
     .with_unsafe_block_signer(signer)

--- a/crates/node/p2p/src/discv5/error.rs
+++ b/crates/node/p2p/src/discv5/error.rs
@@ -9,9 +9,9 @@ pub enum Discv5BuilderError {
     /// The node discovery config is not set
     #[error("The node discovery config is not set")]
     DiscoveryConfigNotSet,
-    /// The node advertised address is not set
-    #[error("The node advertised address is not set")]
-    AdvertisedAddrNotSet,
+    /// The node advertised information is not set
+    #[error("The local node information is not set")]
+    LocalNodeNotSet,
     /// The chain ID is not set.
     #[error("chain ID not set")]
     ChainIdNotSet,

--- a/crates/node/p2p/src/discv5/mod.rs
+++ b/crates/node/p2p/src/discv5/mod.rs
@@ -1,7 +1,7 @@
 //! Discv5 Service for the OP Stack
 
 mod builder;
-pub use builder::{AdvertisedIpAndPort, Discv5Builder};
+pub use builder::{Discv5Builder, LocalNode};
 
 mod error;
 pub use error::Discv5BuilderError;

--- a/crates/node/p2p/src/lib.rs
+++ b/crates/node/p2p/src/lib.rs
@@ -36,8 +36,7 @@ pub use peers::{
 
 mod discv5;
 pub use discv5::{
-    AdvertisedIpAndPort, Discv5Builder, Discv5BuilderError, Discv5Driver, Discv5Handler,
-    HandlerRequest,
+    Discv5Builder, Discv5BuilderError, Discv5Driver, Discv5Handler, HandlerRequest, LocalNode,
 };
 
 mod utils;

--- a/crates/node/p2p/src/net/config.rs
+++ b/crates/node/p2p/src/net/config.rs
@@ -1,6 +1,6 @@
 //! Configuration for the `Network`.
 
-use crate::{PeerScoreLevel, discv5::AdvertisedIpAndPort, peers::PeerMonitoring};
+use crate::{PeerScoreLevel, discv5::LocalNode, peers::PeerMonitoring};
 use alloy_primitives::Address;
 use discv5::Enr;
 use libp2p::identity::Keypair;
@@ -14,7 +14,7 @@ pub struct Config {
     pub discovery_config: discv5::Config,
     /// The local node's advertised address to external peers.
     /// Note: This may be different from the node's discovery listen address.
-    pub discovery_address: AdvertisedIpAndPort,
+    pub discovery_address: LocalNode,
     /// The interval to find peers.
     pub discovery_interval: Duration,
     /// The gossip address.

--- a/examples/discovery/Cargo.toml
+++ b/examples/discovery/Cargo.toml
@@ -13,3 +13,4 @@ kona-p2p.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
+discv5.workspace = true

--- a/examples/gossip/Cargo.toml
+++ b/examples/gossip/Cargo.toml
@@ -15,3 +15,4 @@ libp2p.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
+discv5.workspace = true

--- a/examples/gossip/src/main.rs
+++ b/examples/gossip/src/main.rs
@@ -18,8 +18,9 @@
 #![warn(unused_crate_dependencies)]
 
 use clap::{ArgAction, Parser};
+use discv5::enr::CombinedKey;
 use kona_cli::init_tracing_subscriber;
-use kona_p2p::{AdvertisedIpAndPort, Network};
+use kona_p2p::{LocalNode, Network};
 use kona_registry::ROLLUP_CONFIGS;
 use libp2p::Multiaddr;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -68,7 +69,12 @@ impl GossipCommand {
 
         let mut gossip_addr = Multiaddr::from(gossip.ip());
         gossip_addr.push(libp2p::multiaddr::Protocol::Tcp(gossip.port()));
-        let disc_addr = AdvertisedIpAndPort::new(
+
+        let CombinedKey::Secp256k1(secret_key) = CombinedKey::generate_secp256k1() else {
+            unreachable!()
+        };
+        let disc_addr = LocalNode::new(
+            secret_key,
             IpAddr::V4(Ipv4Addr::UNSPECIFIED),
             self.disc_port,
             self.disc_port,


### PR DESCRIPTION
## Description
This PR ensures that the keys advertised by discv5 for the local node matches the one from the gossip layer. Currently the node uses different keys for discv5 and the gossip layer which may cause some of the instability we have observed at the gossip layer (nodes get dropped unexpectedly).
