### PR TITLE
feat(genesis): Add `is_first_fork_block` helpers to `RollupConfig`

### DIFF
--- a/crates/protocol/genesis/src/rollup.rs
+++ b/crates/protocol/genesis/src/rollup.rs
@@ -195,10 +195,22 @@ impl RollupConfig {
             self.is_canyon_active(timestamp)
     }
 
+    /// Returns true if the timestamp marks the first Regolith block.
+    pub fn is_first_regolith_block(&self, timestamp: u64) -> bool {
+        self.is_regolith_active(timestamp) &&
+            !self.is_regolith_active(timestamp.saturating_sub(self.block_time))
+    }
+
     /// Returns true if Canyon is active at the given timestamp.
     pub fn is_canyon_active(&self, timestamp: u64) -> bool {
         self.hardforks.canyon_time.is_some_and(|t| timestamp >= t) ||
             self.is_delta_active(timestamp)
+    }
+
+    /// Returns true if the timestamp marks the first Canyon block.
+    pub fn is_first_canyon_block(&self, timestamp: u64) -> bool {
+        self.is_canyon_active(timestamp) &&
+            !self.is_canyon_active(timestamp.saturating_sub(self.block_time))
     }
 
     /// Returns true if Delta is active at the given timestamp.
@@ -207,10 +219,22 @@ impl RollupConfig {
             self.is_ecotone_active(timestamp)
     }
 
+    /// Returns true if the timestamp marks the first Delta block.
+    pub fn is_first_delta_block(&self, timestamp: u64) -> bool {
+        self.is_delta_active(timestamp) &&
+            !self.is_delta_active(timestamp.saturating_sub(self.block_time))
+    }
+
     /// Returns true if Ecotone is active at the given timestamp.
     pub fn is_ecotone_active(&self, timestamp: u64) -> bool {
         self.hardforks.ecotone_time.is_some_and(|t| timestamp >= t) ||
             self.is_fjord_active(timestamp)
+    }
+
+    /// Returns true if the timestamp marks the first Ecotone block.
+    pub fn is_first_ecotone_block(&self, timestamp: u64) -> bool {
+        self.is_ecotone_active(timestamp) &&
+            !self.is_ecotone_active(timestamp.saturating_sub(self.block_time))
     }
 
     /// Returns true if Fjord is active at the given timestamp.
@@ -219,10 +243,22 @@ impl RollupConfig {
             self.is_granite_active(timestamp)
     }
 
+    /// Returns true if the timestamp marks the first Fjord block.
+    pub fn is_first_fjord_block(&self, timestamp: u64) -> bool {
+        self.is_fjord_active(timestamp) &&
+            !self.is_fjord_active(timestamp.saturating_sub(self.block_time))
+    }
+
     /// Returns true if Granite is active at the given timestamp.
     pub fn is_granite_active(&self, timestamp: u64) -> bool {
         self.hardforks.granite_time.is_some_and(|t| timestamp >= t) ||
             self.is_holocene_active(timestamp)
+    }
+
+    /// Returns true if the timestamp marks the first Granite block.
+    pub fn is_first_granite_block(&self, timestamp: u64) -> bool {
+        self.is_granite_active(timestamp) &&
+            !self.is_granite_active(timestamp.saturating_sub(self.block_time))
     }
 
     /// Returns true if Holocene is active at the given timestamp.
@@ -231,9 +267,21 @@ impl RollupConfig {
             self.is_isthmus_active(timestamp)
     }
 
+    /// Returns true if the timestamp marks the first Holocene block.
+    pub fn is_first_holocene_block(&self, timestamp: u64) -> bool {
+        self.is_holocene_active(timestamp) &&
+            !self.is_holocene_active(timestamp.saturating_sub(self.block_time))
+    }
+
     /// Returns true if the pectra blob schedule is active at the given timestamp.
     pub fn is_pectra_blob_schedule_active(&self, timestamp: u64) -> bool {
         self.hardforks.pectra_blob_schedule_time.is_some_and(|t| timestamp >= t)
+    }
+
+    /// Returns true if the timestamp marks the first pectra blob schedule block.
+    pub fn is_first_pectra_blob_schedule_block(&self, timestamp: u64) -> bool {
+        self.is_pectra_blob_schedule_active(timestamp) &&
+            !self.is_pectra_blob_schedule_active(timestamp.saturating_sub(self.block_time))
     }
 
     /// Returns true if Isthmus is active at the given timestamp.
@@ -242,9 +290,21 @@ impl RollupConfig {
             self.is_interop_active(timestamp)
     }
 
+    /// Returns true if the timestamp marks the first Isthmus block.
+    pub fn is_first_isthmus_block(&self, timestamp: u64) -> bool {
+        self.is_isthmus_active(timestamp) &&
+            !self.is_isthmus_active(timestamp.saturating_sub(self.block_time))
+    }
+
     /// Returns true if Interop is active at the given timestamp.
     pub fn is_interop_active(&self, timestamp: u64) -> bool {
         self.hardforks.interop_time.is_some_and(|t| timestamp >= t)
+    }
+
+    /// Returns true if the timestamp marks the first Interop block.
+    pub fn is_first_interop_block(&self, timestamp: u64) -> bool {
+        self.is_interop_active(timestamp) &&
+            !self.is_interop_active(timestamp.saturating_sub(self.block_time))
     }
 
     /// Returns true if a DA Challenge proxy Address is provided in the rollup config and the
