### PR TITLE
fix(node/p2p): Wait for Swarm Address Dialing

### DIFF
--- a/crates/node/p2p/README.md
+++ b/crates/node/p2p/README.md
@@ -20,29 +20,32 @@ use kona_p2p::{LocalNode, Network};
 use libp2p::Multiaddr;
 use discv5::enr::CombinedKey;
 
-// Construct the Network
-let signer = address!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
-let gossip = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 9099);
-let mut gossip_addr = Multiaddr::from(gossip.ip());
-gossip_addr.push(libp2p::multiaddr::Protocol::Tcp(gossip.port()));
-let advertise_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+#[tokio::main]
+async fn main() {
+    // Construct the Network
+    let signer = address!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    let gossip = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 9099);
+    let mut gossip_addr = Multiaddr::from(gossip.ip());
+    gossip_addr.push(libp2p::multiaddr::Protocol::Tcp(gossip.port()));
+    let advertise_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
 
-let CombinedKey::Secp256k1(k256_key) = CombinedKey::generate_secp256k1() else {
-    unreachable!()
-};
-let disc = LocalNode::new(k256_key, advertise_ip, 9097, 9098);
-let network = Network::builder()
-    .with_chain_id(10) // op mainnet chain id
-    .with_unsafe_block_signer(signer)
-    .with_discovery_address(disc)
-    .with_gossip_address(gossip_addr)
-    .build()
-    .expect("Failed to builder network driver");
+    let CombinedKey::Secp256k1(k256_key) = CombinedKey::generate_secp256k1() else {
+        unreachable!()
+    };
+    let disc = LocalNode::new(k256_key, advertise_ip, 9097, 9098);
+    let network = Network::builder()
+        .with_chain_id(10) // op mainnet chain id
+        .with_unsafe_block_signer(signer)
+        .with_discovery_address(disc)
+        .with_gossip_address(gossip_addr)
+        .build()
+        .expect("Failed to builder network driver");
 
