### PR TITLE
fix(std-fpvm): Large file IO

### DIFF
--- a/bin/host/src/backend/online.rs
+++ b/bin/host/src/backend/online.rs
@@ -97,8 +97,9 @@ where
     async fn route_hint(&self, hint: String) -> PreimageOracleResult<()> {
         trace!(target: "host_backend", "Received hint: {hint}");
 
-        let parsed_hint =
-            hint.parse::<Hint<C::HintType>>().map_err(|_| PreimageOracleError::KeyNotFound)?;
+        let parsed_hint = hint
+            .parse::<Hint<C::HintType>>()
+            .map_err(|e| PreimageOracleError::HintParseFailed(e.to_string()))?;
         if self.proactive_hints.contains(&parsed_hint.ty) {
             debug!(target: "host_backend", "Proactive hint received; Immediately fetching {hint}");
             H::fetch_hint(parsed_hint, &self.cfg, &self.providers, self.kv.clone())

--- a/crates/proof/preimage/src/errors.rs
+++ b/crates/proof/preimage/src/errors.rs
@@ -22,6 +22,9 @@ pub enum PreimageOracleError {
     /// Buffer length mismatch.
     #[error("Buffer length mismatch. Expected {0}, got {1}.")]
     BufferLengthMismatch(usize, usize),
+    /// Failed to parse hint.
+    #[error("Failed to parse hint: {0}")]
+    HintParseFailed(String),
     /// Other errors.
     #[error("Error in preimage server: {0}")]
     Other(String),

--- a/crates/proof/std-fpvm/src/io.rs
+++ b/crates/proof/std-fpvm/src/io.rs
@@ -30,7 +30,7 @@ cfg_if! {
             fn read(fd: FileDescriptor, buf: &mut [u8]) -> IOResult<usize> {
                 unsafe {
                     let mut file = File::from_raw_fd(fd as i32);
-                    file.read(buf).map_err(|_| IOError(-9))?;
+                    file.read_exact(buf).map_err(|_| IOError(-9))?;
                     std::mem::forget(file);
                     Ok(buf.len())
                 }


### PR DESCRIPTION
## Overview

Small fix for large IO operations using `NativeClientIO` in the FPVM environment. This hasn't come up before for us, since all reads are generally within the size of an operating system page on the host machine. However, with the `L2PayloadWitness` hint, we easily breach that boundary.