### PR TITLE
fix(bin/node): Enable Metrics

### DIFF
--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -19,13 +19,14 @@ workspace = true
 kona-derive.workspace = true
 kona-sources.workspace = true
 kona-cli.workspace = true
-kona-p2p.workspace = true
 kona-engine.workspace = true
 kona-genesis.workspace = true
 kona-protocol.workspace = true
-kona-registry = { workspace = true, features = ["tabled"] }
-kona-node-service.workspace = true
+
 kona-rpc = { workspace = true, features = ["std"] }
+kona-p2p = { workspace = true, features = ["metrics"] }
+kona-registry = { workspace = true, features = ["tabled"] }
+kona-node-service = { workspace = true, features = ["metrics"] }
 
 # alloy
 alloy-provider.workspace = true

--- a/crates/node/p2p/src/gossip/handler.rs
+++ b/crates/node/p2p/src/gossip/handler.rs
@@ -57,7 +57,7 @@ impl Handler for BlockHandler {
         } else if msg.topic == self.blocks_v4_topic.hash() {
             OpNetworkPayloadEnvelope::decode_v4(&msg.data)
         } else {
-            warn!(target: "node::p2p::gossip", topic = ?msg.topic, "Received block with unknown topic");
+            warn!(target: "gossip", topic = ?msg.topic, "Received block with unknown topic");
             return (MessageAcceptance::Reject, None);
         };
 
@@ -65,12 +65,12 @@ impl Handler for BlockHandler {
             Ok(envelope) => match self.block_valid(&envelope) {
                 Ok(()) => (MessageAcceptance::Accept, Some(envelope)),
                 Err(err) => {
-                    warn!(target: "node::p2p::gossip", ?err, ?envelope, "Received invalid block");
+                    warn!(target: "gossip", ?err, hash = ?envelope.payload_hash, "Received invalid block");
                     (err.into(), None)
                 }
             },
             Err(err) => {
-                warn!(target: "node::p2p::gossip", ?err, "Failed to decode block");
+                warn!(target: "gossip", ?err, "Failed to decode block");
                 (MessageAcceptance::Reject, None)
             }
         }

--- a/crates/node/p2p/src/macros.rs
+++ b/crates/node/p2p/src/macros.rs
@@ -6,5 +6,7 @@ macro_rules! set {
     ($metric:ident, $value:expr) => {
         #[cfg(feature = "metrics")]
         $crate::metrics::$metric.set($value);
+        #[cfg(feature = "metrics")]
+        tracing::info!(target: "metrics", "Set {} to {}", stringify!($metric), $value);
     };
 }

--- a/crates/node/service/Cargo.toml
+++ b/crates/node/service/Cargo.toml
@@ -48,3 +48,7 @@ jsonrpsee = { workspace = true, features = ["server"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tower.workspace = true
 http-body-util.workspace = true
+
+[features]
+default = []
+metrics = ["kona-p2p/metrics"]


### PR DESCRIPTION
### Description

Enables metrics by toggling `kona-p2p` `metrics` feature flag on for the `kona-node` binary.