### PR TITLE
perf(std-fpvm): Switch to `buddy_system_allocator`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1604,6 +1604,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "buddy_system_allocator"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a0108968a3a2dab95b089c0fc3f1afa7759aa5ebe6f1d86d206d6f7ba726eb"
+dependencies = [
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5046,9 +5055,9 @@ name = "kona-std-fpvm"
 version = "0.2.0"
 dependencies = [
  "async-trait",
+ "buddy_system_allocator",
  "cfg-if",
  "kona-preimage",
- "linked_list_allocator",
  "thiserror 2.0.12",
  "tracing",
 ]
@@ -5526,15 +5535,6 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "linked_list_allocator"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afa463f5405ee81cdb9cc2baf37e08ec7e4c8209442b5d72c04cfb2cd6e6286"
-dependencies = [
- "spinning_top",
 ]
 
 [[package]]
@@ -8246,21 +8246,15 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
-name = "spinning_top"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9eb1a2f4c41445a3a0ff9abc5221c5fcd28e1f13cd7c0397706f9ac938ddb0"
 dependencies = [
  "lock_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,7 @@ async-channel = "2.3.1"
 http-body-util = "0.1.3"
 unsigned-varint = "0.8.0"
 tracing-appender = "0.2.3"
-linked_list_allocator = "0.10.5"
+buddy_system_allocator = "0.11.0"
 
 rand = { version = "0.9.1", default-features = false }
 tabled = { version = "0.19", default-features = false }

--- a/crates/proof/std-fpvm/Cargo.toml
+++ b/crates/proof/std-fpvm/Cargo.toml
@@ -18,14 +18,14 @@ kona-preimage.workspace = true
 # External
 cfg-if.workspace = true
 thiserror.workspace = true
-linked_list_allocator.workspace = true
+buddy_system_allocator.workspace = true
 async-trait.workspace = true
 
 # `tracing` feature dependencies
 tracing = { workspace = true, optional = true }
 
 [package.metadata.cargo-udeps.ignore]
-normal = ["linked_list_allocator"]
+normal = ["buddy_system_allocator"]
 
 [features]
 tracing = ["dep:tracing"]

--- a/crates/proof/std-fpvm/src/traits/basic.rs
+++ b/crates/proof/std-fpvm/src/traits/basic.rs
@@ -19,7 +19,7 @@ pub trait BasicKernelInterface {
     /// Read from the given file descriptor into the passed buffer.
     fn read(fd: FileDescriptor, buf: &mut [u8]) -> IOResult<usize>;
 
-    /// Map new memory with with block size `size`. Returns the new heap pointer.
+    /// Map new memory with block size `size`. Returns the new heap pointer.
     fn mmap(size: usize) -> IOResult<usize>;
 
     /// Exit the process with the given exit code. The implementation of this function


### PR DESCRIPTION
## Overview

Switches `kona-std-fpvm` over to the `buddy_system_allocator`, now that memory usage isn't a very sensitive resource in the FPVM variant of the proof program (after #1567)

The `buddy_system_allocator` is much more efficient for some of the large allocations we have to do, for example during channel decompression. It does, however, come with the tradeoff of a larger memory footprint, since it allocates in `2^n` byte blocks.

### Benchmarks (`linked_list_allocator` (current) vs. `buddy_system_allocator`)

![buddy_benchmarks](https://github.com/user-attachments/assets/4921efaa-bb06-4d83-97ec-0b9b4a1906c7)
