### PR TITLE
feat(protocol): Complete `Predeploys` definition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4610,6 +4610,7 @@ version = "0.3.0"
 dependencies = [
  "alloy-eips 0.15.6",
  "alloy-primitives",
+ "kona-protocol",
  "op-alloy-consensus",
 ]
 
@@ -4675,6 +4676,7 @@ dependencies = [
  "async-trait",
  "derive_more",
  "kona-genesis",
+ "kona-protocol",
  "kona-registry",
  "op-alloy-consensus",
  "rand 0.9.1",

--- a/bin/host/src/interop/handler.rs
+++ b/bin/host/src/interop/handler.rs
@@ -11,7 +11,7 @@ use alloy_eips::{
     eip4844::{FIELD_ELEMENTS_PER_BLOB, IndexedBlobHash},
 };
 use alloy_op_evm::OpEvmFactory;
-use alloy_primitives::{Address, B256, Bytes, address, keccak256};
+use alloy_primitives::{Address, B256, Bytes, keccak256};
 use alloy_provider::Provider;
 use alloy_rlp::{Decodable, Encodable};
 use alloy_rpc_types::Block;
@@ -32,7 +32,7 @@ use kona_proof::{
     sync::new_pipeline_cursor,
 };
 use kona_proof_interop::{HintType, PreState};
-use kona_protocol::{BlockInfo, OutputRoot};
+use kona_protocol::{BlockInfo, OutputRoot, Predeploys};
 use kona_registry::ROLLUP_CONFIGS;
 use std::sync::Arc;
 use tokio::task;
@@ -195,9 +195,6 @@ impl HintHandler for InteropHintHandler {
                 )?;
             }
             HintType::L2OutputRoot => {
-                const L2_TO_L1_MESSAGE_PASSER_ADDRESS: Address =
-                    address!("4200000000000000000000000000000000000016");
-
                 ensure!(hint.data.len() >= 32 && hint.data.len() <= 40, "Invalid hint data length");
 
                 let hash = B256::from_slice(&hint.data.as_ref()[0..32]);
@@ -236,7 +233,7 @@ impl HintHandler for InteropHintHandler {
 
                 // Fetch the storage root for the L2 head block.
                 let l2_to_l1_message_passer = l2_provider
-                    .get_proof(L2_TO_L1_MESSAGE_PASSER_ADDRESS, Default::default())
+                    .get_proof(Predeploys::L2_TO_L1_MESSAGE_PASSER, Default::default())
                     .block_id(block_number.into())
                     .await?;
 

--- a/bin/host/src/single/handler.rs
+++ b/bin/host/src/single/handler.rs
@@ -9,7 +9,7 @@ use alloy_eips::{
     eip2718::Encodable2718,
     eip4844::{FIELD_ELEMENTS_PER_BLOB, IndexedBlobHash},
 };
-use alloy_primitives::{Address, B256, Bytes, address, keccak256};
+use alloy_primitives::{Address, B256, Bytes, keccak256};
 use alloy_provider::Provider;
 use alloy_rlp::Decodable;
 use alloy_rpc_types::{Block, debug::ExecutionWitness};
@@ -18,7 +18,7 @@ use ark_ff::{BigInteger, PrimeField};
 use async_trait::async_trait;
 use kona_preimage::{PreimageKey, PreimageKeyType};
 use kona_proof::{Hint, HintType, l1::ROOTS_OF_UNITY};
-use kona_protocol::{BlockInfo, OutputRoot};
+use kona_protocol::{BlockInfo, OutputRoot, Predeploys};
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use tracing::warn;
 
@@ -193,9 +193,6 @@ impl HintHandler for SingleChainHintHandler {
                 store_ordered_trie(kv.as_ref(), encoded_transactions.as_slice()).await?;
             }
             HintType::StartingL2Output => {
-                const L2_TO_L1_MESSAGE_PASSER_ADDRESS: Address =
-                    address!("4200000000000000000000000000000000000016");
-
                 ensure!(hint.data.len() == 32, "Invalid hint data length");
 
                 // Fetch the header for the L2 head block.
@@ -209,7 +206,7 @@ impl HintHandler for SingleChainHintHandler {
                 // Fetch the storage root for the L2 head block.
                 let l2_to_l1_message_passer = providers
                     .l2
-                    .get_proof(L2_TO_L1_MESSAGE_PASSER_ADDRESS, Default::default())
+                    .get_proof(Predeploys::L2_TO_L1_MESSAGE_PASSER, Default::default())
                     .block_id(cfg.agreed_l2_head_hash.into())
                     .await?;
 

--- a/crates/proof/executor/src/builder/assemble.rs
+++ b/crates/proof/executor/src/builder/assemble.rs
@@ -2,8 +2,7 @@
 
 use super::StatelessL2Builder;
 use crate::{
-    ExecutorError, ExecutorResult, TrieDBError, TrieDBProvider,
-    constants::{L2_TO_L1_BRIDGE, SHA256_EMPTY},
+    ExecutorError, ExecutorResult, TrieDBError, TrieDBProvider, constants::SHA256_EMPTY,
     util::encode_holocene_eip_1559_params,
 };
 use alloc::vec::Vec;
@@ -14,7 +13,7 @@ use alloy_primitives::{B256, Sealable, U256, logs_bloom};
 use alloy_trie::EMPTY_ROOT_HASH;
 use kona_genesis::RollupConfig;
 use kona_mpt::{TrieHinter, ordered_trie_with_encoder};
-use kona_protocol::OutputRoot;
+use kona_protocol::{OutputRoot, Predeploys};
 use op_alloy_consensus::OpReceiptEnvelope;
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use revm::{context::BlockEnv, database::BundleState};
@@ -150,11 +149,11 @@ where
 
     /// Fetches the L2 to L1 message passer account from the cache or underlying trie.
     fn message_passer_account(&mut self, block_number: u64) -> Result<B256, TrieDBError> {
-        match self.trie_db.storage_roots().get(&L2_TO_L1_BRIDGE) {
+        match self.trie_db.storage_roots().get(&Predeploys::L2_TO_L1_MESSAGE_PASSER) {
             Some(storage_root) => Ok(storage_root.blind()),
             None => Ok(self
                 .trie_db
-                .get_trie_account(&L2_TO_L1_BRIDGE, block_number)?
+                .get_trie_account(&Predeploys::L2_TO_L1_MESSAGE_PASSER, block_number)?
                 .ok_or(TrieDBError::MissingAccountInfo)?
                 .storage_root),
         }

--- a/crates/proof/executor/src/constants.rs
+++ b/crates/proof/executor/src/constants.rs
@@ -1,9 +1,6 @@
 //! Protocol constants for the executor.
 
-use alloy_primitives::{Address, B256, address, b256};
-
-/// The address of the L2 to L1 bridge predeploy.
-pub(crate) const L2_TO_L1_BRIDGE: Address = address!("4200000000000000000000000000000000000016");
+use alloy_primitives::{B256, b256};
 
 /// The version byte for the Holocene extra data.
 pub(crate) const HOLOCENE_EXTRA_DATA_VERSION: u8 = 0x00;

--- a/crates/protocol/derive/src/attributes/stateful.rs
+++ b/crates/protocol/derive/src/attributes/stateful.rs
@@ -8,17 +8,16 @@ use crate::{
 use alloc::{boxed::Box, fmt::Debug, string::ToString, sync::Arc, vec, vec::Vec};
 use alloy_consensus::{Eip658Value, Receipt};
 use alloy_eips::{BlockNumHash, eip2718::Encodable2718};
-use alloy_primitives::{Address, B256, Bytes, address};
+use alloy_primitives::{Address, B256, Bytes};
 use alloy_rlp::Encodable;
 use alloy_rpc_types_engine::PayloadAttributes;
 use async_trait::async_trait;
 use kona_genesis::RollupConfig;
 use kona_hardforks::{Hardfork, Hardforks};
-use kona_protocol::{DEPOSIT_EVENT_ABI_HASH, L1BlockInfoTx, L2BlockInfo, decode_deposit};
+use kona_protocol::{
+    DEPOSIT_EVENT_ABI_HASH, L1BlockInfoTx, L2BlockInfo, Predeploys, decode_deposit,
+};
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
-
-/// The sequencer fee vault address.
-const SEQUENCER_FEE_VAULT_ADDRESS: Address = address!("4200000000000000000000000000000000000011");
 
 /// A stateful implementation of the [AttributesBuilder].
 #[derive(Debug, Default)]
@@ -180,7 +179,7 @@ where
             payload_attributes: PayloadAttributes {
                 timestamp: next_l2_time,
                 prev_randao: l1_header.mix_hash,
-                suggested_fee_recipient: SEQUENCER_FEE_VAULT_ADDRESS,
+                suggested_fee_recipient: Predeploys::SEQUENCER_FEE_VAULT,
                 parent_beacon_block_root: parent_beacon_root,
                 withdrawals,
             },
@@ -239,7 +238,7 @@ mod tests {
     };
     use alloc::vec;
     use alloy_consensus::Header;
-    use alloy_primitives::{B256, Log, LogData, U64, U256};
+    use alloy_primitives::{B256, Log, LogData, U64, U256, address};
     use kona_genesis::{HardForkConfig, SystemConfig};
     use kona_protocol::{BlockInfo, DepositError};
 
@@ -452,7 +451,7 @@ mod tests {
             payload_attributes: PayloadAttributes {
                 timestamp: next_l2_time,
                 prev_randao,
-                suggested_fee_recipient: SEQUENCER_FEE_VAULT_ADDRESS,
+                suggested_fee_recipient: Predeploys::SEQUENCER_FEE_VAULT,
                 parent_beacon_block_root: None,
                 withdrawals: None,
             },
@@ -502,7 +501,7 @@ mod tests {
             payload_attributes: PayloadAttributes {
                 timestamp: next_l2_time,
                 prev_randao,
-                suggested_fee_recipient: SEQUENCER_FEE_VAULT_ADDRESS,
+                suggested_fee_recipient: Predeploys::SEQUENCER_FEE_VAULT,
                 parent_beacon_block_root: None,
                 withdrawals: Some(Vec::default()),
             },
@@ -553,7 +552,7 @@ mod tests {
             payload_attributes: PayloadAttributes {
                 timestamp: next_l2_time,
                 prev_randao,
-                suggested_fee_recipient: SEQUENCER_FEE_VAULT_ADDRESS,
+                suggested_fee_recipient: Predeploys::SEQUENCER_FEE_VAULT,
                 parent_beacon_block_root,
                 withdrawals: Some(vec![]),
             },
@@ -603,7 +602,7 @@ mod tests {
             payload_attributes: PayloadAttributes {
                 timestamp: next_l2_time,
                 prev_randao,
-                suggested_fee_recipient: SEQUENCER_FEE_VAULT_ADDRESS,
+                suggested_fee_recipient: Predeploys::SEQUENCER_FEE_VAULT,
                 parent_beacon_block_root: Some(B256::ZERO),
                 withdrawals: Some(vec![]),
             },

--- a/crates/protocol/hardforks/Cargo.toml
+++ b/crates/protocol/hardforks/Cargo.toml
@@ -15,6 +15,9 @@ exclude.workspace = true
 workspace = true
 
 [dependencies]
+# Workspace
+kona-protocol.workspace = true
+
 # Alloy
 alloy-eips.workspace = true
 alloy-primitives = { workspace = true, features = ["rlp"] }

--- a/crates/protocol/hardforks/src/ecotone.rs
+++ b/crates/protocol/hardforks/src/ecotone.rs
@@ -3,6 +3,7 @@
 use alloc::{string::String, vec::Vec};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, hex};
+use kona_protocol::Predeploys;
 use op_alloy_consensus::{TxDeposit, UpgradeDepositSource};
 
 use crate::Hardfork;
@@ -19,13 +20,6 @@ impl Ecotone {
 
     /// The depositor account address.
     pub const DEPOSITOR_ACCOUNT: Address = address!("DeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001");
-
-    /// The Gas Price Oracle Proxy Address
-    pub const GAS_PRICE_ORACLE_PROXY: Address =
-        address!("420000000000000000000000000000000000000F");
-
-    /// The L1 Block Proxy Address
-    pub const L1_BLOCK_PROXY: Address = address!("4200000000000000000000000000000000000015");
 
     /// The Enable Ecotone Input Method 4Byte Signature
     pub const ENABLE_ECOTONE_INPUT: [u8; 4] = hex!("22b908b3");
@@ -135,7 +129,7 @@ impl Ecotone {
             TxDeposit {
                 source_hash: Self::update_l1_block_source(),
                 from: Address::ZERO,
-                to: TxKind::Call(Self::L1_BLOCK_PROXY),
+                to: TxKind::Call(Predeploys::L1_BLOCK_INFO),
                 mint: 0.into(),
                 value: U256::ZERO,
                 gas_limit: 50_000,
@@ -147,7 +141,7 @@ impl Ecotone {
             TxDeposit {
                 source_hash: Self::update_gas_price_oracle_source(),
                 from: Address::ZERO,
-                to: TxKind::Call(Self::GAS_PRICE_ORACLE_PROXY),
+                to: TxKind::Call(Predeploys::GAS_PRICE_ORACLE),
                 mint: 0.into(),
                 value: U256::ZERO,
                 gas_limit: 50_000,
@@ -159,7 +153,7 @@ impl Ecotone {
             TxDeposit {
                 source_hash: Self::enable_ecotone_source(),
                 from: Self::DEPOSITOR_ACCOUNT,
-                to: TxKind::Call(Self::GAS_PRICE_ORACLE_PROXY),
+                to: TxKind::Call(Predeploys::GAS_PRICE_ORACLE),
                 mint: 0.into(),
                 value: U256::ZERO,
                 gas_limit: 80_000,

--- a/crates/protocol/hardforks/src/fjord.rs
+++ b/crates/protocol/hardforks/src/fjord.rs
@@ -3,6 +3,7 @@
 use alloc::{string::String, vec::Vec};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, hex};
+use kona_protocol::Predeploys;
 use op_alloy_consensus::{TxDeposit, UpgradeDepositSource};
 
 use crate::Hardfork;
@@ -16,10 +17,6 @@ impl Fjord {
     /// This is computed by using go-ethereum's `crypto.CreateAddress` function,
     /// with the Gas Price Oracle Deployer Address and nonce 0.
     pub const GAS_PRICE_ORACLE: Address = address!("b528d11cc114e026f138fe568744c6d45ce6da7a");
-
-    /// The gas price oracle proxy address.
-    pub const GAS_PRICE_ORACLE_PROXY: Address =
-        address!("420000000000000000000000000000000000000F");
 
     /// The L1 Info Depositer Address.
     pub const L1_INFO_DEPOSITER: Address = address!("deaddeaddeaddeaddeaddeaddeaddeaddead0001");
@@ -80,7 +77,7 @@ impl Fjord {
             TxDeposit {
                 source_hash: Self::update_fjord_gas_price_oracle_source(),
                 from: Address::ZERO,
-                to: TxKind::Call(Self::GAS_PRICE_ORACLE_PROXY),
+                to: TxKind::Call(Predeploys::GAS_PRICE_ORACLE),
                 mint: 0.into(),
                 value: U256::ZERO,
                 gas_limit: 50_000,
@@ -92,7 +89,7 @@ impl Fjord {
             TxDeposit {
                 source_hash: Self::enable_fjord_source(),
                 from: Self::L1_INFO_DEPOSITER,
-                to: TxKind::Call(Self::GAS_PRICE_ORACLE_PROXY),
+                to: TxKind::Call(Predeploys::GAS_PRICE_ORACLE),
                 mint: 0.into(),
                 value: U256::ZERO,
                 gas_limit: 90_000,

--- a/crates/protocol/hardforks/src/isthmus.rs
+++ b/crates/protocol/hardforks/src/isthmus.rs
@@ -7,6 +7,7 @@
 use alloc::{string::String, vec::Vec};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, hex};
+use kona_protocol::Predeploys;
 use op_alloy_consensus::{TxDeposit, UpgradeDepositSource};
 
 use crate::Hardfork;
@@ -30,24 +31,13 @@ impl Isthmus {
     /// L1 Block Deployer Address
     pub const L1_BLOCK_DEPLOYER: Address = address!("4210000000000000000000000000000000000003");
 
-    /// The L1 Block Proxy Address
-    pub const L1_BLOCK_PROXY: Address = address!("4200000000000000000000000000000000000015");
-
     /// The Gas Price Oracle Deployer Address
     pub const GAS_PRICE_ORACLE_DEPLOYER: Address =
         address!("4210000000000000000000000000000000000004");
 
-    /// The address of the Gas Price Oracle Proxy
-    pub const GAS_PRICE_ORACLE_PROXY: Address =
-        address!("420000000000000000000000000000000000000F");
-
     /// The Operator Fee Vault Deployer Address
     pub const OPERATOR_FEE_VAULT_DEPLOYER: Address =
         address!("4210000000000000000000000000000000000005");
-
-    /// The address of the Operator Fee Vault Proxy
-    pub const OPERATOR_FEE_VAULT_PROXY: Address =
-        address!("420000000000000000000000000000000000001B");
 
     /// The new L1 Block Address
     /// This is computed by using go-ethereum's `crypto.CreateAddress` function,
@@ -175,7 +165,7 @@ impl Isthmus {
             TxDeposit {
                 source_hash: Self::update_l1_block_source(),
                 from: Address::default(),
-                to: TxKind::Call(Self::L1_BLOCK_PROXY),
+                to: TxKind::Call(Predeploys::L1_BLOCK_INFO),
                 mint: 0.into(),
                 value: U256::ZERO,
                 gas_limit: 50_000,
@@ -185,7 +175,7 @@ impl Isthmus {
             TxDeposit {
                 source_hash: Self::update_gas_price_oracle_source(),
                 from: Address::default(),
-                to: TxKind::Call(Self::GAS_PRICE_ORACLE_PROXY),
+                to: TxKind::Call(Predeploys::GAS_PRICE_ORACLE),
                 mint: 0.into(),
                 value: U256::ZERO,
                 gas_limit: 50_000,
@@ -195,7 +185,7 @@ impl Isthmus {
             TxDeposit {
                 source_hash: Self::update_operator_fee_vault_source(),
                 from: Address::default(),
-                to: TxKind::Call(Self::OPERATOR_FEE_VAULT_PROXY),
+                to: TxKind::Call(Predeploys::OPERATOR_FEE_VAULT),
                 mint: 0.into(),
                 value: U256::ZERO,
                 gas_limit: 50_000,
@@ -205,7 +195,7 @@ impl Isthmus {
             TxDeposit {
                 source_hash: Self::enable_isthmus_source(),
                 from: Self::DEPOSITOR_ACCOUNT,
-                to: TxKind::Call(Self::GAS_PRICE_ORACLE_PROXY),
+                to: TxKind::Call(Predeploys::GAS_PRICE_ORACLE),
                 mint: 0.into(),
                 value: U256::ZERO,
                 gas_limit: 90_000,

--- a/crates/protocol/interop/Cargo.toml
+++ b/crates/protocol/interop/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 # Workspace
 kona-genesis.workspace = true
 kona-registry.workspace = true
+kona-protocol.workspace = true
 
 # General
 thiserror.workspace = true

--- a/crates/protocol/interop/src/access_list.rs
+++ b/crates/protocol/interop/src/access_list.rs
@@ -1,6 +1,6 @@
-use crate::CROSS_L2_INBOX_ADDRESS;
 use alloy_eips::eip2930::AccessListItem;
 use alloy_primitives::B256;
+use kona_protocol::Predeploys;
 
 /// Parses [`AccessListItem`]s to inbox entries.
 ///
@@ -13,14 +13,16 @@ pub fn parse_access_list_items_to_inbox_entries<'a>(
 }
 
 /// Parse [`AccessListItem`] to inbox entries, if any.
-/// Max 3 inbox entries can exist per [`AccessListItem`] that points to [`CROSS_L2_INBOX_ADDRESS`].
+/// Max 3 inbox entries can exist per [`AccessListItem`] that points to
+/// [`Predeploys::CROSS_L2_INBOX`].
 ///
-/// Returns `Vec::new()` if [`AccessListItem`] address doesn't point to [`CROSS_L2_INBOX_ADDRESS`].
+/// Returns `Vec::new()` if [`AccessListItem`] address doesn't point to
+/// [`Predeploys::CROSS_L2_INBOX`].
 ///
 /// See: <https://github.com/ethereum-optimism/specs/blob/main/specs/interop/predeploys.md#access-list>
 pub fn parse_access_list_item_to_inbox_entries(
     access_list_item: &AccessListItem,
 ) -> Option<impl Iterator<Item = &B256>> {
-    (access_list_item.address == CROSS_L2_INBOX_ADDRESS)
+    (access_list_item.address == Predeploys::CROSS_L2_INBOX)
         .then(|| access_list_item.storage_keys.iter())
 }

--- a/crates/protocol/interop/src/constants.rs
+++ b/crates/protocol/interop/src/constants.rs
@@ -1,10 +1,5 @@
 //! Constants for the OP Stack interop protocol.
 
-use alloy_primitives::{Address, address};
-
-/// The address of the L2 cross chain inbox predeploy proxy.
-pub const CROSS_L2_INBOX_ADDRESS: Address = address!("4200000000000000000000000000000000000022");
-
 /// The expiry window for relaying an initiating message (in seconds).
 /// <https://specs.optimism.io/interop/messaging.html#message-expiry-invariant>
 pub const MESSAGE_EXPIRY_WINDOW: u64 = 30 * 24 * 60 * 60;

--- a/crates/protocol/interop/src/lib.rs
+++ b/crates/protocol/interop/src/lib.rs
@@ -40,7 +40,7 @@ mod derived;
 pub use derived::DerivedIdPair;
 
 mod constants;
-pub use constants::{CROSS_L2_INBOX_ADDRESS, MESSAGE_EXPIRY_WINDOW, SUPER_ROOT_VERSION};
+pub use constants::{MESSAGE_EXPIRY_WINDOW, SUPER_ROOT_VERSION};
 
 #[cfg(test)]
 mod test_util;

--- a/crates/protocol/interop/src/message.rs
+++ b/crates/protocol/interop/src/message.rs
@@ -3,11 +3,11 @@
 //! <https://specs.optimism.io/interop/messaging.html#messaging>
 //! <https://github.com/ethereum-optimism/optimism/blob/34d5f66ade24bd1f3ce4ce7c0a6cfc1a6540eca1/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol>
 
-use crate::constants::CROSS_L2_INBOX_ADDRESS;
 use alloc::{vec, vec::Vec};
 use alloy_primitives::{Bytes, Log, keccak256};
 use alloy_sol_types::{SolEvent, sol};
 use derive_more::{AsRef, From};
+use kona_protocol::Predeploys;
 use op_alloy_consensus::OpReceiptEnvelope;
 
 sol! {
@@ -143,7 +143,7 @@ pub fn parse_logs_to_executing_msgs<'a>(
 /// Max one [`ExecutingMessage`] event can exist per log. Returns `None` if log doesn't contain
 /// executing message event.
 pub fn parse_log_to_executing_message(log: &Log) -> Option<ExecutingMessage> {
-    (log.address == CROSS_L2_INBOX_ADDRESS && log.topics().len() == 2)
+    (log.address == Predeploys::CROSS_L2_INBOX && log.topics().len() == 2)
         .then(|| ExecutingMessage::decode_log_data(&log.data).ok())
         .flatten()
 }

--- a/crates/protocol/interop/src/test_util.rs
+++ b/crates/protocol/interop/src/test_util.rs
@@ -2,11 +2,12 @@
 
 #![allow(missing_docs, unreachable_pub)]
 
-use crate::{CROSS_L2_INBOX_ADDRESS, ExecutingMessage, MessageIdentifier, traits::InteropProvider};
+use crate::{ExecutingMessage, MessageIdentifier, traits::InteropProvider};
 use alloy_consensus::{Header, Receipt, ReceiptWithBloom, Sealed};
 use alloy_primitives::{Address, B256, Bytes, Log, LogData, U256, map::HashMap};
 use alloy_sol_types::{SolEvent, SolValue};
 use async_trait::async_trait;
+use kona_protocol::Predeploys;
 use op_alloy_consensus::OpReceiptEnvelope;
 
 #[derive(Debug, Clone, Default)]
@@ -164,7 +165,7 @@ impl ChainBuilder {
         let receipt = OpReceiptEnvelope::Eip1559(ReceiptWithBloom {
             receipt: Receipt {
                 logs: vec![Log {
-                    address: CROSS_L2_INBOX_ADDRESS,
+                    address: Predeploys::CROSS_L2_INBOX,
                     data: LogData::new(
                         vec![ExecutingMessage::SIGNATURE_HASH, message_hash],
                         MessageIdentifier {

--- a/crates/protocol/protocol/src/info/variant.rs
+++ b/crates/protocol/protocol/src/info/variant.rs
@@ -9,13 +9,11 @@ use op_alloy_consensus::{DepositSourceDomain, L1InfoDepositSource, TxDeposit};
 
 use crate::{
     BlockInfoError, DecodeError, L1BlockInfoBedrock, L1BlockInfoEcotone, L1BlockInfoIsthmus,
+    Predeploys,
 };
 
 /// The system transaction gas limit post-Regolith
 const REGOLITH_SYSTEM_TX_GAS: u64 = 1_000_000;
-
-/// The address of the L1 Block contract
-pub(crate) const L1_BLOCK_ADDRESS: Address = address!("4200000000000000000000000000000000000015");
 
 /// The depositor address of the L1 info transaction
 pub(crate) const L1_INFO_DEPOSITOR_ADDRESS: Address =
@@ -156,7 +154,7 @@ impl L1BlockInfoTx {
         let mut deposit_tx = TxDeposit {
             source_hash: source.source_hash(),
             from: L1_INFO_DEPOSITOR_ADDRESS,
-            to: TxKind::Call(L1_BLOCK_ADDRESS),
+            to: TxKind::Call(Predeploys::L1_BLOCK_INFO),
             mint: None,
             value: U256::ZERO,
             gas_limit: 150_000_000,
@@ -1002,7 +1000,7 @@ mod test {
 
         assert!(matches!(l1_info, L1BlockInfoTx::Isthmus(_)));
         assert_eq!(deposit_tx.from, L1_INFO_DEPOSITOR_ADDRESS);
-        assert_eq!(deposit_tx.to, TxKind::Call(L1_BLOCK_ADDRESS));
+        assert_eq!(deposit_tx.to, TxKind::Call(Predeploys::L1_BLOCK_INFO));
         assert_eq!(deposit_tx.mint, None);
         assert_eq!(deposit_tx.value, U256::ZERO);
         assert_eq!(deposit_tx.gas_limit, REGOLITH_SYSTEM_TX_GAS);

--- a/crates/protocol/protocol/src/predeploys.rs
+++ b/crates/protocol/protocol/src/predeploys.rs
@@ -12,9 +12,82 @@ pub struct Predeploys;
 
 impl Predeploys {
     /// List of all predeploys.
-    pub const ALL: [Address; 1] = [Self::L2_TO_L1_MESSAGE_PASSER];
+    pub const ALL: [Address; 18] = [
+        Self::WETH9,
+        Self::L2_CROSS_DOMAIN_MESSENGER,
+        Self::L2_STANDARD_BRIDGE,
+        Self::SEQUENCER_FEE_VAULT,
+        Self::OP_MINTABLE_ERC20_FACTORY,
+        Self::GAS_PRICE_ORACLE,
+        Self::GOVERNANCE_TOKEN,
+        Self::L2_ERC721_BRIDGE,
+        Self::L1_BLOCK_INFO,
+        Self::L2_TO_L1_MESSAGE_PASSER,
+        Self::OP_MINTABLE_ERC721_FACTORY,
+        Self::PROXY_ADMIN,
+        Self::BASE_FEE_VAULT,
+        Self::L1_FEE_VAULT,
+        Self::SCHEMA_REGISTRY,
+        Self::EAS,
+        Self::OPERATOR_FEE_VAULT,
+        Self::CROSS_L2_INBOX,
+    ];
+
+    /// The WETH9 predeploy address.
+    pub const WETH9: Address = address!("0x4200000000000000000000000000000000000006");
+
+    /// The L2 cross-domain messenger proxy address.
+    pub const L2_CROSS_DOMAIN_MESSENGER: Address =
+        address!("0x4200000000000000000000000000000000000007");
+
+    /// The L2 standard bridge proxy address.
+    pub const L2_STANDARD_BRIDGE: Address = address!("0x4200000000000000000000000000000000000010");
+
+    /// The sequencer fee vault proxy address.
+    pub const SEQUENCER_FEE_VAULT: Address = address!("0x4200000000000000000000000000000000000011");
+
+    /// The Optimism mintable ERC20 factory proxy address.
+    pub const OP_MINTABLE_ERC20_FACTORY: Address =
+        address!("0x4200000000000000000000000000000000000012");
+
+    /// The gas price oracle proxy address.
+    pub const GAS_PRICE_ORACLE: Address = address!("0x420000000000000000000000000000000000000F");
+
+    /// The governance token proxy address.
+    pub const GOVERNANCE_TOKEN: Address = address!("0x4200000000000000000000000000000000000042");
+
+    /// The L2 ERC721 bridge proxy address.
+    pub const L2_ERC721_BRIDGE: Address = address!("0x4200000000000000000000000000000000000014");
+
+    /// The L1 block information proxy address.
+    pub const L1_BLOCK_INFO: Address = address!("0x4200000000000000000000000000000000000015");
 
     /// The L2 contract `L2ToL1MessagePasser`, stores commitments to withdrawal transactions.
     pub const L2_TO_L1_MESSAGE_PASSER: Address =
         address!("0x4200000000000000000000000000000000000016");
+
+    /// The Optimism mintable ERC721 proxy address.
+    pub const OP_MINTABLE_ERC721_FACTORY: Address =
+        address!("0x4200000000000000000000000000000000000017");
+
+    /// The L2 proxy admin address.
+    pub const PROXY_ADMIN: Address = address!("0x4200000000000000000000000000000000000018");
+
+    /// The base fee vault address.
+    pub const BASE_FEE_VAULT: Address = address!("0x4200000000000000000000000000000000000019");
+
+    /// The L1 fee vault address.
+    pub const L1_FEE_VAULT: Address = address!("0x420000000000000000000000000000000000001a");
+
+    /// The schema registry proxy address.
+    pub const SCHEMA_REGISTRY: Address = address!("0x4200000000000000000000000000000000000020");
+
+    /// The EAS proxy address.
+    pub const EAS: Address = address!("0x4200000000000000000000000000000000000021");
+
+    /// The Operator Fee Vault proxy address.
+    pub const OPERATOR_FEE_VAULT: Address = address!("420000000000000000000000000000000000001B");
+
+    /// The CrossL2Inbox proxy address.
+    pub const CROSS_L2_INBOX: Address = address!("0x4200000000000000000000000000000000000022");
 }


### PR DESCRIPTION
## Overview

Small aesthetic / consistency cleanup across the codebase - completes the definition of predeploys within `kona-protocol`'s `Predeploys` struct, and uses them everywhere rather than the odd one-off local constants in a few crates.