### PR TITLE
fix(node/engine): Incorrect Engine Method Use in Insert Task

### DIFF
--- a/crates/node/engine/src/task_queue/tasks/insert/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/insert/task.rs
@@ -128,9 +128,7 @@ impl EngineTaskExt for InsertUnsafeTask {
                 self.client.new_payload_v3(payload, block_root).await
             }
             OpExecutionPayload::V4(payload) => {
-                self.client
-                    .new_payload_v4(payload.payload_inner, block_root)
-                    .await
+                self.client.new_payload_v4(payload.payload_inner, block_root).await
             }
         };
 


### PR DESCRIPTION
### Description

The `InsertUnsafeTask` used the incorrect engine api methods since it was not importing the `OpEngineApi` extension trait.

This PR + a patch with https://github.com/alloy-rs/op-alloy/pull/509 fixes inserting unsafe payloads in the engine api.