### PR TITLE
chore(docker): Update `cannon` tag

### DIFF
--- a/bin/client/justfile
+++ b/bin/client/justfile
@@ -216,7 +216,7 @@ run-client-cannon block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc verbo
   just build-cannon-client
 
   echo "Loading client program into Cannon state format..."
-  cannon load-elf --path=$CLIENT_BIN_PATH --type multithreaded64-3
+  cannon load-elf --path=$CLIENT_BIN_PATH --type multithreaded64-4
 
   echo "Building host program for native target..."
   cargo build --bin kona-host --release
@@ -264,7 +264,7 @@ run-client-cannon-offline block_number l2_claim l2_output_root l2_head l1_head l
   just build-cannon-client
 
   echo "Loading client program into Cannon state format..."
-  cannon load-elf --path=$CLIENT_BIN_PATH --type multithreaded64-3
+  cannon load-elf --path=$CLIENT_BIN_PATH --type multithreaded64-4
 
   echo "Building host program for native target..."
   cargo build --bin kona-host

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -39,12 +39,7 @@ variable "CANNON_TAG" {
   //
   // You can override this if you'd like to use a different tag to generate the prestate.
   // https://github.com/ethereum-optimism/optimism/releases
-  //
-  // NOTE: This version of cannon will not run `kona-client`. This is just a stub tag.
-  // https://github.com/ethereum-optimism/optimism/pull/14454 must be merged and included
-  // in order for `kona-client` to run on cannon. Once this tag is updated to a version that
-  // does support kona, remove this comment.
-  default = "cannon/v1.4.0"
+  default = "cannon/v1.5.0-alpha.1"
 }
 
 // Special target: https://github.com/docker/metadata-action#bake-definition

--- a/docker/fpvm-prestates/asterisc-repro.dockerfile
+++ b/docker/fpvm-prestates/asterisc-repro.dockerfile
@@ -91,3 +91,4 @@ COPY --from=prestate-build /asterisc .
 COPY --from=prestate-build /kona-client-elf .
 COPY --from=prestate-build /prestate.bin.gz .
 COPY --from=prestate-build /prestate-proof.json .
+COPY --from=prestate-build /meta.json .

--- a/docker/fpvm-prestates/cannon-repro.dockerfile
+++ b/docker/fpvm-prestates/cannon-repro.dockerfile
@@ -71,7 +71,7 @@ COPY --from=client-build /kona-client-elf $CLIENT_BIN_PATH
 RUN $CANNON_BIN_PATH load-elf \
   --path=$CLIENT_BIN_PATH \
   --out=$PRESTATE_OUT_PATH \
-  --type multithreaded64-3
+  --type multithreaded64-4
 
 # Create `prestate-proof.json`
 RUN $CANNON_BIN_PATH run \
@@ -93,3 +93,4 @@ COPY --from=prestate-build /cannon .
 COPY --from=prestate-build /kona-client-elf .
 COPY --from=prestate-build /prestate.bin.gz .
 COPY --from=prestate-build /prestate-proof.json .
+COPY --from=prestate-build /meta.json .


### PR DESCRIPTION
## Overview

Updates the `cannon` tag to [`cannon/v1.5.0-alpha.1`](https://github.com/ethereum-optimism/optimism/tree/cannon/v1.5.0-alpha.1), which adds support for the `DCLO` and `DCLZ` instructions required to run `kona`'s `mips64r1` target.