### PR TITLE
chore(docker): Update `asterisc` tag

### DIFF
--- a/.github/workflows/client_host.yaml
+++ b/.github/workflows/client_host.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Build `asterisc`
         if: "!contains(matrix.target, 'native')"
         run: |
-          cd asterisc && git checkout v1.2.0 && make build-rvgo
+          cd asterisc && git checkout v1.3.0 && make build-rvgo
           mv ./rvgo/bin/asterisc /usr/local/bin/
       - name: Set run environment
         run: |

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -31,7 +31,7 @@ variable "ASTERISC_TAG" {
   //
   // You can override this if you'd like to use a different tag to generate the prestate.
   // https://github.com/ethereum-optimism/asterisc/releases
-  default = "v1.2.0"
+  default = "v1.3.0"
 }
 
 variable "CANNON_TAG" {


### PR DESCRIPTION
## Overview

Bumps the `asterisc` tag to [`v1.3.0`](https://github.com/ethereum-optimism/asterisc/releases/tag/v1.3.0).