### PR TITLE
chore(client): Loosen type constraints on `FpvmOpEvmFactory`

### DIFF
--- a/bin/client/src/fpvm_evm/precompiles/bls12_g1_add.rs
+++ b/bin/client/src/fpvm_evm/precompiles/bls12_g1_add.rs
@@ -8,7 +8,7 @@
 
 use crate::fpvm_evm::precompiles::utils::precompile_run;
 use alloc::string::ToString;
-use kona_preimage::{Channel, HintWriter, OracleReader};
+use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use revm::precompile::{
     PrecompileError, PrecompileOutput, PrecompileResult, bls12_381,
     bls12_381_const::{G1_ADD_BASE_GAS_FEE, G1_ADD_INPUT_LENGTH},
@@ -18,12 +18,16 @@ use revm::precompile::{
 ///
 /// Notice, there is no input size limit for this precompile.
 /// See: <https://specs.optimism.io/protocol/isthmus/exec-engine.html#evm-changes>
-pub(crate) fn fpvm_bls12_g1_add<C: Channel + Send + Sync>(
+pub(crate) fn fpvm_bls12_g1_add<H, O>(
     input: &[u8],
     gas_limit: u64,
-    hint_writer: &HintWriter<C>,
-    oracle_reader: &OracleReader<C>,
-) -> PrecompileResult {
+    hint_writer: &H,
+    oracle_reader: &O,
+) -> PrecompileResult
+where
+    H: HintWriterClient + Send + Sync,
+    O: PreimageOracleClient + Send + Sync,
+{
     if G1_ADD_BASE_GAS_FEE > gas_limit {
         return Err(PrecompileError::OutOfGas);
     }

--- a/bin/client/src/fpvm_evm/precompiles/bls12_g1_msm.rs
+++ b/bin/client/src/fpvm_evm/precompiles/bls12_g1_msm.rs
@@ -8,7 +8,7 @@
 
 use crate::fpvm_evm::precompiles::utils::{msm_required_gas, precompile_run};
 use alloc::string::ToString;
-use kona_preimage::{Channel, HintWriter, OracleReader};
+use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use revm::precompile::{
     PrecompileError, PrecompileOutput, PrecompileResult, bls12_381,
     bls12_381_const::{DISCOUNT_TABLE_G1_MSM, G1_MSM_BASE_GAS_FEE, G1_MSM_INPUT_LENGTH},
@@ -20,12 +20,16 @@ use revm::precompile::{
 const BLS12_MAX_G1_MSM_SIZE_ISTHMUS: usize = 513760;
 
 /// Performs an FPVM-accelerated `bls12` g1 msm check precompile call after the Isthmus Hardfork.
-pub(crate) fn fpvm_bls12_g1_msm<C: Channel + Send + Sync>(
+pub(crate) fn fpvm_bls12_g1_msm<H, O>(
     input: &[u8],
     gas_limit: u64,
-    hint_writer: &HintWriter<C>,
-    oracle_reader: &OracleReader<C>,
-) -> PrecompileResult {
+    hint_writer: &H,
+    oracle_reader: &O,
+) -> PrecompileResult
+where
+    H: HintWriterClient + Send + Sync,
+    O: PreimageOracleClient + Send + Sync,
+{
     if input.len() > BLS12_MAX_G1_MSM_SIZE_ISTHMUS {
         return Err(PrecompileError::Other(alloc::format!(
             "G1MSM input length must be at most {}",

--- a/bin/client/src/fpvm_evm/precompiles/bls12_g2_add.rs
+++ b/bin/client/src/fpvm_evm/precompiles/bls12_g2_add.rs
@@ -8,7 +8,7 @@
 
 use crate::fpvm_evm::precompiles::utils::precompile_run;
 use alloc::string::ToString;
-use kona_preimage::{Channel, HintWriter, OracleReader};
+use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use revm::precompile::{
     PrecompileError, PrecompileOutput, PrecompileResult, bls12_381,
     bls12_381_const::{G2_ADD_BASE_GAS_FEE, G2_ADD_INPUT_LENGTH},
@@ -18,12 +18,16 @@ use revm::precompile::{
 ///
 /// Notice, there is no input size limit for this precompile.
 /// See: <https://specs.optimism.io/protocol/isthmus/exec-engine.html#evm-changes>
-pub(crate) fn fpvm_bls12_g2_add<C: Channel + Send + Sync>(
+pub(crate) fn fpvm_bls12_g2_add<H, O>(
     input: &[u8],
     gas_limit: u64,
-    hint_writer: &HintWriter<C>,
-    oracle_reader: &OracleReader<C>,
-) -> PrecompileResult {
+    hint_writer: &H,
+    oracle_reader: &O,
+) -> PrecompileResult
+where
+    H: HintWriterClient + Send + Sync,
+    O: PreimageOracleClient + Send + Sync,
+{
     if G2_ADD_BASE_GAS_FEE > gas_limit {
         return Err(PrecompileError::OutOfGas);
     }

--- a/bin/client/src/fpvm_evm/precompiles/bls12_g2_msm.rs
+++ b/bin/client/src/fpvm_evm/precompiles/bls12_g2_msm.rs
@@ -8,7 +8,7 @@
 
 use crate::fpvm_evm::precompiles::utils::{msm_required_gas, precompile_run};
 use alloc::string::ToString;
-use kona_preimage::{Channel, HintWriter, OracleReader};
+use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use revm::precompile::{
     PrecompileError, PrecompileOutput, PrecompileResult, bls12_381,
     bls12_381_const::{DISCOUNT_TABLE_G2_MSM, G2_MSM_BASE_GAS_FEE, G2_MSM_INPUT_LENGTH},
@@ -20,12 +20,16 @@ use revm::precompile::{
 const BLS12_MAX_G2_MSM_SIZE_ISTHMUS: usize = 488448;
 
 /// Performs an FPVM-accelerated BLS12-381 G2 msm check.
-pub(crate) fn fpvm_bls12_g2_msm<C: Channel + Send + Sync>(
+pub(crate) fn fpvm_bls12_g2_msm<H, O>(
     input: &[u8],
     gas_limit: u64,
-    hint_writer: &HintWriter<C>,
-    oracle_reader: &OracleReader<C>,
-) -> PrecompileResult {
+    hint_writer: &H,
+    oracle_reader: &O,
+) -> PrecompileResult
+where
+    H: HintWriterClient + Send + Sync,
+    O: PreimageOracleClient + Send + Sync,
+{
     let input_len = input.len();
 
     if input_len > BLS12_MAX_G2_MSM_SIZE_ISTHMUS {

--- a/bin/client/src/fpvm_evm/precompiles/bls12_map_fp.rs
+++ b/bin/client/src/fpvm_evm/precompiles/bls12_map_fp.rs
@@ -8,7 +8,7 @@
 
 use crate::fpvm_evm::precompiles::utils::precompile_run;
 use alloc::string::ToString;
-use kona_preimage::{Channel, HintWriter, OracleReader};
+use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use revm::precompile::{
     PrecompileError, PrecompileOutput, PrecompileResult, bls12_381,
     bls12_381_const::{MAP_FP_TO_G1_BASE_GAS_FEE, PADDED_FP_LENGTH},
@@ -18,12 +18,16 @@ use revm::precompile::{
 ///
 /// Notice, there is no input size limit for this precompile.
 /// See: <https://specs.optimism.io/protocol/isthmus/exec-engine.html#evm-changes>
-pub(crate) fn fpvm_bls12_map_fp<C: Channel + Send + Sync>(
+pub(crate) fn fpvm_bls12_map_fp<H, O>(
     input: &[u8],
     gas_limit: u64,
-    hint_writer: &HintWriter<C>,
-    oracle_reader: &OracleReader<C>,
-) -> PrecompileResult {
+    hint_writer: &H,
+    oracle_reader: &O,
+) -> PrecompileResult
+where
+    H: HintWriterClient + Send + Sync,
+    O: PreimageOracleClient + Send + Sync,
+{
     if MAP_FP_TO_G1_BASE_GAS_FEE > gas_limit {
         return Err(PrecompileError::OutOfGas);
     }

--- a/bin/client/src/fpvm_evm/precompiles/bls12_map_fp2.rs
+++ b/bin/client/src/fpvm_evm/precompiles/bls12_map_fp2.rs
@@ -8,7 +8,7 @@
 
 use crate::fpvm_evm::precompiles::utils::precompile_run;
 use alloc::string::ToString;
-use kona_preimage::{Channel, HintWriter, OracleReader};
+use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use revm::precompile::{
     PrecompileError, PrecompileOutput, PrecompileResult, bls12_381,
     bls12_381_const::{MAP_FP2_TO_G2_BASE_GAS_FEE, PADDED_FP2_LENGTH},
@@ -18,12 +18,16 @@ use revm::precompile::{
 ///
 /// Notice, there is no input size limit for this precompile.
 /// See: <https://specs.optimism.io/protocol/isthmus/exec-engine.html#evm-changes>
-pub(crate) fn fpvm_bls12_map_fp2<C: Channel + Send + Sync>(
+pub(crate) fn fpvm_bls12_map_fp2<H, O>(
     input: &[u8],
     gas_limit: u64,
-    hint_writer: &HintWriter<C>,
-    oracle_reader: &OracleReader<C>,
-) -> PrecompileResult {
+    hint_writer: &H,
+    oracle_reader: &O,
+) -> PrecompileResult
+where
+    H: HintWriterClient + Send + Sync,
+    O: PreimageOracleClient + Send + Sync,
+{
     if MAP_FP2_TO_G2_BASE_GAS_FEE > gas_limit {
         return Err(PrecompileError::OutOfGas);
     }

--- a/bin/client/src/fpvm_evm/precompiles/bls12_pair.rs
+++ b/bin/client/src/fpvm_evm/precompiles/bls12_pair.rs
@@ -8,7 +8,7 @@
 
 use crate::fpvm_evm::precompiles::utils::precompile_run;
 use alloc::string::ToString;
-use kona_preimage::{Channel, HintWriter, OracleReader};
+use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use revm::precompile::{
     PrecompileError, PrecompileOutput, PrecompileResult, bls12_381,
     bls12_381_const::{PAIRING_INPUT_LENGTH, PAIRING_MULTIPLIER_BASE, PAIRING_OFFSET_BASE},
@@ -18,12 +18,16 @@ use revm::precompile::{
 const BLS12_MAX_PAIRING_SIZE_ISTHMUS: usize = 235_008;
 
 /// Performs an FPVM-accelerated BLS12-381 pairing check.
-pub(crate) fn fpvm_bls12_pairing<C: Channel + Send + Sync>(
+pub(crate) fn fpvm_bls12_pairing<H, O>(
     input: &[u8],
     gas_limit: u64,
-    hint_writer: &HintWriter<C>,
-    oracle_reader: &OracleReader<C>,
-) -> PrecompileResult {
+    hint_writer: &H,
+    oracle_reader: &O,
+) -> PrecompileResult
+where
+    H: HintWriterClient + Send + Sync,
+    O: PreimageOracleClient + Send + Sync,
+{
     let input_len = input.len();
 
     if input_len > BLS12_MAX_PAIRING_SIZE_ISTHMUS {

--- a/bin/client/src/fpvm_evm/precompiles/bn128_pair.rs
+++ b/bin/client/src/fpvm_evm/precompiles/bn128_pair.rs
@@ -2,7 +2,7 @@
 
 use crate::fpvm_evm::precompiles::utils::precompile_run;
 use alloc::string::ToString;
-use kona_preimage::{Channel, HintWriter, OracleReader};
+use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use revm::precompile::{
     PrecompileError, PrecompileOutput, PrecompileResult,
     bn128::{
@@ -14,12 +14,16 @@ use revm::precompile::{
 const BN256_MAX_PAIRING_SIZE_GRANITE: usize = 112_687;
 
 /// Runs the FPVM-accelerated `ecpairing` precompile call.
-pub(crate) fn fpvm_bn128_pair<C: Channel + Send + Sync>(
+pub(crate) fn fpvm_bn128_pair<H, O>(
     input: &[u8],
     gas_limit: u64,
-    hint_writer: &HintWriter<C>,
-    oracle_reader: &OracleReader<C>,
-) -> PrecompileResult {
+    hint_writer: &H,
+    oracle_reader: &O,
+) -> PrecompileResult
+where
+    H: HintWriterClient + Send + Sync,
+    O: PreimageOracleClient + Send + Sync,
+{
     let gas_used =
         (input.len() / PAIR_ELEMENT_LEN) as u64 * ISTANBUL_PAIR_PER_POINT + ISTANBUL_PAIR_BASE;
 
@@ -43,12 +47,16 @@ pub(crate) fn fpvm_bn128_pair<C: Channel + Send + Sync>(
 
 /// Runs the FPVM-accelerated `ecpairing` precompile call, with the input size limited by the
 /// Granite hardfork.
-pub(crate) fn fpvm_bn128_pair_granite<C: Channel + Send + Sync>(
+pub(crate) fn fpvm_bn128_pair_granite<H, O>(
     input: &[u8],
     gas_limit: u64,
-    hint_writer: &HintWriter<C>,
-    oracle_reader: &OracleReader<C>,
-) -> PrecompileResult {
+    hint_writer: &H,
+    oracle_reader: &O,
+) -> PrecompileResult
+where
+    H: HintWriterClient + Send + Sync,
+    O: PreimageOracleClient + Send + Sync,
+{
     if input.len() > BN256_MAX_PAIRING_SIZE_GRANITE {
         return Err(PrecompileError::Bn128PairLength);
     }

--- a/bin/client/src/fpvm_evm/precompiles/ecrecover.rs
+++ b/bin/client/src/fpvm_evm/precompiles/ecrecover.rs
@@ -3,19 +3,23 @@
 use crate::fpvm_evm::precompiles::utils::precompile_run;
 use alloc::string::ToString;
 use alloy_primitives::Address;
-use kona_preimage::{Channel, HintWriter, OracleReader};
+use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use revm::precompile::{PrecompileError, PrecompileOutput, PrecompileResult};
 
 /// Address of the `ecrecover` precompile.
 pub(crate) const ECRECOVER_ADDR: Address = revm::precompile::u64_to_address(1);
 
 /// Runs the FPVM-accelerated `ecrecover` precompile call.
-pub(crate) fn fpvm_ec_recover<C: Channel + Send + Sync>(
+pub(crate) fn fpvm_ec_recover<H, O>(
     input: &[u8],
     gas_limit: u64,
-    hint_writer: &HintWriter<C>,
-    oracle_reader: &OracleReader<C>,
-) -> PrecompileResult {
+    hint_writer: &H,
+    oracle_reader: &O,
+) -> PrecompileResult
+where
+    H: HintWriterClient + Send + Sync,
+    O: PreimageOracleClient + Send + Sync,
+{
     const ECRECOVER_BASE: u64 = 3_000;
 
     if ECRECOVER_BASE > gas_limit {

--- a/bin/client/src/fpvm_evm/precompiles/kzg_point_eval.rs
+++ b/bin/client/src/fpvm_evm/precompiles/kzg_point_eval.rs
@@ -3,19 +3,23 @@
 use crate::fpvm_evm::precompiles::utils::precompile_run;
 use alloc::string::ToString;
 use alloy_primitives::Address;
-use kona_preimage::{Channel, HintWriter, OracleReader};
+use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use revm::precompile::{PrecompileError, PrecompileOutput, PrecompileResult};
 
 /// Address of the KZG point evaluation precompile.
 pub(crate) const KZG_POINT_EVAL_ADDR: Address = revm::precompile::u64_to_address(0x0A);
 
 /// Runs the FPVM-accelerated `kzgPointEval` precompile call.
-pub(crate) fn fpvm_kzg_point_eval<C: Channel + Send + Sync>(
+pub(crate) fn fpvm_kzg_point_eval<H, O>(
     input: &[u8],
     gas_limit: u64,
-    hint_writer: &HintWriter<C>,
-    oracle_reader: &OracleReader<C>,
-) -> PrecompileResult {
+    hint_writer: &H,
+    oracle_reader: &O,
+) -> PrecompileResult
+where
+    H: HintWriterClient + Send + Sync,
+    O: PreimageOracleClient + Send + Sync,
+{
     const GAS_COST: u64 = 50_000;
 
     if gas_limit < GAS_COST {

--- a/bin/client/src/fpvm_evm/precompiles/provider.rs
+++ b/bin/client/src/fpvm_evm/precompiles/provider.rs
@@ -5,7 +5,7 @@ use crate::fpvm_evm::precompiles::{
 };
 use alloc::{boxed::Box, string::String, vec, vec::Vec};
 use alloy_primitives::{Address, Bytes};
-use kona_preimage::{Channel, HintWriter, OracleReader};
+use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use op_revm::{
     OpSpecId,
     precompiles::{fjord, granite, isthmus},
@@ -20,27 +20,27 @@ use revm::{
 
 /// The FPVM-accelerated precompiles.
 #[derive(Debug)]
-pub struct OpFpvmPrecompiles<C: Channel> {
+pub struct OpFpvmPrecompiles<H, O> {
     /// The default [`EthPrecompiles`] provider.
     inner: EthPrecompiles,
     /// The accelerated precompiles for the current [`OpSpecId`].
-    accelerated_precompiles: HashMap<Address, AcceleratedPrecompileFn<C>>,
+    accelerated_precompiles: HashMap<Address, AcceleratedPrecompileFn<H, O>>,
     /// The [`OpSpecId`] of the precompiles.
     spec: OpSpecId,
-    /// The inner [`HintWriter`].
-    hint_writer: HintWriter<C>,
-    /// The inner [`OracleReader`].
-    oracle_reader: OracleReader<C>,
+    /// The inner [`HintWriterClient`].
+    hint_writer: H,
+    /// The inner [`PreimageOracleClient`].
+    oracle_reader: O,
 }
 
-impl<C: Channel + Send + Sync> OpFpvmPrecompiles<C> {
+impl<H, O> OpFpvmPrecompiles<H, O>
+where
+    H: HintWriterClient + Clone + Send + Sync + 'static,
+    O: PreimageOracleClient + Clone + Send + Sync + 'static,
+{
     /// Create a new precompile provider with the given [`OpSpecId`].
     #[inline]
-    pub fn new_with_spec(
-        spec: OpSpecId,
-        hint_writer: HintWriter<C>,
-        oracle_reader: OracleReader<C>,
-    ) -> Self {
+    pub fn new_with_spec(spec: OpSpecId, hint_writer: H, oracle_reader: O) -> Self {
         let precompiles = match spec {
             spec @ (OpSpecId::BEDROCK |
             OpSpecId::REGOLITH |
@@ -52,10 +52,14 @@ impl<C: Channel + Send + Sync> OpFpvmPrecompiles<C> {
         };
 
         let accelerated_precompiles = match spec {
-            OpSpecId::BEDROCK | OpSpecId::REGOLITH | OpSpecId::CANYON => accelerated_bedrock::<C>(),
-            OpSpecId::ECOTONE | OpSpecId::FJORD => accelerated_ecotone::<C>(),
-            OpSpecId::GRANITE | OpSpecId::HOLOCENE => accelerated_granite::<C>(),
-            OpSpecId::ISTHMUS | OpSpecId::INTEROP | OpSpecId::OSAKA => accelerated_isthmus::<C>(),
+            OpSpecId::BEDROCK | OpSpecId::REGOLITH | OpSpecId::CANYON => {
+                accelerated_bedrock::<H, O>()
+            }
+            OpSpecId::ECOTONE | OpSpecId::FJORD => accelerated_ecotone::<H, O>(),
+            OpSpecId::GRANITE | OpSpecId::HOLOCENE => accelerated_granite::<H, O>(),
+            OpSpecId::ISTHMUS | OpSpecId::INTEROP | OpSpecId::OSAKA => {
+                accelerated_isthmus::<H, O>()
+            }
         };
 
         Self {
@@ -71,9 +75,10 @@ impl<C: Channel + Send + Sync> OpFpvmPrecompiles<C> {
     }
 }
 
-impl<CTX, C> PrecompileProvider<CTX> for OpFpvmPrecompiles<C>
+impl<CTX, H, O> PrecompileProvider<CTX> for OpFpvmPrecompiles<H, O>
 where
-    C: Channel + Clone + Send + Sync,
+    H: HintWriterClient + Clone + Send + Sync + 'static,
+    O: PreimageOracleClient + Clone + Send + Sync + 'static,
     CTX: ContextTr<Cfg: Cfg<Spec = OpSpecId>>,
 {
     type Output = InterpreterResult;
@@ -146,82 +151,100 @@ where
 }
 
 /// A precompile function that can be accelerated by the FPVM.
-type AcceleratedPrecompileFn<C> =
-    fn(&[u8], u64, &HintWriter<C>, &OracleReader<C>) -> PrecompileResult;
+type AcceleratedPrecompileFn<H, O> = fn(&[u8], u64, &H, &O) -> PrecompileResult;
 
 /// A tuple type for accelerated precompiles with an associated [`Address`].
-struct AcceleratedPrecompile<C> {
+struct AcceleratedPrecompile<H, O> {
     /// The address of the precompile.
     address: Address,
     /// The precompile function.
-    precompile: AcceleratedPrecompileFn<C>,
+    precompile: AcceleratedPrecompileFn<H, O>,
 }
 
-impl<C> AcceleratedPrecompile<C> {
+impl<H, O> AcceleratedPrecompile<H, O> {
     /// Create a new accelerated precompile.
-    fn new(address: Address, precompile: AcceleratedPrecompileFn<C>) -> Self {
+    fn new(address: Address, precompile: AcceleratedPrecompileFn<H, O>) -> Self {
         Self { address, precompile }
     }
 }
 
 /// The accelerated precompiles for the bedrock spec.
-fn accelerated_bedrock<C: Channel + Send + Sync>() -> Vec<AcceleratedPrecompile<C>> {
+fn accelerated_bedrock<H, O>() -> Vec<AcceleratedPrecompile<H, O>>
+where
+    H: HintWriterClient + Send + Sync,
+    O: PreimageOracleClient + Send + Sync,
+{
     vec![
-        AcceleratedPrecompile::new(ECRECOVER_ADDR, super::ecrecover::fpvm_ec_recover::<C>),
-        AcceleratedPrecompile::new(bn128::pair::ADDRESS, super::bn128_pair::fpvm_bn128_pair::<C>),
+        AcceleratedPrecompile::new(ECRECOVER_ADDR, super::ecrecover::fpvm_ec_recover::<H, O>),
+        AcceleratedPrecompile::new(
+            bn128::pair::ADDRESS,
+            super::bn128_pair::fpvm_bn128_pair::<H, O>,
+        ),
     ]
 }
 
 /// The accelerated precompiles for the ecotone spec.
-fn accelerated_ecotone<C: Channel + Send + Sync>() -> Vec<AcceleratedPrecompile<C>> {
-    let mut base = accelerated_bedrock::<C>();
+fn accelerated_ecotone<H, O>() -> Vec<AcceleratedPrecompile<H, O>>
+where
+    H: HintWriterClient + Send + Sync,
+    O: PreimageOracleClient + Send + Sync,
+{
+    let mut base = accelerated_bedrock::<H, O>();
     base.push(AcceleratedPrecompile::new(
         KZG_POINT_EVAL_ADDR,
-        super::kzg_point_eval::fpvm_kzg_point_eval::<C>,
+        super::kzg_point_eval::fpvm_kzg_point_eval::<H, O>,
     ));
     base
 }
 
 /// The accelerated precompiles for the granite spec.
-fn accelerated_granite<C: Channel + Send + Sync>() -> Vec<AcceleratedPrecompile<C>> {
-    let mut base = accelerated_ecotone::<C>();
+fn accelerated_granite<H, O>() -> Vec<AcceleratedPrecompile<H, O>>
+where
+    H: HintWriterClient + Send + Sync,
+    O: PreimageOracleClient + Send + Sync,
+{
+    let mut base = accelerated_ecotone::<H, O>();
     base.push(AcceleratedPrecompile::new(
         bn128::pair::ADDRESS,
-        super::bn128_pair::fpvm_bn128_pair_granite::<C>,
+        super::bn128_pair::fpvm_bn128_pair_granite::<H, O>,
     ));
     base
 }
 
 /// The accelerated precompiles for the isthmus spec.
-fn accelerated_isthmus<C: Channel + Send + Sync>() -> Vec<AcceleratedPrecompile<C>> {
-    let mut base = accelerated_granite::<C>();
+fn accelerated_isthmus<H, O>() -> Vec<AcceleratedPrecompile<H, O>>
+where
+    H: HintWriterClient + Send + Sync,
+    O: PreimageOracleClient + Send + Sync,
+{
+    let mut base = accelerated_granite::<H, O>();
     base.push(AcceleratedPrecompile::new(
         bls12_381_const::G1_ADD_ADDRESS,
-        super::bls12_g1_add::fpvm_bls12_g1_add::<C>,
+        super::bls12_g1_add::fpvm_bls12_g1_add::<H, O>,
     ));
     base.push(AcceleratedPrecompile::new(
         bls12_381_const::G1_MSM_ADDRESS,
-        super::bls12_g1_msm::fpvm_bls12_g1_msm::<C>,
+        super::bls12_g1_msm::fpvm_bls12_g1_msm::<H, O>,
     ));
     base.push(AcceleratedPrecompile::new(
         bls12_381_const::G2_ADD_ADDRESS,
-        super::bls12_g2_add::fpvm_bls12_g2_add::<C>,
+        super::bls12_g2_add::fpvm_bls12_g2_add::<H, O>,
     ));
     base.push(AcceleratedPrecompile::new(
         bls12_381_const::G2_MSM_ADDRESS,
-        super::bls12_g2_msm::fpvm_bls12_g2_msm::<C>,
+        super::bls12_g2_msm::fpvm_bls12_g2_msm::<H, O>,
     ));
     base.push(AcceleratedPrecompile::new(
         bls12_381_const::MAP_FP_TO_G1_ADDRESS,
-        super::bls12_map_fp::fpvm_bls12_map_fp::<C>,
+        super::bls12_map_fp::fpvm_bls12_map_fp::<H, O>,
     ));
     base.push(AcceleratedPrecompile::new(
         bls12_381_const::MAP_FP2_TO_G2_ADDRESS,
-        super::bls12_map_fp2::fpvm_bls12_map_fp2::<C>,
+        super::bls12_map_fp2::fpvm_bls12_map_fp2::<H, O>,
     ));
     base.push(AcceleratedPrecompile::new(
         bls12_381_const::PAIRING_ADDRESS,
-        super::bls12_pair::fpvm_bls12_pairing::<C>,
+        super::bls12_pair::fpvm_bls12_pairing::<H, O>,
     ));
     base
 }

--- a/bin/client/src/fpvm_evm/precompiles/utils.rs
+++ b/bin/client/src/fpvm_evm/precompiles/utils.rs
@@ -30,9 +30,7 @@ macro_rules! precompile_run {
     ($hint_writer:expr, $oracle_reader:expr, $hint_data:expr) => {
         async move {
             use alloc::{string::ToString, vec::Vec};
-            use kona_preimage::{
-                PreimageKey, PreimageKeyType, PreimageOracleClient, errors::PreimageOracleError,
-            };
+            use kona_preimage::{PreimageKey, PreimageKeyType, errors::PreimageOracleError};
             use kona_proof::{HintType, errors::OracleProviderError};
 
             // Write the hint for the precompile run.

--- a/bin/client/src/kona.rs
+++ b/bin/client/src/kona.rs
@@ -8,7 +8,6 @@
 extern crate alloc;
 
 use alloc::string::String;
-use kona_client::fpvm_evm::FpvmOpEvmFactory;
 use kona_preimage::{HintWriter, OracleReader};
 use kona_std_fpvm::{FileChannel, FileDescriptor};
 use kona_std_fpvm_proc::client_entry;
@@ -38,9 +37,5 @@ fn main() -> Result<(), String> {
             .expect("Failed to set tracing subscriber");
     }
 
-    kona_proof::block_on(kona_client::single::run(
-        ORACLE_READER,
-        HINT_WRITER,
-        FpvmOpEvmFactory::new(HINT_WRITER, ORACLE_READER),
-    ))
+    kona_proof::block_on(kona_client::single::run(ORACLE_READER, HINT_WRITER))
 }

--- a/bin/client/src/kona_interop.rs
+++ b/bin/client/src/kona_interop.rs
@@ -8,7 +8,6 @@
 extern crate alloc;
 
 use alloc::string::String;
-use kona_client::fpvm_evm::FpvmOpEvmFactory;
 use kona_preimage::{HintWriter, OracleReader};
 use kona_std_fpvm::{FileChannel, FileDescriptor};
 use kona_std_fpvm_proc::client_entry;
@@ -38,9 +37,5 @@ fn main() -> Result<(), String> {
             .expect("Failed to set tracing subscriber");
     }
 
-    kona_proof::block_on(kona_client::interop::run(
-        ORACLE_READER,
-        HINT_WRITER,
-        FpvmOpEvmFactory::new(HINT_WRITER, ORACLE_READER),
-    ))
+    kona_proof::block_on(kona_client::interop::run(ORACLE_READER, HINT_WRITER))
 }

--- a/bin/host/src/interop/cfg.rs
+++ b/bin/host/src/interop/cfg.rs
@@ -10,7 +10,6 @@ use alloy_primitives::{B256, Bytes};
 use alloy_provider::{Provider, RootProvider};
 use clap::Parser;
 use kona_cli::cli_styles;
-use kona_client::fpvm_evm::FpvmOpEvmFactory;
 use kona_genesis::RollupConfig;
 use kona_preimage::{
     BidirectionalChannel, Channel, HintReader, HintWriter, OracleReader, OracleServer,
@@ -190,9 +189,8 @@ impl InteropHost {
 
         let server_task = self.start_server(hint.host, preimage.host).await?;
         let client_task = task::spawn(kona_client::interop::run(
-            OracleReader::new(preimage.client.clone()),
-            HintWriter::new(hint.client.clone()),
-            FpvmOpEvmFactory::new(HintWriter::new(hint.client), OracleReader::new(preimage.client)),
+            OracleReader::new(preimage.client),
+            HintWriter::new(hint.client),
         ));
 
         let (_, client_result) = tokio::try_join!(server_task, client_task)?;

--- a/bin/host/src/single/cfg.rs
+++ b/bin/host/src/single/cfg.rs
@@ -10,7 +10,6 @@ use alloy_primitives::B256;
 use alloy_provider::RootProvider;
 use clap::Parser;
 use kona_cli::cli_styles;
-use kona_client::fpvm_evm::FpvmOpEvmFactory;
 use kona_genesis::RollupConfig;
 use kona_preimage::{
     BidirectionalChannel, Channel, HintReader, HintWriter, OracleReader, OracleServer,
@@ -202,9 +201,8 @@ impl SingleChainHost {
 
         let server_task = self.start_server(hint.host, preimage.host).await?;
         let client_task = task::spawn(kona_client::single::run(
-            OracleReader::new(preimage.client.clone()),
-            HintWriter::new(hint.client.clone()),
-            FpvmOpEvmFactory::new(HintWriter::new(hint.client), OracleReader::new(preimage.client)),
+            OracleReader::new(preimage.client),
+            HintWriter::new(hint.client),
         ));
 
         let (_, client_result) = tokio::try_join!(server_task, client_task)?;


### PR DESCRIPTION
## Overview

Refactors the `FvpmOpEvmFactory` and accelerated precompiles to accept looser types. Rather than requiring a `HintWriter` and `OracleReader`, the constraints have been lowered to implementations of the `HintWriterClient` and `PreimageOracleClient`.

By default, both the single-chain and interop FPP entrypoints now construct the `FpvmOpEvmFactory` in the background, rather than requiring an `EvmFactory` implementation to be explicitly passed.