### PR TITLE
chore(interop): Refactor `MessageGraph` test utilities

### DIFF
--- a/crates/protocol/interop/src/errors.rs
+++ b/crates/protocol/interop/src/errors.rs
@@ -20,32 +20,6 @@ pub enum MessageGraphError<E> {
     /// Dependency set is impossibly empty
     #[error("Dependency set is impossibly empty")]
     EmptyDependencySet,
-    /// Remote message not found
-    #[error("Remote message not found on chain ID {0} with message hash {1}")]
-    RemoteMessageNotFound(u64, B256),
-    /// Invalid message origin
-    #[error("Invalid message origin. Expected {0}, got {1}")]
-    InvalidMessageOrigin(Address, Address),
-    /// Invalid message payload hash
-    #[error("Invalid message hash. Expected {0}, got {1}")]
-    InvalidMessageHash(B256, B256),
-    /// Invalid message timestamp
-    #[error("Invalid message timestamp. Expected {0}, got {1}")]
-    InvalidMessageTimestamp(u64, u64),
-    /// Interop not activated yet
-    #[error(
-        "Interop hardfork has not been activated yet. Activation time: {0}, initiating message time: {1}"
-    )]
-    InteropNotActivated(u64, u64),
-    /// Message is in the future
-    #[error("Message is in the future. Expected timestamp to be <= {0}, got {1}")]
-    MessageInFuture(u64, u64),
-    /// Message has exceeded the expiry window.
-    #[error("Message has exceeded the expiry window. Timestamp: {0}")]
-    MessageExpired(u64),
-    /// Invalid messages were found
-    #[error("Invalid messages found on chains: {0:?}")]
-    InvalidMessages(Vec<u64>),
     /// Missing a [RollupConfig] for a chain ID
     ///
     /// [RollupConfig]: kona_genesis::RollupConfig
@@ -54,6 +28,69 @@ pub enum MessageGraphError<E> {
     /// Interop provider error
     #[error("Interop provider: {0}")]
     InteropProviderError(#[from] E),
+    /// Remote message not found
+    #[error("Remote message not found on chain ID {chain_id} with message hash {message_hash}")]
+    RemoteMessageNotFound {
+        /// The remote chain ID
+        chain_id: u64,
+        /// The message hash
+        message_hash: B256,
+    },
+    /// Invalid message origin
+    #[error("Invalid message origin. Expected {expected}, got {actual}")]
+    InvalidMessageOrigin {
+        /// The expected message origin
+        expected: Address,
+        /// The actual message origin
+        actual: Address,
+    },
+    /// Invalid message payload hash
+    #[error("Invalid message hash. Expected {expected}, got {actual}")]
+    InvalidMessageHash {
+        /// The expected message hash
+        expected: B256,
+        /// The actual message hash
+        actual: B256,
+    },
+    /// Invalid message timestamp
+    #[error("Invalid message timestamp. Expected {expected}, got {actual}")]
+    InvalidMessageTimestamp {
+        /// The expected timestamp
+        expected: u64,
+        /// The actual timestamp
+        actual: u64,
+    },
+    /// Interop not activated yet
+    #[error(
+        "Interop hardfork has not been active for at least one block. Activation time: {activation_time}, initiating message time: {initiating_message_time}"
+    )]
+    InteropNotActivated {
+        /// The timestamp of the interop activation
+        activation_time: u64,
+        /// The timestamp of the initiating message
+        initiating_message_time: u64,
+    },
+    /// Message is in the future
+    #[error("Message is in the future. Expected timestamp to be <= {max}, got {actual}")]
+    MessageInFuture {
+        /// The expected max timestamp
+        max: u64,
+        /// The actual timestamp
+        actual: u64,
+    },
+    /// Message has exceeded the expiry window.
+    #[error(
+        "Message has exceeded the expiry window. Initiating Timestamp: {initiating_timestamp}, Executing Timestamp: {executing_timestamp}"
+    )]
+    MessageExpired {
+        /// The timestamp of the initiating message
+        initiating_timestamp: u64,
+        /// The timestamp of the executing message
+        executing_timestamp: u64,
+    },
+    /// Invalid messages were found
+    #[error("Invalid messages found on chains: {0:?}")]
+    InvalidMessages(Vec<u64>),
 }
 
 /// A [Result] alias for the [MessageGraphError] type.

--- a/crates/protocol/interop/src/test_util.rs
+++ b/crates/protocol/interop/src/test_util.rs
@@ -1,17 +1,18 @@
 //! Test utilities for `kona-interop`.
 
