### PR TITLE
chore(node/engine): Decrease Temporary Log Level

### DIFF
--- a/crates/node/engine/src/task_queue/tasks/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/task.rs
@@ -43,7 +43,7 @@ impl EngineTaskExt for EngineTask {
         while let Err(e) = self.execute_inner(state).await {
             match e {
                 EngineTaskError::Temporary(e) => {
-                    warn!(target: "engine", "{e}");
+                    trace!(target: "engine", "{e}");
                     continue;
                 }
                 EngineTaskError::Critical(e) => {


### PR DESCRIPTION
### Description

Temporary engine error logs spam the cli when temporarily stuck.

Since it's not a critical error, decrease the log level to `TRACE` since it's quite common.

Further, it's actually expected behaviour to receive a temporary error when the EL hasn't sync'd up to the L2 block for example in the consolidation task.