-// Starting the network spawns gossip and discovery service
-// handling in a new thread so this is a non-blocking,
-// synchronous operation that does not need to be awaited.
-network.start().expect("Failed to start network driver");
+    // Starting the network spawns gossip and discovery service
+    // handling in a new thread so this is a non-blocking,
+    // synchronous operation that does not need to be awaited.
+    network.start().await.expect("Failed to start network driver");
+}
 ```
 
 [!WARNING]: ###example

--- a/crates/node/p2p/src/discv5/driver.rs
+++ b/crates/node/p2p/src/discv5/driver.rs
@@ -166,7 +166,7 @@ impl Discv5Driver {
         for enr in &boot_enrs {
             let validation = EnrValidation::validate(enr, self.chain_id);
             if validation.is_invalid() {
-                debug!(target: "discovery", "Ignoring Invalid Bootnode ENR: {:?}. {:?}", enr, validation);
+                trace!(target: "discovery", "Ignoring Invalid Bootnode ENR: {:?}. {:?}", enr, validation);
                 continue;
             }
             match self.disc.add_enr(enr.clone()) {
@@ -195,12 +195,12 @@ impl Discv5Driver {
         for enr in self.store.valid_peers() {
             let validation = EnrValidation::validate(enr, self.chain_id);
             if validation.is_invalid() {
-                debug!(target: "discovery", "Ignoring Invalid Bootnode ENR: {:?}. {:?}", enr, validation);
+                trace!(target: "discovery", "Ignoring Invalid Bootnode ENR: {:?}. {:?}", enr, validation);
                 continue;
             }
             match self.disc.add_enr(enr.clone()) {
                 Ok(_) => count += 1,
-                Err(e) => debug!(target: "discovery", "Failed to add ENR to discv5 table: {:?}", e),
+                Err(e) => trace!(target: "discovery", "Failed to add ENR to discv5 table: {:?}", e),
             }
         }
         info!(target: "discovery", "Added {} Bootstore ENRs to discovery table", count);

--- a/crates/node/p2p/src/gossip/behaviour.rs
+++ b/crates/node/p2p/src/gossip/behaviour.rs
@@ -54,7 +54,7 @@ impl Behaviour {
                             .subscribe(&topic)
                             .map_err(|_| BehaviourError::SubscriptionFailed);
                         if res.is_ok() {
-                            info!("libp2p switch subscribed to topic: {}", topic.to_string());
+                            info!(target: "gossip", "Subscribed to topic: {}", topic.to_string());
                         }
                         res
                     })

--- a/crates/node/p2p/src/gossip/builder.rs
+++ b/crates/node/p2p/src/gossip/builder.rs
@@ -135,6 +135,7 @@ impl GossipDriverBuilder {
         // Construct the gossip behaviour
         let config = self.config.unwrap_or(crate::default_config());
         info!(
+            target: "gossip",
             "Config [Mesh D: {}] [Mesh L: {}] [Mesh H: {}] [Gossip Lazy: {}] [Flood Publish: {}]",
             config.mesh_n(),
             config.mesh_n_low(),
@@ -158,13 +159,13 @@ impl GossipDriverBuilder {
         }
 
         // Build the swarm.
-        info!("Building Swarm with Peer ID: {}", keypair.public().to_peer_id());
+        info!(target: "gossip", "Building Swarm with Peer ID: {}", keypair.public().to_peer_id());
         let swarm = SwarmBuilder::with_existing_identity(keypair)
             .with_tokio()
             .with_tcp(
                 TcpConfig::default(),
                 |i: &Keypair| {
-                    info!("Noise Config Peer ID: {}", i.public().to_peer_id());
+                    info!(target: "gossip", "Noise Config Peer ID: {}", i.public().to_peer_id());
                     NoiseConfig::new(i)
                 },
                 YamuxConfig::default,

--- a/crates/node/p2p/src/net/driver.rs
+++ b/crates/node/p2p/src/net/driver.rs
@@ -61,7 +61,7 @@ impl Network {
 
     /// Starts the Discv5 peer discovery & libp2p services
     /// and continually listens for new peers and messages to handle
-    pub fn start(mut self) -> Result<(), TransportError<std::io::Error>> {
+    pub async fn start(mut self) -> Result<(), TransportError<std::io::Error>> {
         let mut rpc = self.rpc.unwrap_or_else(|| tokio::sync::mpsc::channel(1).1);
         let mut publish = self.publish_rx.unwrap_or_else(|| tokio::sync::mpsc::channel(1).1);
         let (handler, mut enr_receiver) = self.discovery.start();
@@ -71,7 +71,7 @@ impl Network {
         let mut peer_score_inspector = tokio::time::interval(Self::PEER_SCORE_INSPECT_FREQUENCY);
 
         // Start the libp2p Swarm
-        self.gossip.listen()?;
+        self.gossip.listen().await?;
 
         // Spawn the network handler
         tokio::spawn(async move {

--- a/crates/node/p2p/tests/gossip_connect.rs
+++ b/crates/node/p2p/tests/gossip_connect.rs
@@ -5,10 +5,10 @@ mod common;
 #[tokio::test]
 async fn test_unknown_peer_connect_fails() {
     let mut driver = common::gossip_driver(4003);
-    assert!(driver.listen().is_ok());
+    assert!(driver.listen().await.is_ok());
 
     let mut driver_2 = common::gossip_driver(4004);
-    assert!(driver_2.listen().is_ok());
+    assert!(driver_2.listen().await.is_ok());
 
     let err = driver.swarm.dial(*driver_2.local_peer_id()).unwrap_err();
     assert!(matches!(err, libp2p::swarm::DialError::NoAddresses));
@@ -17,10 +17,10 @@ async fn test_unknown_peer_connect_fails() {
 #[tokio::test]
 async fn test_connect_to_peer() {
     let mut driver = common::gossip_driver(4005);
-    assert!(driver.listen().is_ok());
+    assert!(driver.listen().await.is_ok());
 
     let mut driver_2 = common::gossip_driver(4006);
-    assert!(driver_2.listen().is_ok());
+    assert!(driver_2.listen().await.is_ok());
 
     assert!(driver.swarm.dial(driver_2.addr).is_ok());
     assert_eq!(driver.connected_peers(), 0);

--- a/crates/node/service/src/actors/network.rs
+++ b/crates/node/service/src/actors/network.rs
@@ -80,7 +80,7 @@ impl NodeActor for NetworkActor {
         };
 
         // Start the network driver.
-        self.driver.start()?;
+        self.driver.start().await?;
 
         loop {
             select! {

--- a/examples/gossip/src/main.rs
+++ b/examples/gossip/src/main.rs
@@ -87,7 +87,7 @@ impl GossipCommand {
             .build()?;
 
         let mut recv = network.unsafe_block_recv();
-        network.start()?;
+        network.start().await?;
         tracing::info!("Gossip driver started, receiving blocks.");
         loop {
             match recv.recv().await {


### PR DESCRIPTION
### Description

Waits for the libp2p swarm to establish listening on its address before proceeding with peer connection.

Avoids the situation where it takes the swarm time to listen on the given address while the network service is sending over peers for it to connect to.