### PR TITLE
feat(proof): Derivation over generic L1/L2/DA providers

### DIFF
--- a/bin/client/src/interop/transition.rs
+++ b/bin/client/src/interop/transition.rs
@@ -19,7 +19,7 @@ use kona_proof::{
     executor::KonaExecutor,
     l1::{OracleBlobProvider, OracleL1ChainProvider, OraclePipeline},
     l2::OracleL2ChainProvider,
-    sync::new_pipeline_cursor,
+    sync::new_oracle_pipeline_cursor,
 };
 use kona_proof_interop::{BootInfo, INVALID_TRANSITION_HASH, OptimisticBlock, PreState};
 use op_alloy_consensus::OpTxEnvelope;
@@ -96,9 +96,13 @@ where
     }
 
     // Create a new derivation driver with the given boot information and oracle.
-    let cursor =
-        new_pipeline_cursor(rollup_config.as_ref(), safe_head, &mut l1_provider, &mut l2_provider)
-            .await?;
+    let cursor = new_oracle_pipeline_cursor(
+        rollup_config.as_ref(),
+        safe_head,
+        &mut l1_provider,
+        &mut l2_provider,
+    )
+    .await?;
     l2_provider.set_cursor(cursor.clone());
 
     let da_provider =

--- a/bin/client/src/interop/transition.rs
+++ b/bin/client/src/interop/transition.rs
@@ -7,7 +7,10 @@ use alloy_consensus::Sealed;
 use alloy_evm::{EvmFactory, FromRecoveredTx, FromTxWithEncoded};
 use alloy_primitives::B256;
 use core::fmt::Debug;
-use kona_derive::errors::{PipelineError, PipelineErrorKind};
+use kona_derive::{
+    errors::{PipelineError, PipelineErrorKind},
+    sources::EthereumDataSource,
+};
 use kona_driver::{Driver, DriverError};
 use kona_executor::TrieDBProvider;
 use kona_preimage::{HintWriterClient, PreimageOracleClient};
@@ -98,11 +101,13 @@ where
             .await?;
     l2_provider.set_cursor(cursor.clone());
 
+    let da_provider =
+        EthereumDataSource::new_from_parts(l1_provider.clone(), beacon, &rollup_config);
     let pipeline = OraclePipeline::new(
         rollup_config.clone(),
         cursor.clone(),
         oracle.clone(),
-        beacon,
+        da_provider,
         l1_provider.clone(),
         l2_provider.clone(),
     )

--- a/bin/client/src/single.rs
+++ b/bin/client/src/single.rs
@@ -15,7 +15,7 @@ use kona_proof::{
     executor::KonaExecutor,
     l1::{OracleBlobProvider, OracleL1ChainProvider, OraclePipeline},
     l2::OracleL2ChainProvider,
-    sync::new_pipeline_cursor,
+    sync::new_oracle_pipeline_cursor,
 };
 use thiserror::Error;
 use tracing::{error, info};
@@ -96,9 +96,13 @@ where
     ////////////////////////////////////////////////////////////////
 
     // Create a new derivation driver with the given boot information and oracle.
-    let cursor =
-        new_pipeline_cursor(rollup_config.as_ref(), safe_head, &mut l1_provider, &mut l2_provider)
-            .await?;
+    let cursor = new_oracle_pipeline_cursor(
+        rollup_config.as_ref(),
+        safe_head,
+        &mut l1_provider,
+        &mut l2_provider,
+    )
+    .await?;
     l2_provider.set_cursor(cursor.clone());
 
     let evm_factory = FpvmOpEvmFactory::new(hint_client, oracle_client);

--- a/bin/client/src/single.rs
+++ b/bin/client/src/single.rs
@@ -1,10 +1,11 @@
 //! Single-chain fault proof program entrypoint.
 
+use crate::fpvm_evm::FpvmOpEvmFactory;
 use alloc::sync::Arc;
 use alloy_consensus::Sealed;
 use alloy_primitives::B256;
 use core::fmt::Debug;
-use kona_derive::errors::PipelineErrorKind;
+use kona_derive::{errors::PipelineErrorKind, prelude::EthereumDataSource};
 use kona_driver::{Driver, DriverError};
 use kona_executor::{ExecutorError, TrieDBProvider};
 use kona_preimage::{CommsClient, HintWriterClient, PreimageKey, PreimageOracleClient};
