### PR TITLE
chore(host): Gate experimental `debug_payloadWitness` usage

### DIFF
--- a/bin/host/src/single/cfg.rs
+++ b/bin/host/src/single/cfg.rs
@@ -107,6 +107,10 @@ pub struct SingleChainHost {
         env
     )]
     pub rollup_config_path: Option<PathBuf>,
+    /// Optionally enables the use of `debug_executePayload` to collect the execution witness from
+    /// the execution layer.
+    #[arg(long, env)]
+    pub enable_experimental_witness_endpoint: bool,
 }
 
 /// An error that can occur when handling single chain hosts
@@ -328,6 +332,18 @@ mod test {
                     "--server",
                     "--l2-chain-id",
                     "0",
+                ]
+                .as_slice(),
+                true,
+            ),
+            (
+                [
+                    "--server",
+                    "--l2-chain-id",
+                    "0",
+                    "--data-dir",
+                    "dummy",
+                    "--enable-experimental-witness-endpoint",
                 ]
                 .as_slice(),
                 true,

--- a/bin/host/src/single/handler.rs
+++ b/bin/host/src/single/handler.rs
@@ -330,6 +330,14 @@ impl HintHandler for SingleChainHintHandler {
                 })?;
             }
             HintType::L2PayloadWitness => {
+                if !cfg.enable_experimental_witness_endpoint {
+                    warn!(
+                        target: "single_hint_handler",
+                        "L2PayloadWitness hint was sent, but payload witness is disabled. Skipping hint."
+                    );
+                    return Ok(());
+                }
+
                 ensure!(hint.data.len() >= 32, "Invalid hint data length");
 
                 let parent_block_hash = B256::from_slice(&hint.data.as_ref()[..32]);


### PR DESCRIPTION
## Overview

Adds a new flag to `kona-host` to gate the use of `debug_payloadWitness`. This prevents runs from performing a call to this endpoint if they don't plan to use it.