@@ -556,6 +616,71 @@ mod tests {
         assert!(config.is_isthmus_active(10));
         assert!(config.is_interop_active(10));
         assert!(!config.is_interop_active(9));
+    }
+
+    #[test]
+    fn test_is_first_fork_block() {
+        let cfg = RollupConfig {
+            hardforks: HardForkConfig {
+                regolith_time: Some(10),
+                canyon_time: Some(20),
+                delta_time: Some(30),
+                ecotone_time: Some(40),
+                fjord_time: Some(50),
+                granite_time: Some(60),
+                holocene_time: Some(70),
+                pectra_blob_schedule_time: Some(80),
+                isthmus_time: Some(90),
+                interop_time: Some(100),
+            },
+            block_time: 2,
+            ..Default::default()
+        };
+
+        // Regolith
+        assert!(!cfg.is_first_regolith_block(8));
+        assert!(cfg.is_first_regolith_block(10));
+        assert!(!cfg.is_first_regolith_block(12));
+
+        // Canyon
+        assert!(!cfg.is_first_canyon_block(18));
+        assert!(cfg.is_first_canyon_block(20));
+        assert!(!cfg.is_first_canyon_block(22));
+
+        // Delta
+        assert!(!cfg.is_first_delta_block(28));
+        assert!(cfg.is_first_delta_block(30));
+        assert!(!cfg.is_first_delta_block(32));
+
+        // Ecotone
+        assert!(!cfg.is_first_ecotone_block(38));
+        assert!(cfg.is_first_ecotone_block(40));
+        assert!(!cfg.is_first_ecotone_block(42));
+
+        // Fjord
+        assert!(!cfg.is_first_fjord_block(48));
+        assert!(cfg.is_first_fjord_block(50));
+        assert!(!cfg.is_first_fjord_block(52));
+
+        // Granite
+        assert!(!cfg.is_first_granite_block(58));
+        assert!(cfg.is_first_granite_block(60));
+        assert!(!cfg.is_first_granite_block(62));
+
+        // Holocene
+        assert!(!cfg.is_first_holocene_block(68));
+        assert!(cfg.is_first_holocene_block(70));
+        assert!(!cfg.is_first_holocene_block(72));
+
+        // Pectra blob schedule
+        assert!(!cfg.is_first_pectra_blob_schedule_block(78));
+        assert!(cfg.is_first_pectra_blob_schedule_block(80));
+        assert!(!cfg.is_first_pectra_blob_schedule_block(82));
+
+        // Isthmus
+        assert!(!cfg.is_first_isthmus_block(88));
+        assert!(cfg.is_first_isthmus_block(90));
+        assert!(!cfg.is_first_isthmus_block(92));
     }
 
     #[test]

--- a/crates/protocol/protocol/src/batch/single.rs
+++ b/crates/protocol/protocol/src/batch/single.rs
@@ -158,10 +158,7 @@ impl SingleBatch {
 
         // If this is the first block in the interop hardfork, and the batch contains any
         // transactions, it must be dropped.
-        if !cfg.is_interop_active(self.timestamp - cfg.block_time) &&
-            cfg.is_interop_active(self.timestamp) &&
-            !self.transactions.is_empty()
-        {
+        if cfg.is_first_interop_block(self.timestamp) && !self.transactions.is_empty() {
             warn!(
                 target: "single_batch",
                 "Sequencer included user transactions in interop transition block. Dropping batch."

--- a/crates/protocol/protocol/src/info/variant.rs
+++ b/crates/protocol/protocol/src/info/variant.rs
@@ -47,11 +47,9 @@ impl L1BlockInfoTx {
         // In the first block of Ecotone, the L1Block contract has not been upgraded yet due to the
         // upgrade transactions being placed after the L1 info transaction. Because of this,
         // for the first block of Ecotone, we send a Bedrock style L1 block info transaction
-        let is_first_ecotone_block =
-            rollup_config.hardforks.ecotone_time.unwrap_or_default() == l2_block_time;
-
-        // If ecotone is *not* active or this is the first block of ecotone, use Bedrock block info.
-        if !rollup_config.is_ecotone_active(l2_block_time) || is_first_ecotone_block {
+        if !rollup_config.is_ecotone_active(l2_block_time) ||
+            rollup_config.is_first_ecotone_block(l2_block_time)
+        {
             return Ok(Self::Bedrock(L1BlockInfoBedrock {
                 number: l1_header.number,
                 time: l1_header.timestamp,
@@ -100,7 +98,7 @@ impl L1BlockInfoTx {
             .unwrap_or(BlobParams::cancun());
 
         if rollup_config.is_isthmus_active(l2_block_time) &&
-            rollup_config.hardforks.isthmus_time.unwrap_or_default() != l2_block_time
+            !rollup_config.is_first_isthmus_block(l2_block_time)
         {
             let operator_fee_scalar = system_config.operator_fee_scalar.unwrap_or_default();
             let operator_fee_constant = system_config.operator_fee_constant.unwrap_or_default();


### PR DESCRIPTION
## Overview

Adds a few helper functions to the `RollupConfig` that check if a timestamp corresponds to the activation block of a hardfork.

closes #1603 