### PR TITLE
fix(node/p2p): Block Validation

### DIFF
--- a/bin/node/src/commands/net.rs
+++ b/bin/node/src/commands/net.rs
@@ -2,6 +2,7 @@
 
 use crate::flags::{GlobalArgs, MetricsArgs, P2PArgs, RpcArgs};
 use clap::Parser;
+use url::Url;
 use kona_p2p::{NetRpcRequest, NetworkBuilder, NetworkRpc};
 use kona_rpc::{OpP2PApiServer, RpcConfig};
 use tracing::{debug, info, warn};
@@ -18,6 +19,11 @@ use tracing::{debug, info, warn};
 #[derive(Parser, Debug, Clone)]
 #[command(about = "Runs the networking stack for the kona-node.")]
 pub struct NetCommand {
+    /// URL of the L1 execution client RPC API.
+    /// This is used to load the unsafe block signer from runtime.
+    /// Without this, the rollup config unsafe block signer will be used which may be outdated.
+    #[arg(long, visible_alias = "l1", env = "L1_ETH_RPC")]
+    pub l1_eth_rpc: Option<Url>,
     /// P2P CLI Flags
     #[command(flatten)]
     pub p2p: P2PArgs,
@@ -58,7 +64,7 @@ impl NetCommand {
 
         // Start the Network Stack
         self.p2p.check_ports()?;
-        let p2p_config = self.p2p.config(&rollup_config, args, None).await?;
+        let p2p_config = self.p2p.config(&rollup_config, args, self.l1_eth_rpc).await?;
         let mut network = NetworkBuilder::from(p2p_config)
             .with_chain_id(args.l2_chain_id)
             .with_rpc_receiver(rx)

--- a/crates/node/p2p/src/gossip/block_validity.rs
+++ b/crates/node/p2p/src/gossip/block_validity.rs
@@ -130,6 +130,8 @@ impl BlockHandler {
         let expected = envelope.payload.block_hash();
         let mut block: Block<OpTxEnvelope> = envelope.payload.clone().try_into_block()?;
         block.header.parent_beacon_block_root = envelope.parent_beacon_block_root;
+        // If isthmus is active, set the requests hash to the empty hash.
+        block.header.requests_hash = Some(alloy_primitives::b256!("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
         let received = block.header.hash_slow();
         if received != expected {
             return Err(BlockInvalidError::BlockHash { expected, received });

--- a/crates/node/p2p/src/gossip/handler.rs
+++ b/crates/node/p2p/src/gossip/handler.rs
@@ -65,7 +65,12 @@ impl Handler for BlockHandler {
             Ok(envelope) => match self.block_valid(&envelope) {
                 Ok(()) => (MessageAcceptance::Accept, Some(envelope)),
                 Err(err) => {
-                    warn!(target: "node::p2p::gossip", ?err, ?envelope, "Received invalid block");
+                    warn!(target: "node::p2p::gossip", ?err, hash = ?envelope.payload_hash, "Received invalid block");
+                    // Write this to a file.
+                    // let _ = std::fs::write(
+                    //     format!("tmp_invalid_block_{:?}.json", envelope.payload_hash),
+                    //     format!("{:?}", envelope),
+                    // );
                     (err.into(), None)
                 }
             },


### PR DESCRIPTION
### Description

Fixes block validation for op-sepolia, setting the requests root to the `SHA256_EMPTY` hash.

I think we do need to gate this behind an `isthmus_active` check using the rollup config and the payload timestamp.