### PR TITLE
fix(node/p2p): Fix multiaddress translation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4804,6 +4804,7 @@ dependencies = [
  "kona-rpc",
  "lazy_static",
  "libp2p",
+ "libp2p-identity",
  "multihash",
  "op-alloy-consensus",
  "op-alloy-rpc-types-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,7 @@ brotli = { version = "8.0.0", default-features = false }
 snap = "1.1.1"
 discv5 = "0.9.1"
 libp2p = "0.55.0"
+libp2p-identity = "0.2.10"
 openssl = "0.10.72"
 
 # Tracing

--- a/crates/node/p2p/Cargo.toml
+++ b/crates/node/p2p/Cargo.toml
@@ -35,6 +35,7 @@ snap.workspace = true
 futures.workspace = true
 discv5 = { workspace = true, features = ["libp2p"] }
 libp2p = { workspace = true, features = ["macros", "tokio", "tcp", "noise", "gossipsub", "ping", "yamux"] }
+libp2p-identity.workspace = true
 openssl = { workspace = true, features = ["vendored"] }
 
 # Cryptography


### PR DESCRIPTION
## Description
Small PR that fixes the enr to multiaddress translation inside the kona-node. The produced multiaddresses did not contain the p2p (peer id) and the udp protocols from the ENRs.