### PR TITLE
chore(genesis): Use `abi_decode_validate`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,9 +281,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5189fa9a8797e92396bc4b4454c5f2073a4945f7c2b366af9af60f9536558f7a"
+checksum = "0068ae277f5ee3153a95eaea8ff10e188ed8ccde9b7f9926305415a2c0ab2442"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -373,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b98b99c1dcfbe74d7f0b31433ff215e7d1555e367d90e62db904f3c9d4ff53"
+checksum = "6a12fe11d0b8118e551c29e1a67ccb6d01cc07ef08086df30f07487146de6fa1"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60fcfa26956bcb22f66ab13407115197f26ef23abca5b48d39a1946897382d74"
+checksum = "5d3ef8e0d622453d969ba3cded54cf6800efdc85cb929fe22c5bdf8335666757"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -659,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a9b402f0013f1ff8c24066eeafc2207a8e52810a2b18b77776ce7fead5af41"
+checksum = "f0e84bd0693c69a8fbe3ec0008465e029c6293494df7cb07580bf4a33eff52e1"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -677,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d02d61741337bb6b3f4899c2e3173fe17ffa2810e143d3b28acd953197c8dd79"
+checksum = "f3de663412dadf9b64f4f92f507f78deebcc92339d12cf15f88ded65d41c7935"
 dependencies = [
  "const-hex",
  "dunce",
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b5f5f9f561c29f78ea521ebe2e5ac1633f1b1442dae582f68ecd57c6350042"
+checksum = "251273c5aa1abb590852f795c938730fa641832fc8fa77b5478ed1bf11b6097e"
 dependencies = [
  "serde",
  "winnow",
@@ -703,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02635bce18205ff8149fb752c753b0a91ea3f3c8ee04c58846448be4811a640"
+checksum = "5460a975434ae594fe2b91586253c1beb404353b78f0a55bf124abcd79557b15"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -4837,7 +4837,7 @@ dependencies = [
  "op-alloy-rpc-types-engine",
  "openssl",
  "rand 0.9.1",
- "secp256k1",
+ "secp256k1 0.31.0",
  "serde",
  "serde_json",
  "snap",
@@ -7383,7 +7383,7 @@ dependencies = [
  "p256",
  "revm-primitives",
  "ripemd",
- "secp256k1",
+ "secp256k1 0.30.0",
  "sha2 0.10.8",
 ]
 
@@ -7851,7 +7851,16 @@ checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.8.5",
- "secp256k1-sys",
+ "secp256k1-sys 0.10.1",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3dff2d01c9aa65c3186a45ff846bfea52cbe6de3b6320ed2a358d90dad0d76"
+dependencies = [
+ "secp256k1-sys 0.11.0",
 ]
 
 [[package]]
@@ -7859,6 +7868,15 @@ name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
 ]
@@ -8397,9 +8415,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34c9c96de1f835488c1501092847b522be88c9ac6fb0d4c0fbea92992324c8f4"
+checksum = "3d0f0d4760f4c2a0823063b2c70e97aa2ad185f57be195172ccc0e23c4b787c4"
 dependencies = [
  "paste",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ alloy-eips = { version = "0.15.6", default-features = false }
 alloy-serde = { version = "0.15.6", default-features = false }
 alloy-network = { version = "0.15.6", default-features = false }
 alloy-provider = { version = "0.15.6", default-features = false }
-alloy-sol-types = { version = "1.0.0", default-features = false }
+alloy-sol-types = { version = "1.1.0", default-features = false }
 alloy-consensus = { version = "0.15.6", default-features = false }
 alloy-transport = { version = "0.15.6", default-features = false }
 alloy-rpc-types = { version = "0.15.6", default-features = false }
@@ -220,5 +220,5 @@ rocksdb = { version = "0.23.0", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
 c-kzg = { version = "2.0.0", default-features = false }
 ark-ff = { version = "0.5.0", default-features = false }
-secp256k1 = { version = "0.30.0", default-features = false }
+secp256k1 = { version = "0.31.0", default-features = false }
 ark-bls12-381 = { version = "0.5.0", default-features = false }

--- a/crates/protocol/genesis/src/system/errors.rs
+++ b/crates/protocol/genesis/src/system/errors.rs
@@ -58,27 +58,18 @@ pub enum BatcherUpdateError {
     /// Invalid data length.
     #[error("Invalid config update log: invalid data length: {0}")]
     InvalidDataLen(usize),
-    /// Failed to type check the data pointer argument from the batcher update log.
-    #[error("Failed to decode batcher update log: data pointer type check failed")]
-    PointerTypeCheck,
     /// Failed to decode the data pointer argument from the batcher update log.
     #[error("Failed to decode batcher update log: data pointer")]
     PointerDecodingError,
     /// The data pointer is invalid.
     #[error("Invalid config update log: invalid data pointer: {0}")]
     InvalidDataPointer(u64),
-    /// Failed to type check the data length argument from the batcher update log.
-    #[error("Failed to decode batcher update log: data length type check failed")]
-    LengthTypeCheck,
     /// Failed to decode the data length argument from the batcher update log.
     #[error("Failed to decode batcher update log: data length")]
     LengthDecodingError,
     /// The data length is invalid.
     #[error("Invalid config update log: invalid data length: {0}")]
     InvalidDataLength(u64),
-    /// Failed to type check the batcher address argument from the batcher update log.
-    #[error("Failed to decode batcher update log: batcher address type check failed")]
-    BatcherAddressTypeCheck,
     /// Failed to decode the batcher address argument from the batcher update log.
     #[error("Failed to decode batcher update log: batcher address")]
     BatcherAddressDecodingError,
@@ -91,29 +82,18 @@ pub enum UnsafeBlockSignerUpdateError {
     /// Invalid data length.
     #[error("Invalid config update log: invalid data length: {0}")]
     InvalidDataLen(usize),
-    /// Failed to type check the data pointer argument from the update log.
-    #[error("Failed to decode unsafe block signer update log: data pointer type check failed")]
-    PointerTypeCheck,
     /// Failed to decode the data pointer argument from the update log.
     #[error("Failed to decode unsafe block signer update log: data pointer")]
     PointerDecodingError,
     /// The data pointer is invalid.
     #[error("Invalid config update log: invalid data pointer: {0}")]
     InvalidDataPointer(u64),
-    /// Failed to type check the data length argument from the update log.
-    #[error("Failed to decode unsafe block signer update log: data length type check failed")]
-    LengthTypeCheck,
     /// Failed to decode the data length argument from the update log.
     #[error("Failed to decode unsafe block signer update log: data length")]
     LengthDecodingError,
     /// The data length is invalid.
     #[error("Invalid config update log: invalid data length: {0}")]
     InvalidDataLength(u64),
-    /// Failed to type check the unsafe block signer address argument from the update log.
-    #[error(
-        "Failed to decode unsafe block signer update log: unsafe block signer address type check failed"
-    )]
-    UnsafeBlockSignerAddressTypeCheck,
     /// Failed to decode the unsafe block signer address argument from the update log.
     #[error("Failed to decode unsafe block signer update log: unsafe block signer address")]
     UnsafeBlockSignerAddressDecodingError,
@@ -126,18 +106,12 @@ pub enum GasConfigUpdateError {
     /// Invalid data length.
     #[error("Invalid config update log: invalid data length: {0}")]
     InvalidDataLen(usize),
-    /// Failed to type check the data pointer argument from the gas config update log.
-    #[error("Failed to decode gas config update log: data pointer type check failed")]
-    PointerTypeCheck,
     /// Failed to decode the data pointer argument from the gas config update log.
     #[error("Failed to decode gas config update log: data pointer")]
     PointerDecodingError,
     /// The data pointer is invalid.
     #[error("Invalid config update log: invalid data pointer: {0}")]
     InvalidDataPointer(u64),
-    /// Failed to type check the data length argument from the gas config update log.
-    #[error("Failed to decode gas config update log: data length type check failed")]
-    LengthTypeCheck,
     /// Failed to decode the data length argument from the gas config update log.
     #[error("Failed to decode gas config update log: data length")]
     LengthDecodingError,
@@ -159,18 +133,12 @@ pub enum GasLimitUpdateError {
     /// Invalid data length.
     #[error("Invalid config update log: invalid data length: {0}")]
     InvalidDataLen(usize),
-    /// Failed to type check the data pointer argument from the gas limit update log.
-    #[error("Failed to decode gas limit update log: data pointer type check failed")]
-    PointerTypeCheck,
     /// Failed to decode the data pointer argument from the gas limit update log.
     #[error("Failed to decode gas limit update log: data pointer")]
     PointerDecodingError,
     /// The data pointer is invalid.
     #[error("Invalid config update log: invalid data pointer: {0}")]
     InvalidDataPointer(u64),
-    /// Failed to type check the data length argument from the gas limit update log.
-    #[error("Failed to type check gas limit update log: data length type check failed")]
-    LengthTypeCheck,
     /// Failed to decode the data length argument from the gas limit update log.
     #[error("Failed to decode gas limit update log: data length")]
     LengthDecodingError,
@@ -189,9 +157,6 @@ pub enum EIP1559UpdateError {
     /// Invalid data length.
     #[error("Invalid config update log: invalid data length: {0}")]
     InvalidDataLen(usize),
-    /// Failed to type check the data pointer argument from the eip 1559 update log.
-    #[error("Failed to decode eip1559 parameter update log: data pointer type check failed")]
-    PointerTypeCheck,
     /// Failed to decode the data pointer argument from the eip 1559 update log.
     #[error("Failed to decode eip1559 parameter update log: data pointer")]
     PointerDecodingError,
@@ -199,17 +164,11 @@ pub enum EIP1559UpdateError {
     #[error("Invalid config update log: invalid data pointer: {0}")]
     InvalidDataPointer(u64),
     /// Failed to decode the data length argument from the eip 1559 update log.
-    #[error("Failed to decode eip1559 parameter update log: data length type check failed")]
-    LengthTypeCheck,
-    /// Failed to decode the data length argument from the eip 1559 update log.
     #[error("Failed to decode eip1559 parameter update log: data length")]
     LengthDecodingError,
     /// The data length is invalid.
     #[error("Invalid config update log: invalid data length: {0}")]
     InvalidDataLength(u64),
-    /// Failed to type check the eip1559 params argument from the eip 1559 update log.
-    #[error("Failed to decode eip1559 parameter update log: eip1559 parameters type check failed")]
-    EIP1559TypeCheckError,
     /// Failed to decode the eip1559 params argument from the eip 1559 update log.
     #[error("Failed to decode eip1559 parameter update log: eip1559 parameters")]
     EIP1559DecodingError,
@@ -222,18 +181,12 @@ pub enum OperatorFeeUpdateError {
     /// Invalid data length.
     #[error("Invalid config update log: invalid data length: {0}")]
     InvalidDataLen(usize),
-    /// Failed to type check the data pointer argument from the operator fee update log.
-    #[error("Failed to decode operator fee parameter update log: data pointer type check failed")]
-    PointerTypeCheck,
     /// Failed to decode the data pointer argument from the operator fee update log.
     #[error("Failed to decode operator fee parameter update log: data pointer")]
     PointerDecodingError,
     /// The data pointer is invalid.
     #[error("Invalid config update log: invalid data pointer: {0}")]
     InvalidDataPointer(u64),
-    /// Failed to type check the data length argument from the operator fee update log.
-    #[error("Failed to decode operator fee parameter update log: data length type check failed")]
-    LengthTypeCheck,
     /// Failed to decode the data length argument from the operator fee update log.
     #[error("Failed to decode operator fee parameter update log: data length")]
     LengthDecodingError,


### PR DESCRIPTION
## Overview

`alloy-sol-types` `v1.1.0` re-introduces validation when ABI decoding. This PR reworks the `SystemConfig` event update parsing logic to use that, rather than the hacky external checks that we had to use with `v1.0.0`.