@@ -18,8 +19,6 @@ use kona_proof::{
 };
 use thiserror::Error;
 use tracing::{error, info};
-
-use crate::fpvm_evm::FpvmOpEvmFactory;
 
 /// An error that can occur when running the fault proof program.
 #[derive(Error, Debug)]
@@ -103,11 +102,13 @@ where
     l2_provider.set_cursor(cursor.clone());
 
     let evm_factory = FpvmOpEvmFactory::new(hint_client, oracle_client);
+    let da_provider =
+        EthereumDataSource::new_from_parts(l1_provider.clone(), beacon, &rollup_config);
     let pipeline = OraclePipeline::new(
         rollup_config.clone(),
         cursor.clone(),
         oracle.clone(),
-        beacon,
+        da_provider,
         l1_provider.clone(),
         l2_provider.clone(),
     )

--- a/bin/host/src/interop/handler.rs
+++ b/bin/host/src/interop/handler.rs
@@ -30,7 +30,7 @@ use kona_proof::{
     executor::KonaExecutor,
     l1::{OracleBlobProvider, OracleL1ChainProvider, OraclePipeline, ROOTS_OF_UNITY},
     l2::OracleL2ChainProvider,
-    sync::new_pipeline_cursor,
+    sync::new_oracle_pipeline_cursor,
 };
 use kona_proof_interop::{HintType, PreState};
 use kona_protocol::{BlockInfo, OutputRoot, Predeploys};
