### PR TITLE
fix(workspace): Build Kona Node

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -86,7 +86,7 @@ build-node:
     --progress plain \
     -f docker/docker-bake.hcl \
     generic
-  docker image tag ghcr.io/op-rs/kona/kona-node:latest kona-node:latest
+  docker image tag ghcr.io/op-rs/kona/kona-node:local kona-node:local
 
 # Build `kona-client` for the `cannon` target.
 build-cannon-client:

--- a/Justfile
+++ b/Justfile
@@ -86,7 +86,7 @@ build-node:
     --progress plain \
     -f docker/docker-bake.hcl \
     generic
-  docker image tag ghcr.io/op-rs/kona/kona-node:local kona-node:local
+  docker image tag ghcr.io/op-rs/kona/kona-node:latest kona-node:latest
 
 # Build `kona-client` for the `cannon` target.
 build-cannon-client:

--- a/Justfile
+++ b/Justfile
@@ -82,11 +82,19 @@ build-native *args='':
 
 # Build target for the `kona-node` docker image.
 build-node:
-  BIN_TARGET=kona-node docker buildx bake \
+  docker build \
     --progress plain \
-    -f docker/docker-bake.hcl \
-    generic
-  docker image tag ghcr.io/op-rs/kona/kona-node:local kona-node:local
+    -f docker/apps/kona_app_generic.dockerfile \
+    --build-arg BIN_TARGET=kona-node \
+    --build-arg TAG=main \
+    -t kona-node:local \
+    .
+
+  # BIN_TARGET=kona-node docker buildx bake \
+  #   --progress plain \
+  #   -f docker/docker-bake.hcl \
+  #   generic
+  # docker image tag ghcr.io/op-rs/kona/kona-node:local kona-node:local
 
 # Build `kona-client` for the `cannon` target.
 build-cannon-client:

--- a/Justfile
+++ b/Justfile
@@ -87,7 +87,7 @@ build-node:
     -f docker/apps/kona_app_generic.dockerfile \
     --build-arg BIN_TARGET=kona-node \
     --build-arg TAG=main \
-    -t kona-node:local \
+    -t ghcr.io/op-rs/kona/kona-node:latest \
     .
 
   # BIN_TARGET=kona-node docker buildx bake \

--- a/Justfile
+++ b/Justfile
@@ -85,8 +85,8 @@ build-node:
   docker build \
     --progress plain \
     -f docker/apps/kona_app_generic.dockerfile \
-    --build-arg BIN_TARGET=kona-node \
-    --build-arg TAG=main \
+    --build-arg "BIN_TARGET=kona-node" \
+    --build-arg "TAG=$(git rev-parse HEAD)" \
     -t ghcr.io/op-rs/kona/kona-node:latest \
     .
 

--- a/Justfile
+++ b/Justfile
@@ -90,12 +90,6 @@ build-node:
     -t ghcr.io/op-rs/kona/kona-node:latest \
     .
 
-  # BIN_TARGET=kona-node docker buildx bake \
-  #   --progress plain \
-  #   -f docker/docker-bake.hcl \
-  #   generic
-  # docker image tag ghcr.io/op-rs/kona/kona-node:local kona-node:local
-
 # Build `kona-client` for the `cannon` target.
 build-cannon-client:
   docker run \


### PR DESCRIPTION
### Description

Fixes the `build-node` justfile target.

This PR gets the kurtosis targets working properly with a local build of the `kona-node`.