### PR TITLE
feat(docker): Enable reproducible prestate builds for interop program

### DIFF
--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -42,6 +42,18 @@ variable "CANNON_TAG" {
   default = "cannon/v1.5.0-alpha.1"
 }
 
+variable "CLIENT_BIN" {
+  // The `kona-client` binary to use in the `kona-{asterisc/cannon}-prestate` targets.
+  //
+  // You can override this if you'd like to use a different `kona-client` binary to generate
+  // the prestate.
+  //
+  // Valid options:
+  // - `kona` (single-chain)
+  // - `kona-int` (interop)
+  default = "kona"
+}
+
 // Special target: https://github.com/docker/metadata-action#bake-definition
 target "docker-metadata-action" {
   tags = ["${DEFAULT_TAG}"]
@@ -77,6 +89,7 @@ target "kona-asterisc-prestate" {
   context = "."
   dockerfile = "docker/fpvm-prestates/asterisc-repro.dockerfile"
   args = {
+    CLIENT_BIN = "${CLIENT_BIN}"
     CLIENT_TAG = "${GIT_REF_NAME}"
     ASTERISC_TAG = "${ASTERISC_TAG}"
   }
@@ -89,6 +102,7 @@ target "kona-cannon-prestate" {
   context = "."
   dockerfile = "docker/fpvm-prestates/cannon-repro.dockerfile"
   args = {
+    CLIENT_BIN = "${CLIENT_BIN}"
     CLIENT_TAG = "${GIT_REF_NAME}"
     CANNON_TAG = "${CANNON_TAG}"
   }

--- a/docker/fpvm-prestates/asterisc-repro.dockerfile
+++ b/docker/fpvm-prestates/asterisc-repro.dockerfile
@@ -33,6 +33,7 @@ RUN git clone https://github.com/ethereum-optimism/asterisc && \
 FROM ghcr.io/op-rs/kona/asterisc-builder:0.1.0 AS client-build
 SHELL ["/bin/bash", "-c"]
 
+ARG CLIENT_BIN
 ARG CLIENT_TAG
 
 # Install deps
@@ -44,8 +45,8 @@ RUN git clone https://github.com/op-rs/kona
 # Build kona-client on the selected tag
 RUN cd kona && \
   git checkout $CLIENT_TAG && \
-  cargo build -Zbuild-std=core,alloc -p kona-client --bin kona --locked --profile release-client-lto && \
-  mv ./target/riscv64imac-unknown-none-elf/release-client-lto/kona /kona-client-elf
+  cargo build -Zbuild-std=core,alloc -p kona-client --bin $CLIENT_BIN --locked --profile release-client-lto && \
+  mv ./target/riscv64imac-unknown-none-elf/release-client-lto/$CLIENT_BIN /kona-client-elf
 
 ################################################################
 #      Create `prestate.bin.gz` + `prestate-proof.json`        #

--- a/docker/fpvm-prestates/cannon-repro.dockerfile
+++ b/docker/fpvm-prestates/cannon-repro.dockerfile
@@ -33,6 +33,7 @@ RUN git clone https://github.com/ethereum-optimism/optimism && \
 FROM ghcr.io/op-rs/kona/cannon-builder:0.1.0 AS client-build
 SHELL ["/bin/bash", "-c"]
 
+ARG CLIENT_BIN
 ARG CLIENT_TAG
 
 # Install deps
@@ -44,8 +45,8 @@ RUN git clone https://github.com/op-rs/kona
 # Build kona-client on the selected tag
 RUN cd kona && \
   git checkout $CLIENT_TAG && \
-  cargo build -Zbuild-std=core,alloc -p kona-client --bin kona --locked --profile release-client-lto && \
-  mv ./target/mips64-unknown-none/release-client-lto/kona /kona-client-elf
+  cargo build -Zbuild-std=core,alloc -p kona-client --bin $CLIENT_BIN --locked --profile release-client-lto && \
+  mv ./target/mips64-unknown-none/release-client-lto/$CLIENT_BIN /kona-client-elf
 
 ################################################################
 #      Create `prestate.bin.gz` + `prestate-proof.json`        #

--- a/docker/fpvm-prestates/justfile
+++ b/docker/fpvm-prestates/justfile
@@ -8,18 +8,46 @@ default:
   @just --list
 
 # Build the `kona-client` prestate artifacts for the specified tags (asterisc + cannon).
-build-client-prestate-artifacts kona_tag asterisc_tag cannon_tag:
+build-client-prestate-artifacts kona_client_variant kona_tag asterisc_tag cannon_tag:
   #!/bin/bash
-  just build-client-prestate-asterisc-artifacts {{kona_tag}} {{asterisc_tag}}
-  just build-client-prestate-cannon-artifacts {{kona_tag}} {{cannon_tag}}
+
+  # Available variants of the client program, parsed from the binary targets of the `kona-client` crate.
+  manifest_path="$(realpath ../../bin/client/Cargo.toml)"
+  available_variants=($(cargo metadata --format-version=1 --manifest-path="$manifest_path" --no-deps |
+    jq -r --arg path "$manifest_path" '.packages[] | select(.manifest_path == $path) | .targets[] | select(.kind[] == "bin") | .name' |
+    xargs))
+
+  # Validates that `$1` is contained in `$2`
+  validate_option() {
+      local input="$1"
+      local valid_options=("${@:2}")
+
+      for option in "${valid_options[@]}"; do
+          if [[ "$input" == "$option" ]]; then
+              return 0
+          fi
+      done
+
+      return 1
+  }
+
+  # Check if `kona_client_variant` is contained within the available variants.
+  if ! validate_option "{{kona_client_variant}}" "${available_variants[@]}"; then
+      echo "Invalid client program variant. Please choose from: ${available_variants[*]}"
+      exit 1
+  fi
+
+  just build-client-prestate-asterisc-artifacts {{kona_client_variant}} {{kona_tag}} {{asterisc_tag}}
+  just build-client-prestate-cannon-artifacts {{kona_client_variant}} {{kona_tag}} {{cannon_tag}}
 
 # Build the `kona-client` prestate artifacts for the latest release (asterisc).
-build-client-prestate-asterisc-artifacts kona_tag asterisc_tag out='./prestate-artifacts-asterisc':
+build-client-prestate-asterisc-artifacts kona_client_variant kona_tag asterisc_tag out='./prestate-artifacts-asterisc':
   #!/bin/bash
   OUTPUT_DIR={{out}}
 
   # Docker bake env
   export GIT_REF_NAME="{{kona_tag}}"
+  export CLIENT_BIN="{{kona_client_variant}}"
   export ASTERISC_TAG="{{asterisc_tag}}"
   export DEFAULT_TAG="kona-asterisc-prestate:local"
 
@@ -29,19 +57,20 @@ build-client-prestate-asterisc-artifacts kona_tag asterisc_tag out='./prestate-a
   # Create the output directory
   mkdir -p $OUTPUT_DIR
 
-  echo "Building kona-client prestate artifacts for the asterisc target. 🐚 Kona Tag: {{kona_tag}} | 🎇 Asterisc Tag: {{asterisc_tag}}"
+  echo "Building kona-client (variant: {{kona_client_variant}}) prestate artifacts for the asterisc target. 🐚 Kona Tag: {{kona_tag}} | 🎇 Asterisc Tag: {{asterisc_tag}}"
   docker buildx bake \
     --set "*.output=$OUTPUT_DIR" \
     -f docker/docker-bake.hcl \
     kona-asterisc-prestate
 
 # Build the `kona-client` prestate artifacts for the latest release (cannon).
-build-client-prestate-cannon-artifacts kona_tag cannon_tag out='./prestate-artifacts-cannon':
+build-client-prestate-cannon-artifacts kona_client_variant kona_tag cannon_tag out='./prestate-artifacts-cannon':
   #!/bin/bash
   OUTPUT_DIR={{out}}
 
   # Docker bake env
   export GIT_REF_NAME="{{kona_tag}}"
+  export CLIENT_BIN="{{kona_client_variant}}"
   export CANNON_TAG="{{cannon_tag}}"
   export DEFAULT_TAG="kona-cannon-prestate:local"
 
@@ -51,7 +80,7 @@ build-client-prestate-cannon-artifacts kona_tag cannon_tag out='./prestate-artif
   # Create the output directory
   mkdir -p $OUTPUT_DIR
 
-  echo "Building kona-client prestate artifacts for the cannon target. 🐚 Kona Tag: {{kona_tag}} | 🔫 Cannon Tag: {{cannon_tag}}"
+  echo "Building kona-client (variant: {{kona_client_variant}}) prestate artifacts for the cannon target. 🐚 Kona Tag: {{kona_tag}} | 🔫 Cannon Tag: {{cannon_tag}}"
   docker buildx bake \
     --set "*.output=$OUTPUT_DIR" \
     -f docker/docker-bake.hcl \


### PR DESCRIPTION
## Overview

Adds a new parameter to the reproducible prestate bake targets that allows for specifying any available binary target of the `kona-client` crate. This allows for reproducible builds of FPVM prestates based off of `kona-int`, the interop variant of the client program.