-#![allow(missing_docs, unreachable_pub)]
+#![allow(missing_docs, unreachable_pub, unused)]
 
 use crate::{ExecutingMessage, MessageIdentifier, traits::InteropProvider};
 use alloy_consensus::{Header, Receipt, ReceiptWithBloom, Sealed};
 use alloy_primitives::{Address, B256, Bytes, Log, LogData, U256, map::HashMap};
 use alloy_sol_types::{SolEvent, SolValue};
 use async_trait::async_trait;
+use kona_genesis::RollupConfig;
 use kona_protocol::Predeploys;
 use op_alloy_consensus::OpReceiptEnvelope;
 
 #[derive(Debug, Clone, Default)]
-pub(crate) struct MockInteropProvider {
+pub struct MockInteropProvider {
     pub headers: HashMap<u64, HashMap<u64, Sealed<Header>>>,
     pub receipts: HashMap<u64, HashMap<u64, Vec<OpReceiptEnvelope>>>,
 }
@@ -33,7 +34,6 @@ pub struct InteropProviderError;
 impl InteropProvider for MockInteropProvider {
     type Error = InteropProviderError;
 
-    /// Fetch a [Header] by its number.
     async fn header_by_number(&self, chain_id: u64, number: u64) -> Result<Header, Self::Error> {
         Ok(self
             .headers
@@ -44,7 +44,6 @@ impl InteropProvider for MockInteropProvider {
             .clone())
     }
 
-    /// Fetch all receipts for a given block by number.
     async fn receipts_by_number(
         &self,
         chain_id: u64,
@@ -53,7 +52,6 @@ impl InteropProvider for MockInteropProvider {
         Ok(self.receipts.get(&chain_id).and_then(|receipts| receipts.get(&number)).unwrap().clone())
     }
 
-    /// Fetch all receipts for a given block by hash.
     async fn receipts_by_hash(
         &self,
         chain_id: u64,
@@ -75,28 +73,25 @@ impl InteropProvider for MockInteropProvider {
 
 pub struct SuperchainBuilder {
     chains: HashMap<u64, ChainBuilder>,
-    timestamp: u64,
-}
-
-pub struct ChainBuilder {
-    header: Header,
-    receipts: Vec<OpReceiptEnvelope>,
 }
 
 impl SuperchainBuilder {
-    pub fn new(timestamp: u64) -> Self {
-        Self { chains: HashMap::default(), timestamp }
+    pub fn new() -> Self {
+        Self { chains: HashMap::default() }
     }
 
     pub fn chain(&mut self, chain_id: u64) -> &mut ChainBuilder {
-        self.chains.entry(chain_id).or_insert_with(|| ChainBuilder::new(self.timestamp))
+        self.chains.entry(chain_id).or_default()
     }
 
     /// Builds the scenario into the format needed for testing
-    pub fn build(self) -> (HashMap<u64, Sealed<Header>>, MockInteropProvider) {
+    pub fn build(
+        self,
+    ) -> (HashMap<u64, Sealed<Header>>, HashMap<u64, RollupConfig>, MockInteropProvider) {
         let mut headers_map = HashMap::default();
         let mut receipts_map = HashMap::default();
         let mut sealed_headers = HashMap::default();
+        let mut rollup_cfgs = HashMap::default();
 
         for (chain_id, chain) in self.chains {
             let header = chain.header;
@@ -104,23 +99,49 @@ impl SuperchainBuilder {
             let sealed_header = header.seal(header_hash);
 
             let mut chain_headers = HashMap::default();
-            chain_headers.insert(0, sealed_header.clone());
+            chain_headers.insert(sealed_header.number, sealed_header.clone());
             headers_map.insert(chain_id, chain_headers);
 
             let mut chain_receipts = HashMap::default();
-            chain_receipts.insert(0, chain.receipts);
+            chain_receipts.insert(sealed_header.number, chain.receipts);
             receipts_map.insert(chain_id, chain_receipts);
 
             sealed_headers.insert(chain_id, sealed_header);
+            rollup_cfgs.insert(chain_id, chain.rollup_config);
         }
 
-        (sealed_headers, MockInteropProvider::new(headers_map, receipts_map))
+        (sealed_headers, rollup_cfgs, MockInteropProvider::new(headers_map, receipts_map))
     }
 }
 
+#[derive(Default)]
+pub struct ChainBuilder {
+    pub rollup_config: RollupConfig,
+    pub header: Header,
+    pub receipts: Vec<OpReceiptEnvelope>,
+}
+
 impl ChainBuilder {
-    pub fn new(timestamp: u64) -> Self {
-        Self { header: Header { timestamp, ..Default::default() }, receipts: Vec::new() }
+    pub fn modify_rollup_cfg(&mut self, f: impl FnOnce(&mut RollupConfig)) -> &mut Self {
+        f(&mut self.rollup_config);
+        self
+    }
+
+    pub fn with_block_time(&mut self, block_time: u64) -> &mut Self {
+        self.modify_rollup_cfg(|cfg| cfg.block_time = block_time)
+    }
+
+    pub fn with_interop_activation_time(&mut self, activation: u64) -> &mut Self {
+        self.modify_rollup_cfg(|cfg| cfg.hardforks.interop_time = Some(activation))
+    }
+
+    pub fn modify_header(&mut self, f: impl FnOnce(&mut Header)) -> &mut Self {
+        f(&mut self.header);
+        self
+    }
+
+    pub fn with_timestamp(&mut self, timestamp: u64) -> &mut Self {
+        self.modify_header(|h| h.timestamp = timestamp)
     }
 
     pub fn add_initiating_message(&mut self, message_data: Bytes) -> &mut Self {
@@ -138,42 +159,19 @@ impl ChainBuilder {
         self
     }
 
-    pub fn add_executing_message(
-        &mut self,
-        message_hash: B256,
-        origin_log_index: u64,
-        origin_chain_id: u64,
-        origin_timestamp: u64,
-    ) -> &mut Self {
-        self.add_executing_message_with_origin(
-            message_hash,
-            Address::ZERO,
-            origin_log_index,
-            origin_chain_id,
-            origin_timestamp,
-        )
-    }
-
-    pub fn add_executing_message_with_origin(
-        &mut self,
-        message_hash: B256,
-        origin_address: Address,
-        origin_log_index: u64,
-        origin_chain_id: u64,
-        origin_timestamp: u64,
-    ) -> &mut Self {
+    pub fn add_executing_message(&mut self, builder: ExecutingMessageBuilder) -> &mut Self {
         let receipt = OpReceiptEnvelope::Eip1559(ReceiptWithBloom {
             receipt: Receipt {
                 logs: vec![Log {
                     address: Predeploys::CROSS_L2_INBOX,
                     data: LogData::new(
-                        vec![ExecutingMessage::SIGNATURE_HASH, message_hash],
+                        vec![ExecutingMessage::SIGNATURE_HASH, builder.message_hash],
                         MessageIdentifier {
-                            origin: origin_address,
-                            blockNumber: U256::ZERO,
-                            logIndex: U256::from(origin_log_index),
-                            timestamp: U256::from(origin_timestamp),
-                            chainId: U256::from(origin_chain_id),
+                            origin: builder.origin_address,
+                            blockNumber: U256::from(builder.origin_block_number),
+                            logIndex: U256::from(builder.origin_log_index),
+                            timestamp: U256::from(builder.origin_timestamp),
+                            chainId: U256::from(builder.origin_chain_id),
                         }
                         .abi_encode()
                         .into(),
@@ -185,6 +183,48 @@ impl ChainBuilder {
             ..Default::default()
         });
         self.receipts.push(receipt);
+        self
+    }
+}
+
+#[derive(Default)]
+pub struct ExecutingMessageBuilder {
+    pub message_hash: B256,
+    pub origin_address: Address,
+    pub origin_log_index: u64,
+    pub origin_chain_id: u64,
+    pub origin_block_number: u64,
+    pub origin_timestamp: u64,
+}
+
+impl ExecutingMessageBuilder {
+    pub const fn with_message_hash(mut self, message_hash: B256) -> Self {
+        self.message_hash = message_hash;
+        self
+    }
+
+    pub const fn with_origin_address(mut self, origin_address: Address) -> Self {
+        self.origin_address = origin_address;
+        self
+    }
+
+    pub const fn with_origin_log_index(mut self, origin_log_index: u64) -> Self {
+        self.origin_log_index = origin_log_index;
+        self
+    }
+
+    pub const fn with_origin_chain_id(mut self, origin_chain_id: u64) -> Self {
+        self.origin_chain_id = origin_chain_id;
+        self
+    }
+
+    pub const fn with_origin_block_number(mut self, origin_block_number: u64) -> Self {
+        self.origin_block_number = origin_block_number;
+        self
+    }
+
+    pub const fn with_origin_timestamp(mut self, origin_timestamp: u64) -> Self {
+        self.origin_timestamp = origin_timestamp;
         self
     }
 }


### PR DESCRIPTION
## Overview

Refactors the `MessageGraph` test utilities in `kona-interop` to be a bit more intuitive.

Note: The errors that caused block invalidity are still opaque to the consumer, and a follow up PR (#1644) exposes them in the API such that the consumer can inspect why a block was deemed to be invalid.