### PR TITLE
feat(interop): Use `FpvmOpEvmFactory` in interop proof program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4904,6 +4904,7 @@ version = "0.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.15.6",
+ "alloy-evm",
  "alloy-op-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -4920,7 +4921,9 @@ dependencies = [
  "kona-registry",
  "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
+ "op-revm",
  "rand 0.9.1",
+ "revm",
  "serde",
  "serde_json",
  "spin 0.10.0",

--- a/bin/client/src/kona_interop.rs
+++ b/bin/client/src/kona_interop.rs
@@ -8,6 +8,7 @@
 extern crate alloc;
 
 use alloc::string::String;
+use kona_client::fpvm_evm::FpvmOpEvmFactory;
 use kona_preimage::{HintWriter, OracleReader};
 use kona_std_fpvm::{FileChannel, FileDescriptor};
 use kona_std_fpvm_proc::client_entry;
@@ -37,5 +38,9 @@ fn main() -> Result<(), String> {
             .expect("Failed to set tracing subscriber");
     }
 
-    kona_proof::block_on(kona_client::interop::run(ORACLE_READER, HINT_WRITER))
+    kona_proof::block_on(kona_client::interop::run(
+        ORACLE_READER,
+        HINT_WRITER,
+        FpvmOpEvmFactory::new(HINT_WRITER, ORACLE_READER),
+    ))
 }

--- a/bin/host/src/interop/cfg.rs
+++ b/bin/host/src/interop/cfg.rs
@@ -10,6 +10,7 @@ use alloy_primitives::{B256, Bytes};
 use alloy_provider::{Provider, RootProvider};
 use clap::Parser;
 use kona_cli::cli_styles;
+use kona_client::fpvm_evm::FpvmOpEvmFactory;
 use kona_genesis::RollupConfig;
 use kona_preimage::{
     BidirectionalChannel, Channel, HintReader, HintWriter, OracleReader, OracleServer,
@@ -189,8 +190,9 @@ impl InteropHost {
 
         let server_task = self.start_server(hint.host, preimage.host).await?;
         let client_task = task::spawn(kona_client::interop::run(
-            OracleReader::new(preimage.client),
-            HintWriter::new(hint.client),
+            OracleReader::new(preimage.client.clone()),
+            HintWriter::new(hint.client.clone()),
+            FpvmOpEvmFactory::new(HintWriter::new(hint.client), OracleReader::new(preimage.client)),
         ));
 
         let (_, client_result) = tokio::try_join!(server_task, client_task)?;

--- a/crates/proof/proof-interop/Cargo.toml
+++ b/crates/proof/proof-interop/Cargo.toml
@@ -28,11 +28,16 @@ alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 alloy-eips.workspace = true
 alloy-rpc-types-engine.workspace = true
+alloy-evm.workspace = true
 
 # OP Alloy
 op-alloy-consensus.workspace = true
 op-alloy-rpc-types-engine.workspace = true
 alloy-op-evm.workspace = true
+
+# revm
+revm.workspace = true
+op-revm.workspace = true
 
 # General
 serde.workspace = true


### PR DESCRIPTION
## Overview

Uses the `FpvmOpEvmFactory` in the interop proof program, adding support for accelerated precompiles.

closes #1543 