### PR TITLE
chore(ci): Remove interop proof from codecov ignore

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -32,10 +32,6 @@ ignore:
   - "crates/providers"
   # Ignore noop files
   - "**/noop.rs"
-  # Interop - WIP
-  - "crates/proof/proof-interop"
-  - "bin/host/src/interop"
-  - "bin/client/src/interop"
   # Node - WIP
   - "bin/node"
   - "crates/node/engine"


### PR DESCRIPTION
## Overview

Removes the `kona-proof-interop` and client/host interop variants from the `codecov.yml`'s ignore list.