### PR TITLE
fix(node/p2p): enable identify protocol. Additional small fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2979,6 +2979,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-bounded"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f328e7fb845fc832912fb6a34f40cf6d1888c92f974d1893a54e97b5ff542e"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5117,6 +5127,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-dns",
  "libp2p-gossipsub",
+ "libp2p-identify",
  "libp2p-identity",
  "libp2p-mdns",
  "libp2p-metrics",
@@ -5229,6 +5240,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-identify"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c06862544f02d05d62780ff590cc25a75f5c2b9df38ec7a370dcae8bb873cf"
+dependencies = [
+ "asynchronous-codec",
+ "either",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "smallvec",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
 name = "libp2p-identity"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5276,6 +5308,7 @@ dependencies = [
  "futures",
  "libp2p-core",
  "libp2p-gossipsub",
+ "libp2p-identify",
  "libp2p-identity",
  "libp2p-ping",
  "libp2p-swarm",

--- a/bin/node/src/flags/p2p.rs
+++ b/bin/node/src/flags/p2p.rs
@@ -280,6 +280,9 @@ impl P2PArgs {
 
         if static_ip {
             builder.disable_enr_update();
+
+            // If we have a static IP, we don't want to use any kind of NAT discovery mechanism.
+            builder.auto_nat_listen_duration(None);
         }
 
         builder.build()

--- a/crates/node/engine/src/client.rs
+++ b/crates/node/engine/src/client.rs
@@ -69,7 +69,7 @@ impl EngineClient {
         let layer_transport = HyperClient::with_service(service);
 
         let http_hyper = Http::with_client(layer_transport, addr);
-        let rpc_client = RpcClient::new(http_hyper, true);
+        let rpc_client = RpcClient::new(http_hyper, false);
         RootProvider::<T>::new(rpc_client)
     }
 

--- a/crates/node/p2p/Cargo.toml
+++ b/crates/node/p2p/Cargo.toml
@@ -34,8 +34,8 @@ op-alloy-rpc-types-engine = { workspace = true, features = ["std"] }
 snap.workspace = true
 futures.workspace = true
 discv5 = { workspace = true, features = ["libp2p"] }
-libp2p = { workspace = true, features = ["macros", "tokio", "tcp", "noise", "gossipsub", "ping", "yamux"] }
-libp2p-identity.workspace = true
+libp2p-identity = { workspace = true, features = ["secp256k1"] }
+libp2p = { workspace = true, features = ["macros", "tokio", "tcp", "noise", "gossipsub", "ping", "yamux", "identify"] }
 openssl = { workspace = true, features = ["vendored"] }
 
 # Cryptography

--- a/crates/node/p2p/src/gossip/builder.rs
+++ b/crates/node/p2p/src/gossip/builder.rs
@@ -124,7 +124,7 @@ impl GossipDriverBuilder {
     pub fn build(mut self) -> Result<GossipDriver, GossipDriverBuilderError> {
         // Extract builder arguments
         let timeout = self.timeout.take().unwrap_or(Duration::from_secs(60));
-        let keypair = self.keypair.take().unwrap_or(Keypair::generate_secp256k1());
+        let keypair = self.keypair.take().ok_or(GossipDriverBuilderError::MissingKeyPair)?;
         let chain_id = self.chain_id.ok_or(GossipDriverBuilderError::MissingChainID)?;
         let addr = self.gossip_addr.take().ok_or(GossipDriverBuilderError::GossipAddrNotSet)?;
         let signer_recv = self.signer.ok_or(GossipDriverBuilderError::MissingUnsafeBlockSigner)?;
@@ -143,7 +143,7 @@ impl GossipDriverBuilder {
             config.gossip_lazy(),
             config.flood_publish()
         );
-        let mut behaviour = Behaviour::new(config, &[Box::new(handler.clone())])?;
+        let mut behaviour = Behaviour::new(keypair.public(), config, &[Box::new(handler.clone())])?;
 
         // If peer scoring is configured, set it on the behaviour.
         if let Some(scoring) = self.scoring {

--- a/crates/node/p2p/src/gossip/driver.rs
+++ b/crates/node/p2p/src/gossip/driver.rs
@@ -178,7 +178,7 @@ impl GossipDriver {
 
         match self.swarm.dial(addr.clone()) {
             Ok(_) => {
-                trace!(peer=?addr, "Dialed peer");
+                trace!(target: "gossip", peer=?addr, "Dialed peer");
                 let count = self.dialed_peers.entry(addr.clone()).or_insert(0);
                 *count += 1;
             }

--- a/crates/node/p2p/src/gossip/driver.rs
+++ b/crates/node/p2p/src/gossip/driver.rs
@@ -178,12 +178,12 @@ impl GossipDriver {
 
         match self.swarm.dial(addr.clone()) {
             Ok(_) => {
-                event!(tracing::Level::TRACE, peer=%addr, "Dialed peer");
+                trace!(peer=?addr, "Dialed peer");
                 let count = self.dialed_peers.entry(addr.clone()).or_insert(0);
                 *count += 1;
             }
             Err(e) => {
-                debug!(target: "gossip", "Failed to connect to peer: {:?}", e);
+                error!(target: "gossip", "Failed to connect to peer: {:?}", e);
             }
         }
     }
@@ -235,42 +235,49 @@ impl GossipDriver {
 
     /// Handles the [`SwarmEvent<Event>`].
     pub fn handle_event(&mut self, event: SwarmEvent<Event>) -> Option<OpNetworkPayloadEnvelope> {
-        if let SwarmEvent::ConnectionEstablished { peer_id, endpoint, .. } = event {
-            let peer_count = self.swarm.connected_peers().count();
-            trace!(target: "gossip", "Connection established: {:?} | Peer Count: {}", peer_id, peer_count);
-            crate::set!(PEER_COUNT, peer_count as i64);
-            self.peerstore.insert(peer_id, endpoint.get_remote_address().clone());
-            return None;
-        }
-        if let SwarmEvent::OutgoingConnectionError { peer_id, error, .. } = event {
-            trace!(target: "gossip", "Outgoing connection error: {:?}", error);
-            if let Some(id) = peer_id {
-                self.redial(id);
+        let event = match event {
+            SwarmEvent::ConnectionEstablished { peer_id, endpoint, .. } => {
+                let peer_count = self.swarm.connected_peers().count();
+                info!(target: "gossip", "Connection established: {:?} | Peer Count: {}", peer_id, peer_count);
+                crate::set!(PEER_COUNT, peer_count as i64);
+                self.peerstore.insert(peer_id, endpoint.get_remote_address().clone());
+                return None;
             }
-            return None;
-        }
-        if let SwarmEvent::ConnectionClosed { peer_id, cause, .. } = event {
-            let peer_count = self.swarm.connected_peers().count();
-            trace!(target: "gossip", "Connection closed, redialing peer: {:?} | {:?} | Peer Count: {}", peer_id, cause, peer_count);
-            crate::set!(PEER_COUNT, peer_count as i64);
-            self.redial(peer_id);
-            return None;
-        }
-        if let SwarmEvent::NewListenAddr { address, .. } = event {
-            debug!(target: "gossip", "Swarm listening on new address: {:?}", address);
-            return None;
-        }
-        let SwarmEvent::Behaviour(event) = event else {
-            trace!(target: "gossip", "Ignoring non-behaviour in event handler: {:?}", event);
-            return None;
+            SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
+                warn!(target: "gossip", "Outgoing connection error: {:?}", error);
+                if let Some(id) = peer_id {
+                    self.redial(id);
+                }
+                return None;
+            }
+            SwarmEvent::ConnectionClosed { peer_id, cause, .. } => {
+                let peer_count = self.swarm.connected_peers().count();
+                warn!(target: "gossip", "Connection closed, redialing peer: {:?} | {:?} | Peer Count: {}", peer_id, cause, peer_count);
+                crate::set!(PEER_COUNT, peer_count as i64);
+                self.redial(peer_id);
+                return None;
+            }
+            SwarmEvent::NewListenAddr { listener_id, address } => {
+                debug!(target: "gossip", reporter_id = ?listener_id, new_address = ?address, "New listen address");
+                return None;
+            }
+            SwarmEvent::Behaviour(event) => event,
+            _ => {
+                debug!(target: "gossip", ?event, "Ignoring non-behaviour in event handler");
+                return None;
+            }
         };
 
         match event {
             Event::Ping(libp2p::ping::Event { peer, result, .. }) => {
-                trace!(target: "gossip", "Ping from peer: {:?} | Result: {:?}", peer, result);
+                debug!(target: "gossip", ?peer, ?result, "Ping received");
                 None
             }
             Event::Gossipsub(e) => self.handle_gossipsub_event(e),
+            Event::Identify(e) => {
+                debug!(target: "gossip", event = ?e, "Identify event received");
+                None
+            }
         }
     }
 }

--- a/crates/node/p2p/src/gossip/error.rs
+++ b/crates/node/p2p/src/gossip/error.rs
@@ -29,6 +29,9 @@ pub enum HandlerEncodeError {
 /// An error type for the [`crate::GossipDriverBuilder`].
 #[derive(Debug, Clone, PartialEq, Eq, From, Error)]
 pub enum GossipDriverBuilderError {
+    /// Missing key pair.
+    #[error("missing key pair")]
+    MissingKeyPair,
     /// Missing chain id.
     #[error("missing chain id")]
     MissingChainID,

--- a/crates/node/p2p/src/gossip/event.rs
+++ b/crates/node/p2p/src/gossip/event.rs
@@ -1,6 +1,6 @@
 //! Event Handling Module.
 
-use libp2p::{gossipsub, ping};
+use libp2p::{gossipsub, identify, ping};
 
 /// The type of message received
 #[derive(Debug)]
@@ -10,6 +10,8 @@ pub enum Event {
     Ping(ping::Event),
     /// Represents a [gossipsub::Event]
     Gossipsub(gossipsub::Event),
+    /// Represents a [identify::Event]
+    Identify(identify::Event),
 }
 
 impl From<ping::Event> for Event {
@@ -23,6 +25,13 @@ impl From<gossipsub::Event> for Event {
     /// Converts [gossipsub::Event] to [Event]
     fn from(value: gossipsub::Event) -> Self {
         Self::Gossipsub(value)
+    }
+}
+
+impl From<identify::Event> for Event {
+    /// Converts [identify::Event] to [Event]
+    fn from(value: identify::Event) -> Self {
+        Self::Identify(value)
     }
 }
 

--- a/crates/node/p2p/src/peers/nodes.rs
+++ b/crates/node/p2p/src/peers/nodes.rs
@@ -120,6 +120,8 @@ pub static OP_RAW_TESTNET_BOOTNODES: &[&str] = &[
 
 #[cfg(test)]
 mod tests {
+    use discv5::enr::EnrPublicKey;
+
     use super::*;
 
     #[test]
@@ -158,6 +160,19 @@ mod tests {
 
         let bootnodes = BootNodes::testnet();
         assert_eq!(bootnodes.len(), 8);
+    }
+
+    #[test]
+    fn parse_enr() {
+        const ENR: &str = "enr:-Jy4QHRgJ9rnWbTs0oOfv8IHt77NDhHE3rwXf3fCh8RRN8sze4gyuQ2MkAapZwneDd_LH77TGCRS5N4wPGm-J5Hh-oCDAQKOgmlkgnY0gmlwhC36_pOHb3BzdGFja4Xkq4MBAIlzZWNwMjU2azGhAqUtGspoH5IzIIAwaqcipQFWripEU12KAiKFqRKDCZWxg3RjcIIjK4N1ZHCCIys";
+        const PEER_ID: &str = "16Uiu2HAm6YT98Hd3qAtop3TFM75uXvuyEhZYwPCfZ9mzRckmFkmW";
+
+        let enr = Enr::from_str(ENR).unwrap();
+        let pub_key = enr.public_key();
+        let pub_key =
+            libp2p_identity::secp256k1::PublicKey::try_from_bytes(&pub_key.encode()).unwrap();
+
+        assert_eq!(PEER_ID, libp2p_identity::PeerId::from_public_key(&pub_key.into()).to_string());
     }
 
     #[test]

--- a/crates/node/p2p/src/peers/utils.rs
+++ b/crates/node/p2p/src/peers/utils.rs
@@ -23,12 +23,6 @@ pub fn enr_to_multiaddr(enr: &Enr) -> Option<Multiaddr> {
         return None;
     };
 
-    if let Some(socket) = enr.udp4_socket() {
-        addr.push(Protocol::Udp(socket.port()));
-    } else if let Some(socket) = enr.udp6_socket() {
-        addr.push(Protocol::Udp(socket.port()));
-    }
-
     let CombinedPublicKey::Secp256k1(pub_key) = enr.public_key() else {
         return None;
     };
@@ -108,7 +102,6 @@ mod tests {
 
         let mut received_ip = None;
         let mut received_tcp_port = None;
-        let mut received_udp_port = None;
         let mut received_p2p_id = None;
 
         for protocol in multiaddr.iter() {
@@ -118,9 +111,6 @@ mod tests {
                 }
                 Protocol::Tcp(port) => {
                     received_tcp_port = Some(port);
-                }
-                Protocol::Udp(port) => {
-                    received_udp_port = Some(port);
                 }
                 Protocol::P2p(id) => {
                     received_p2p_id = Some(id);
@@ -132,7 +122,6 @@ mod tests {
         }
         assert_eq!(received_ip, Some(ip));
         assert_eq!(received_tcp_port, Some(tcp_port));
-        assert_eq!(received_udp_port, Some(udp_port));
         assert_eq!(received_p2p_id, Some(peer_id));
     }
 
@@ -154,7 +143,6 @@ mod tests {
 
         let mut received_ip = None;
         let mut received_tcp_port = None;
-        let mut received_udp_port = None;
         let mut received_p2p_id = None;
 
         for protocol in multiaddr.iter() {
@@ -164,9 +152,6 @@ mod tests {
                 }
                 Protocol::Tcp(port) => {
                     received_tcp_port = Some(port);
-                }
-                Protocol::Udp(port) => {
-                    received_udp_port = Some(port);
                 }
                 Protocol::P2p(id) => {
                     received_p2p_id = Some(id);
@@ -178,7 +163,6 @@ mod tests {
         }
         assert_eq!(received_ip, Some(ip));
         assert_eq!(received_tcp_port, Some(tcp_port));
-        assert_eq!(received_udp_port, Some(udp_port));
         assert_eq!(received_p2p_id, Some(peer_id));
     }
 

--- a/crates/node/p2p/src/rpc/request.rs
+++ b/crates/node/p2p/src/rpc/request.rs
@@ -78,7 +78,7 @@ impl NetRpcRequest {
                 protocol_version: "1".to_string(),
                 enr: enr.to_string(),
                 addresses,
-                protocols: None, // TODO: peer supported protocols
+                protocols: None,
                 connectedness: kona_rpc::Connectedness::Connected,
                 direction: kona_rpc::Direction::Inbound,
                 protected: false,

--- a/crates/node/p2p/tests/common/mod.rs
+++ b/crates/node/p2p/tests/common/mod.rs
@@ -16,15 +16,15 @@ pub(crate) fn gossip_driver(port: u16) -> GossipDriver {
     // Use the default `kona_p2p` config for the gossipsub protocol.
     let config = kona_p2p::default_config();
 
+    let keypair = Keypair::generate_secp256k1();
+
     // Construct a Behaviour instance
     let unsafe_block_signer = Address::default();
     let (_, unsafe_block_signer_recv) = tokio::sync::watch::channel(unsafe_block_signer);
     let handler = BlockHandler::new(chain_id, unsafe_block_signer_recv);
-    let behaviour =
-        Behaviour::new(config, &[Box::new(handler.clone())]).expect("creates behaviour");
+    let behaviour = Behaviour::new(keypair.public(), config, &[Box::new(handler.clone())])
+        .expect("creates behaviour");
 
-    // Construct the
-    let keypair = Keypair::generate_secp256k1();
     let swarm = SwarmBuilder::with_existing_identity(keypair)
         .with_tokio()
         .with_tcp(

--- a/crates/node/service/src/service/standard/builder.rs
+++ b/crates/node/service/src/service/standard/builder.rs
@@ -131,7 +131,7 @@ impl RollupNodeBuilder {
 
         let layer_transport = HyperClient::with_service(service);
         let http_hyper = Http::with_client(layer_transport, l2_rpc_url.clone());
-        let rpc_client = RpcClient::new(http_hyper, true);
+        let rpc_client = RpcClient::new(http_hyper, false);
         let l2_provider = RootProvider::<Optimism>::new(rpc_client);
 
         let rpc_launcher = self.rpc_config.map(|c| c.as_launcher()).unwrap_or_default();

--- a/crates/providers/providers-alloy/src/l2_chain_provider.rs
+++ b/crates/providers/providers-alloy/src/l2_chain_provider.rs
@@ -107,7 +107,7 @@ impl AlloyL2ChainProvider {
 
         let layer_transport = HyperClient::with_service(service);
         let http_hyper = Http::with_client(layer_transport, url);
-        let rpc_client = RpcClient::new(http_hyper, true);
+        let rpc_client = RpcClient::new(http_hyper, false);
 
         let rpc = RootProvider::<Optimism>::new(rpc_client);
         Self::new(rpc, rollup_config, cache_size)


### PR DESCRIPTION
## Description
This PR brings an additional wave of fixes to the p2p layer for the kona node. In particular this PR:
- Enables the `identify` protocol for node discovery. This helps kickstart the gossip layer from the op-node
- Does a small change to the RPCClients to remove the `is_local` flag
- Removes the udp protocol from the converted multiaddresses from ENRs (it produces malformed multiaddresses)
- Does a couple of small log visibility changes that were useful to debug the kona-node inside kurtosis

## Note
Merging this PR will fix the p2p gossip for kona-nodes and allow them to receive/gossip blocks on the p2p layer. Kona-nodes can also communicate with op-nodes (tested in Kurtosis)

To some extent, merging this PR will fix #1396 

## What remains to do
It seems that the peers get graylisted after a while and eventually get ejected from the gossip layer. We'll need to fine-tune network parameters to make sure this doesn't happen