### PR TITLE
feat(workspace): Kurtosis Justfile Targets

### DIFF
--- a/.config/optimism_package.json
+++ b/.config/optimism_package.json
@@ -1,0 +1,4 @@
+{
+  "repository": "https://github.com/theochap/optimism-package",
+  "branch": "theo/kona-node-integration"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ target/
 # Monorepo workspace
 monorepo/
 
+# `optimism-package` workspace
+optimism-package/
+
 # Environment Variables
 .env
 

--- a/Justfile
+++ b/Justfile
@@ -80,6 +80,14 @@ test-docs:
 build-native *args='':
   cargo build --workspace $@
 
+# Build target for the `kona-node` docker image.
+build-node:
+  BIN_TARGET=kona-node docker buildx bake \
+    --progress plain \
+    -f docker/docker-bake.hcl \
+    generic
+  docker image tag ghcr.io/op-rs/kona/kona-node:latest kona-node:latest
+
 # Build `kona-client` for the `cannon` target.
 build-cannon-client:
   docker run \
@@ -118,6 +126,40 @@ monorepo:
 # Remove the monorepo directory
 clean-monorepo:
   rm -rf monorepo/
+
+# Installs the optimism-package repository
+optimism-package:
+  #!/bin/bash
+  OPTIMISM_PACKAGE_REPO=$(jq -r '.repository' .config/optimism_package.json)
+  OPTIMISM_PACKAGE_BRANCH=$(jq -r '.branch' .config/optimism_package.json)
+  ([ ! -d optimism-package ] && git clone ${OPTIMISM_PACKAGE_REPO} optimism-package)
+  (cd optimism-package && git fetch origin && git checkout ${OPTIMISM_PACKAGE_BRANCH})
+
+# Remove the optimism-package directory
+clean-optimism-package:
+  rm -rf optimism-package/
+
+# Spins up kurtosis with the `kona-node` docker image
+kurtosis-up:
+  #!/bin/bash
+  # Check if the optimism-package directory exists
+  if [ ! -d optimism-package ]; then
+    echo "optimism-package directory not found. Installing with `just optimism-package`."
+    just optimism-package
+  fi
+
+  # Check if the kurtosis command is available
+  if ! command -v kurtosis &> /dev/null; then
+    echo "kurtosis command not found. Please install kurtosis."
+    exit 1
+  fi
+
+  # Run the kurtosis test
+  (cd optimism-package && kurtosis run . --args-file ../.config/kurtosis_network_params.yaml)
+
+# Winds down kurtosis, cleaning up the network
+kurtosis-down:
+  kurtosis clean -a
 
 # Run action tests for the single-chain client program on the native target
 action-tests-single test_name='Test_ProgramAction' *args='':

--- a/Justfile
+++ b/Justfile
@@ -86,7 +86,7 @@ build-node:
     --progress plain \
     -f docker/docker-bake.hcl \
     generic
-  docker image tag ghcr.io/op-rs/kona/kona-node:latest kona-node:latest
+  docker image tag ghcr.io/op-rs/kona/kona-node:local kona-node:local
 
 # Build `kona-client` for the `cannon` target.
 build-cannon-client:


### PR DESCRIPTION
### Description

Adds a few targets to the workspace `Justfile` to make it easier to work with kurtosis.

- `build-node`: Builds the `kona-node` docker image, tagging it as `kona-node:latest`.
- `optimism-package`: Clones the `optimism-package` repo specified in `.config/optimism_package.json` to `optimism-package`. This directory is ignored by git through `.gitignore`.
- `kurtosis-up`: Spins up kurtosis using the network params defined in `.config/kurtosis_network_params.yaml` from inside the `optimism-package`, installing it through `just optimism-package` if not already cloned.
- `kurtosis-down`: Cleans up kurtosis.

In another PR it would be nice to add a few targets that grab the logs for the `kona-node` and `op-node` instances for debugging.