### PR TITLE
fix(host-interop): Ignore block data hint if chain hasn't progressed

### DIFF
--- a/bin/client/src/interop/consolidate.rs
+++ b/bin/client/src/interop/consolidate.rs
@@ -11,7 +11,7 @@ use kona_proof_interop::{
     BootInfo, HintType, OracleInteropProvider, PreState, SuperchainConsolidator,
 };
 use kona_registry::{HashMap, ROLLUP_CONFIGS};
-use tracing::info;
+use tracing::{error, info};
 
 /// Executes the consolidation phase of the interop proof with the given [PreimageOracleClient] and
 /// [HintWriterClient].
@@ -111,8 +111,19 @@ where
 
     // Ensure that the post-state matches the claimed post-state.
     if post_commitment != boot.claimed_post_state {
+        error!(
+            target: "client_interop",
+            claimed = ?boot.claimed_post_state,
+            actual = ?post_commitment,
+            "Post state validation failed",
+        );
         return Err(FaultProofProgramError::InvalidClaim(boot.claimed_post_state, post_commitment));
     }
 
+    info!(
+        target: "client_interop",
+        root = ?boot.claimed_post_state,
+        "Super root validation succeeded"
+    );
     Ok(())
 }


### PR DESCRIPTION
## Overview

There is a small issue in this hint currently, where it is possible for the agreed block hash to equal the disputed block hash. This is because the `SuperRoot` progresses every 1s, but the chains within it do not necessarily. In the event that the agreed block hash equals the disputed block hash, the block data hint can be ignored.