@@ -490,7 +490,7 @@ impl HintHandler for InteropHintHandler {
                             .map(|header| Sealed::new_unchecked(header, agreed_block_hash))?;
                         let target_block = safe_head.number + 1;
 
-                        let cursor = new_pipeline_cursor(
+                        let cursor = new_oracle_pipeline_cursor(
                             rollup_config.as_ref(),
                             safe_head,
                             &mut l1_provider,

--- a/bin/host/src/interop/handler.rs
+++ b/bin/host/src/interop/handler.rs
@@ -18,6 +18,7 @@ use alloy_rpc_types::Block;
 use anyhow::{Result, anyhow, ensure};
 use ark_ff::{BigInteger, PrimeField};
 use async_trait::async_trait;
+use kona_derive::prelude::EthereumDataSource;
 use kona_driver::Driver;
 use kona_executor::TrieDBProvider;
 use kona_preimage::{
@@ -498,11 +499,16 @@ impl HintHandler for InteropHintHandler {
                         .await?;
                         l2_provider.set_cursor(cursor.clone());
 
+                        let da_provider = EthereumDataSource::new_from_parts(
+                            l1_provider.clone(),
+                            beacon,
+                            &rollup_config,
+                        );
                         let pipeline = OraclePipeline::new(
                             rollup_config.clone(),
                             cursor.clone(),
                             oracle,
-                            beacon,
+                            da_provider,
                             l1_provider,
                             l2_provider.clone(),
                         )

--- a/crates/proof/proof/src/l1/mod.rs
+++ b/crates/proof/proof/src/l1/mod.rs
@@ -1,9 +1,7 @@
 //! Contains the L1 constructs of the proof, backed by the preimage oracle ABI as a data source.
 
 mod pipeline;
-pub use pipeline::{
-    OracleAttributesBuilder, OracleDataProvider, OracleDerivationPipeline, OraclePipeline,
-};
+pub use pipeline::{OraclePipeline, ProviderAttributesBuilder, ProviderDerivationPipeline};
 
 mod blob_provider;
 pub use blob_provider::{OracleBlobProvider, ROOTS_OF_UNITY};

--- a/crates/proof/proof/src/l1/pipeline.rs
+++ b/crates/proof/proof/src/l1/pipeline.rs
@@ -9,9 +9,9 @@ use kona_derive::{
     errors::PipelineErrorKind,
     pipeline::{DerivationPipeline, PipelineBuilder},
     prelude::AttributesQueueStage,
-    sources::EthereumDataSource,
     traits::{
-        BlobProvider, ChainProvider, L2ChainProvider, OriginProvider, Pipeline, SignalReceiver,
+        ChainProvider, DataAvailabilityProvider, L2ChainProvider, OriginProvider, Pipeline,
+        SignalReceiver,
     },
     types::{PipelineResult, ResetSignal, Signal, StepResult},
 };
@@ -23,46 +23,41 @@ use kona_rpc::OpAttributesWithParent;
 use spin::RwLock;
 
 /// An oracle-backed derivation pipeline.
-pub type OracleDerivationPipeline<L1, L2, B> = DerivationPipeline<
-    AttributesQueueStage<OracleDataProvider<L1, B>, L1, L2, OracleAttributesBuilder<L1, L2>>,
-    L2,
->;
-
-/// An oracle-backed Ethereum data source.
-pub type OracleDataProvider<L1, B> = EthereumDataSource<L1, B>;
+pub type ProviderDerivationPipeline<L1, L2, DA> =
+    DerivationPipeline<AttributesQueueStage<DA, L1, L2, ProviderAttributesBuilder<L1, L2>>, L2>;
 
 /// An oracle-backed payload attributes builder for the `AttributesQueue` stage of the derivation
 /// pipeline.
-pub type OracleAttributesBuilder<L1, L2> = StatefulAttributesBuilder<L1, L2>;
+pub type ProviderAttributesBuilder<L1, L2> = StatefulAttributesBuilder<L1, L2>;
 
 /// An oracle-backed derivation pipeline.
 #[derive(Debug)]
-pub struct OraclePipeline<O, L1, L2, B>
+pub struct OraclePipeline<O, L1, L2, DA>
 where
     O: CommsClient + FlushableCache + Send + Sync + Debug,
     L1: ChainProvider + Send + Sync + Debug + Clone,
     L2: L2ChainProvider + Send + Sync + Debug + Clone,
-    B: BlobProvider + Send + Sync + Debug + Clone,
+    DA: DataAvailabilityProvider + Send + Sync + Debug + Clone,
 {
     /// The internal derivation pipeline.
-    pub pipeline: OracleDerivationPipeline<L1, L2, B>,
+    pub pipeline: ProviderDerivationPipeline<L1, L2, DA>,
     /// The caching oracle.
     pub caching_oracle: Arc<O>,
 }
 
-impl<O, L1, L2, B> OraclePipeline<O, L1, L2, B>
+impl<O, L1, L2, DA> OraclePipeline<O, L1, L2, DA>
 where
     O: CommsClient + FlushableCache + FlushableCache + Send + Sync + Debug,
     L1: ChainProvider + Send + Sync + Debug + Clone,
     L2: L2ChainProvider + Send + Sync + Debug + Clone,
-    B: BlobProvider + Send + Sync + Debug + Clone,
+    DA: DataAvailabilityProvider + Send + Sync + Debug + Clone,
 {
     /// Constructs a new oracle-backed derivation pipeline.
     pub async fn new(
         cfg: Arc<RollupConfig>,
         sync_start: Arc<RwLock<PipelineCursor>>,
         caching_oracle: Arc<O>,
-        blob_provider: B,
+        da_provider: DA,
         chain_provider: L1,
         mut l2_chain_provider: L2,
     ) -> PipelineResult<Self> {
@@ -71,11 +66,10 @@ where
             l2_chain_provider.clone(),
             chain_provider.clone(),
         );
-        let dap = EthereumDataSource::new_from_parts(chain_provider.clone(), blob_provider, &cfg);
 
         let mut pipeline = PipelineBuilder::new()
             .rollup_config(cfg.clone())
-            .dap_source(dap)
+            .dap_source(da_provider)
             .l2_chain_provider(l2_chain_provider.clone())
             .chain_provider(chain_provider)
             .builder(attributes)
@@ -102,13 +96,13 @@ where
     }
 }
 
-impl<O, L1, L2, B> DriverPipeline<OracleDerivationPipeline<L1, L2, B>>
-    for OraclePipeline<O, L1, L2, B>
+impl<O, L1, L2, DA> DriverPipeline<ProviderDerivationPipeline<L1, L2, DA>>
+    for OraclePipeline<O, L1, L2, DA>
 where
     O: CommsClient + FlushableCache + Send + Sync + Debug,
     L1: ChainProvider + Send + Sync + Debug + Clone,
     L2: L2ChainProvider + Send + Sync + Debug + Clone,
-    B: BlobProvider + Send + Sync + Debug + Clone,
+    DA: DataAvailabilityProvider + Send + Sync + Debug + Clone,
 {
     /// Flushes the cache on re-org.
     fn flush(&mut self) {
@@ -117,12 +111,12 @@ where
 }
 
 #[async_trait]
-impl<O, L1, L2, B> SignalReceiver for OraclePipeline<O, L1, L2, B>
+impl<O, L1, L2, DA> SignalReceiver for OraclePipeline<O, L1, L2, DA>
 where
     O: CommsClient + FlushableCache + Send + Sync + Debug,
     L1: ChainProvider + Send + Sync + Debug + Clone,
     L2: L2ChainProvider + Send + Sync + Debug + Clone,
-    B: BlobProvider + Send + Sync + Debug + Clone,
+    DA: DataAvailabilityProvider + Send + Sync + Debug + Clone,
 {
     /// Receives a signal from the driver.
     async fn signal(&mut self, signal: Signal) -> PipelineResult<()> {
@@ -130,12 +124,12 @@ where
     }
 }
 
-impl<O, L1, L2, B> OriginProvider for OraclePipeline<O, L1, L2, B>
+impl<O, L1, L2, DA> OriginProvider for OraclePipeline<O, L1, L2, DA>
 where
     O: CommsClient + FlushableCache + Send + Sync + Debug,
     L1: ChainProvider + Send + Sync + Debug + Clone,
     L2: L2ChainProvider + Send + Sync + Debug + Clone,
-    B: BlobProvider + Send + Sync + Debug + Clone,
+    DA: DataAvailabilityProvider + Send + Sync + Debug + Clone,
 {
     /// Returns the optional L1 [BlockInfo] origin.
     fn origin(&self) -> Option<BlockInfo> {
@@ -143,12 +137,12 @@ where
     }
 }
 
-impl<O, L1, L2, B> Iterator for OraclePipeline<O, L1, L2, B>
+impl<O, L1, L2, DA> Iterator for OraclePipeline<O, L1, L2, DA>
 where
     O: CommsClient + FlushableCache + Send + Sync + Debug,
     L1: ChainProvider + Send + Sync + Debug + Clone,
     L2: L2ChainProvider + Send + Sync + Debug + Clone,
-    B: BlobProvider + Send + Sync + Debug + Clone,
+    DA: DataAvailabilityProvider + Send + Sync + Debug + Clone,
 {
     type Item = OpAttributesWithParent;
 
@@ -158,12 +152,12 @@ where
 }
 
 #[async_trait]
-impl<O, L1, L2, B> Pipeline for OraclePipeline<O, L1, L2, B>
+impl<O, L1, L2, DA> Pipeline for OraclePipeline<O, L1, L2, DA>
 where
     O: CommsClient + FlushableCache + Send + Sync + Debug,
     L1: ChainProvider + Send + Sync + Debug + Clone,
     L2: L2ChainProvider + Send + Sync + Debug + Clone,
-    B: BlobProvider + Send + Sync + Debug + Clone,
+    DA: DataAvailabilityProvider + Send + Sync + Debug + Clone,
 {
     /// Peeks at the next [OpAttributesWithParent] from the pipeline.
     fn peek(&self) -> Option<&OpAttributesWithParent> {

--- a/crates/proof/proof/src/sync.rs
+++ b/crates/proof/proof/src/sync.rs
@@ -1,29 +1,26 @@
 //! Sync Start
 
-use crate::{
-    FlushableCache, errors::OracleProviderError, l1::OracleL1ChainProvider,
-    l2::OracleL2ChainProvider,
-};
 use alloc::sync::Arc;
 use alloy_consensus::{Header, Sealed};
 use alloy_primitives::B256;
 use core::fmt::Debug;
-use kona_derive::traits::ChainProvider;
+use kona_derive::{prelude::L2ChainProvider, traits::ChainProvider};
 use kona_driver::{PipelineCursor, TipCursor};
-use kona_preimage::CommsClient;
 use kona_protocol::BatchValidationProvider;
 use kona_registry::RollupConfig;
 use spin::RwLock;
 
 /// Constructs a [`PipelineCursor`] from the caching oracle, boot info, and providers.
-pub async fn new_pipeline_cursor<O>(
+pub async fn new_pipeline_cursor<L1, L2>(
     rollup_config: &RollupConfig,
     safe_header: Sealed<Header>,
-    chain_provider: &mut OracleL1ChainProvider<O>,
-    l2_chain_provider: &mut OracleL2ChainProvider<O>,
-) -> Result<Arc<RwLock<PipelineCursor>>, OracleProviderError>
+    chain_provider: &mut L1,
+    l2_chain_provider: &mut L2,
+) -> Result<Arc<RwLock<PipelineCursor>>, <L2 as BatchValidationProvider>::Error>
 where
-    O: CommsClient + FlushableCache + FlushableCache + Send + Sync + Debug,
+    L1: ChainProvider + Send + Sync + Debug + Clone,
+    L2: L2ChainProvider + Send + Sync + Debug + Clone,
+    <L2 as BatchValidationProvider>::Error: From<<L1 as ChainProvider>::Error>,
 {
     let safe_head_info = l2_chain_provider.l2_block_info_by_number(safe_header.number).await?;
     let l1_origin = chain_provider.block_info_by_number(safe_head_info.l1_origin.number).await?;

--- a/crates/proof/proof/src/sync.rs
+++ b/crates/proof/proof/src/sync.rs
@@ -1,26 +1,28 @@
 //! Sync Start
 
+use crate::errors::OracleProviderError;
 use alloc::sync::Arc;
 use alloy_consensus::{Header, Sealed};
 use alloy_primitives::B256;
 use core::fmt::Debug;
-use kona_derive::{prelude::L2ChainProvider, traits::ChainProvider};
+use kona_derive::traits::ChainProvider;
 use kona_driver::{PipelineCursor, TipCursor};
 use kona_protocol::BatchValidationProvider;
 use kona_registry::RollupConfig;
 use spin::RwLock;
 
 /// Constructs a [`PipelineCursor`] from the caching oracle, boot info, and providers.
-pub async fn new_pipeline_cursor<L1, L2>(
+pub async fn new_oracle_pipeline_cursor<L1, L2>(
     rollup_config: &RollupConfig,
     safe_header: Sealed<Header>,
     chain_provider: &mut L1,
     l2_chain_provider: &mut L2,
-) -> Result<Arc<RwLock<PipelineCursor>>, <L2 as BatchValidationProvider>::Error>
+) -> Result<Arc<RwLock<PipelineCursor>>, OracleProviderError>
 where
     L1: ChainProvider + Send + Sync + Debug + Clone,
-    L2: L2ChainProvider + Send + Sync + Debug + Clone,
-    <L2 as BatchValidationProvider>::Error: From<<L1 as ChainProvider>::Error>,
+    L2: BatchValidationProvider + Send + Sync + Debug + Clone,
+    OracleProviderError:
+        From<<L1 as ChainProvider>::Error> + From<<L2 as BatchValidationProvider>::Error>,
 {
     let safe_head_info = l2_chain_provider.l2_block_info_by_number(safe_header.number).await?;
     let l1_origin = chain_provider.block_info_by_number(safe_head_info.l1_origin.number).await?;


### PR DESCRIPTION
This PR refactors the derivation pipeline in `kona-proof` to accept generic `ChainProvider`, `L2ChainProvider` and `DataAvailabilityProvider` types. This allows finer-grain customization of the derivation pipeline with less code duplication. 

For example, the following projects would need only plug in their custom providers instead of vendoring in the entire pipeline code just to change the `OracleDerivationPipeline`/`OracleDataProvider` type aliases:
* [Kailua](https://github.com/risc0/kailua/blob/15a2a8f8135eb25d055962ecde78ba3197844c99/crates/common/src/kona/pipeline.rs#L15)
* [Hokulea](https://github.com/Layr-Labs/hokulea/blob/4f8b33af384ef19d630eaf0f24885f11d3ea15d5/crates/proof/src/pipeline.rs#L47)
* [Hana](https://github.com/celestiaorg/hana/blob/50efa651802cdc601934ebb00e4af2865a204da9/crates/oracle/src/pipeline.rs#L32)

Decreasing the amount of vendoring required should also serve to keep these projects up to date with the latest changes in the standard Kona pipeline.