### PR TITLE
fix(node/engine): Don't use Genesis in EngineState

### DIFF
--- a/crates/node/service/src/actors/engine.rs
+++ b/crates/node/service/src/actors/engine.rs
@@ -96,7 +96,7 @@ impl EngineLauncher {
 
     /// Returns an [`EngineStateBuilder`].
     pub fn state_builder(&self) -> EngineStateBuilder {
-        EngineStateBuilder::new(self.client(), self.config.genesis)
+        EngineStateBuilder::new(self.client())
     }
 }
 


### PR DESCRIPTION
### Description

Removes the genesis block info fallback in the `EngineStateBuilder`.

By letting the engine state have default block info for the safe and finalized heads, EL sync is correctly kicked off since the hashes are zeroed.