### PR TITLE
chore(bin/node): Disable DISCV5 logging by default

### DIFF
--- a/bin/node/src/commands/node.rs
+++ b/bin/node/src/commands/node.rs
@@ -66,7 +66,11 @@ pub struct NodeCommand {
 impl NodeCommand {
     /// Initializes the telemetry stack and Prometheus metrics recorder.
     pub fn init_telemetry(&self, args: &GlobalArgs, metrics: &MetricsArgs) -> anyhow::Result<()> {
-        args.init_tracing(None)?;
+        // Filter out discovery warnings since they're very very noisy.
+        let filter = tracing_subscriber::EnvFilter::from_default_env()
+            .add_directive("discv5=error".parse()?);
+
+        args.init_tracing(Some(filter))?;
         metrics.init_metrics()
     }
 


### PR DESCRIPTION
### Description

Small PR to disable `discv5` logging by default. They're _incredibly_ noisy. Can be enabled manually through the env.