### PR TITLE
chore(client): Bump heap size

### DIFF
--- a/bin/client/src/kona.rs
+++ b/bin/client/src/kona.rs
@@ -27,7 +27,7 @@ static ORACLE_READER: OracleReader<FileChannel> = OracleReader::new(ORACLE_READE
 /// The global hint writer.
 static HINT_WRITER: HintWriter<FileChannel> = HintWriter::new(HINT_WRITER_PIPE);
 
-#[client_entry(100_000_000)]
+#[client_entry(200_000_000)]
 fn main() -> Result<(), String> {
     #[cfg(feature = "client-tracing")]
     {

--- a/bin/client/src/kona_interop.rs
+++ b/bin/client/src/kona_interop.rs
@@ -26,7 +26,7 @@ static ORACLE_READER: OracleReader<FileChannel> = OracleReader::new(ORACLE_READE
 /// The global hint writer.
 static HINT_WRITER: HintWriter<FileChannel> = HintWriter::new(HINT_WRITER_PIPE);
 
-#[client_entry(100_000_000)]
+#[client_entry(200_000_000)]
 fn main() -> Result<(), String> {
     #[cfg(feature = "client-tracing")]
     {

--- a/bin/host/src/backend/online.rs
+++ b/bin/host/src/backend/online.rs
@@ -97,8 +97,9 @@ where
     async fn route_hint(&self, hint: String) -> PreimageOracleResult<()> {
         trace!(target: "host_backend", "Received hint: {hint}");
 
-        let parsed_hint =
-            hint.parse::<Hint<C::HintType>>().map_err(|_| PreimageOracleError::KeyNotFound)?;
+        let parsed_hint = hint
+            .parse::<Hint<C::HintType>>()
+            .map_err(|e| PreimageOracleError::Other(format!("failed to parse hint: {e}")))?;
         if self.proactive_hints.contains(&parsed_hint.ty) {
             debug!(target: "host_backend", "Proactive hint received; Immediately fetching {hint}");
             H::fetch_hint(parsed_hint, &self.cfg, &self.providers, self.kv.clone())

--- a/crates/proof/std-fpvm/src/io.rs
+++ b/crates/proof/std-fpvm/src/io.rs
@@ -30,7 +30,7 @@ cfg_if! {
             fn read(fd: FileDescriptor, buf: &mut [u8]) -> IOResult<usize> {
                 unsafe {
                     let mut file = File::from_raw_fd(fd as i32);
-                    file.read(buf).map_err(|_| IOError(-9))?;
+                    file.read_exact(buf).map_err(|_| IOError(-9))?;
                     std::mem::forget(file);
                     Ok(buf.len())
                 }


### PR DESCRIPTION
## Overview

Bumps the heap size of the client program to 200MB. As chains start to raise their block sizes, this should give us a bit of headroom.

In the near future, we should consider writing our own allocator for the FPVM to `mmap` new memory when necessary.