### PR TITLE
feat(std-fpvm): Instruct kernel to lazily allocate pages

### DIFF
--- a/bin/client/src/kona.rs
+++ b/bin/client/src/kona.rs
@@ -27,7 +27,7 @@ static ORACLE_READER: OracleReader<FileChannel> = OracleReader::new(ORACLE_READE
 /// The global hint writer.
 static HINT_WRITER: HintWriter<FileChannel> = HintWriter::new(HINT_WRITER_PIPE);
 
-#[client_entry(100_000_000)]
+#[client_entry]
 fn main() -> Result<(), String> {
     #[cfg(feature = "client-tracing")]
     {

--- a/bin/client/src/kona_interop.rs
+++ b/bin/client/src/kona_interop.rs
@@ -26,7 +26,7 @@ static ORACLE_READER: OracleReader<FileChannel> = OracleReader::new(ORACLE_READE
 /// The global hint writer.
 static HINT_WRITER: HintWriter<FileChannel> = HintWriter::new(HINT_WRITER_PIPE);
 
-#[client_entry(100_000_000)]
+#[client_entry]
 fn main() -> Result<(), String> {
     #[cfg(feature = "client-tracing")]
     {

--- a/crates/proof/std-fpvm/src/io.rs
+++ b/crates/proof/std-fpvm/src/io.rs
@@ -36,6 +36,10 @@ cfg_if! {
                 }
             }
 
+            fn mmap(_size: usize) -> IOResult<usize> {
+                unimplemented!("mmap is unimplemented for the native target; The default global allocator is favored.");
+            }
+
             fn exit(code: usize) -> ! {
                 std::process::exit(code as i32)
             }
@@ -74,6 +78,12 @@ pub fn write(fd: FileDescriptor, buf: &[u8]) -> IOResult<usize> {
 #[inline]
 pub fn read(fd: FileDescriptor, buf: &mut [u8]) -> IOResult<usize> {
     ClientIO::read(fd, buf)
+}
+
+/// Map new memory of block size `size`. Returns the new heap pointer.
+#[inline]
+pub fn mmap(size: usize) -> IOResult<usize> {
+    ClientIO::mmap(size)
 }
 
 /// Exit the process with the given exit code.

--- a/crates/proof/std-fpvm/src/mips64/io.rs
+++ b/crates/proof/std-fpvm/src/mips64/io.rs
@@ -21,6 +21,9 @@ pub(crate) enum SyscallNumber {
     Read = 5000,
     /// Similar behavior as Linux/MIPS with support for unaligned writes.
     Write = 5001,
+    /// Similar behavior as Linux/MIPS for mapping memory on the host machine. Only accepts 2
+    /// arguments for cannon.
+    Mmap = 5009,
 }
 
 impl BasicKernelInterface for Mips64IO {
@@ -42,6 +45,16 @@ impl BasicKernelInterface for Mips64IO {
                 fd.into(),
                 buf.as_ptr() as usize,
                 buf.len(),
+            ))
+        }
+    }
+
+    fn mmap(size: usize) -> IOResult<usize> {
+        unsafe {
+            crate::linux::from_ret(syscall::syscall2(
+                SyscallNumber::Mmap as usize,
+                0usize, // anonymous map
+                size,
             ))
         }
     }

--- a/crates/proof/std-fpvm/src/mips64/syscall.rs
+++ b/crates/proof/std-fpvm/src/mips64/syscall.rs
@@ -65,6 +65,40 @@ pub(crate) unsafe fn syscall1(n: usize, arg1: usize) -> usize {
     if err == 0 { ret } else { ret.wrapping_neg() }
 }
 
+/// Issues a raw system call with 2 arguments. (e.g. cannon's flavor of mmap)
+///
+/// # Safety
+///
+/// Running a system call is inherently unsafe. It is the caller's
+/// responsibility to ensure safety.
+#[inline]
+pub(crate) unsafe fn syscall2(n: usize, arg1: usize, arg2: usize) -> usize {
+    let mut err: usize;
+    let mut ret: usize;
+    unsafe {
+        asm!(
+            "syscall",
+            inlateout("$2") n => ret,
+            lateout("$7") err,
+            in("$4") arg1,
+            in("$5") arg2,
+            // All temporary registers are always clobbered
+            lateout("$8") _,
+            lateout("$9") _,
+            lateout("$10") _,
+            lateout("$11") _,
+            lateout("$12") _,
+            lateout("$13") _,
+            lateout("$14") _,
+            lateout("$15") _,
+            lateout("$24") _,
+            lateout("$25") _,
+            options(nostack, preserves_flags)
+        );
+    }
+    if err == 0 { ret } else { ret.wrapping_neg() }
+}
+
 /// Issues a raw system call with 3 arguments. (e.g. read, write)
 #[inline]
 pub(crate) unsafe fn syscall3(n: usize, arg1: usize, arg2: usize, arg3: usize) -> usize {

--- a/crates/proof/std-fpvm/src/riscv64/syscall.rs
+++ b/crates/proof/std-fpvm/src/riscv64/syscall.rs
@@ -53,3 +53,36 @@ pub(crate) unsafe fn syscall3(
     }
     ret
 }
+
+/// Issues a raw system call with 6 arguments. (e.g. mmap)
+///
+/// # Safety
+///
+/// Running a system call is inherently unsafe. It is the caller's
+/// responsibility to ensure safety.
+#[inline]
+pub(crate) unsafe fn syscall6(
+    syscall_number: usize,
+    arg1: usize,
+    arg2: usize,
+    arg3: usize,
+    arg4: usize,
+    arg5: usize,
+    arg6: usize,
+) -> usize {
+    let mut ret: usize;
+    unsafe {
+        asm!(
+            "ecall",
+            in("a7") syscall_number,
+            inlateout("a0") arg1 => ret,
+            in("a1") arg2,
+            in("a2") arg3,
+            in("a3") arg4,
+            in("a4") arg5,
+            in("a5") arg6,
+            options(nostack, preserves_flags)
+        );
+    }
+    ret
+}

--- a/crates/proof/std-fpvm/src/traits/basic.rs
+++ b/crates/proof/std-fpvm/src/traits/basic.rs
@@ -19,6 +19,9 @@ pub trait BasicKernelInterface {
     /// Read from the given file descriptor into the passed buffer.
     fn read(fd: FileDescriptor, buf: &mut [u8]) -> IOResult<usize>;
 
+    /// Map new memory with with block size `size`. Returns the new heap pointer.
+    fn mmap(size: usize) -> IOResult<usize>;
+
     /// Exit the process with the given exit code. The implementation of this function
     /// should always panic after invoking the `EXIT` syscall.
     fn exit(code: usize) -> !;


### PR DESCRIPTION
## Overview

Removes the statically sized heap in the FPVM-targeted client program, in favor of asking the kernel to lazily allocate pages at runtime. This enables `kona-proof` to be safe in the face of L2 chains scaling their throughput, often resulting in larger decompressed channel sizes and large transaction lists that the program must ephemerally hold onto.

### How this works

Optimism's fault proof VMs support a minimal implementation of the `mmap` system call, where they bump a local variable in the kernel that keeps track of the current heap pointer. If a new allocation occurs within the mapped virtual memory, it will lazily allocate new pages for the program it is emulating to use. See [`cannon`'s mmap impl](https://github.com/ethereum-optimism/optimism/blob/18b74a03dea61c58a02e4e5a156e9091be9ccba7/cannon/mipsevm/exec/mips_syscalls.go#L109-L133) + [`asterisc`'s mmap impl](https://github.com/ethereum-optimism/asterisc/blob/1f48878be281466cff4f696e88321efe134f812b/rvgo/fast/vm.go#L360-L398).

Because of this platform-specific behavior, we can avoid an OOM handler and instead request the FPVM to optimistically map a large amount of memory at startup for `kona-client` to _potentially_ use. To do this, we add support for 1 new syscall, `mmap`, and dispatch a single `mmap` at startup to ask the FPVM kernel to reserve this address space for the program's heap.

Note that in practice, the terabyte of mapped memory is never going to be fully utilized. The address space is just reserved, and the program, while running on the FPVM, only allocates + uses what it needs (from our existing metrics, this is between 50-90MB depending on the chain, and gradually trending upwards.)

### `kona-std-fpvm-proc` API-breakage

This PR introduces an API breaking change to `kona-std-fpvm-proc`, since it no longer accepts a configurable heap size. This crate, however, is only used internally for FPVM-targeting client programs, and I think that's fine.

### Results

FPVMs running `kona-client` are now able to allocate new pages at runtime, rather than running the risk of OOMing if memory growth surpassed the statically allocated heap.

<img width="1288" alt="Screenshot 2025-04-29 at 1 12 55 PM" src="https://github.com/user-attachments/assets/2d524e00-b3db-4e69-a476-b4b56eb4c2a3" />
