### PR TITLE
chore(workspace): Add FPVM artifacts to `gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,10 @@ monorepo/
 # kona-host data-dir
 data/
 
-# Exclude maili shadow crate Cargo.lock files
-**/**/**/maili/Cargo.lock
+# FPVM artifacts
+./state.bin.gz
+./meta.json
+./out.json
+
+# Prestate artifacts
+prestate-artifacts-*


### PR DESCRIPTION
## Overview

Adds a few QOL improvements to the `.gitignore` file when working with the FPVM recipes in `kona-client`.

Also removes `maili` shadow crates from the gitignore, since those got axed in #1072.