### PR TITLE
feat(node/service): Superchain Signaling with Runtime Loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4747,6 +4747,7 @@ dependencies = [
  "kona-protocol",
  "kona-providers-alloy",
  "kona-rpc",
+ "kona-sources",
  "libp2p",
  "op-alloy-network",
  "op-alloy-rpc-types-engine",
@@ -7668,7 +7669,7 @@ dependencies = [
  "rustls-webpki 0.103.2",
  "security-framework 3.2.0",
  "security-framework-sys",
- "webpki-root-certs",
+ "webpki-root-certs 0.26.11",
  "windows-sys 0.59.0",
 ]
 
@@ -8669,7 +8670,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tungstenite",
- "webpki-roots",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -9217,18 +9218,36 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "0.26.10"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99403924bc5f23afefc319b8ac67ed0e50669f6e52a413314cccb1fdbc93ba0"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.0",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a83f7e1a9f8712695c03eabe9ed3fbca0feff0152f33f12593e5a6303cb1a4"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.10"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37493cadf42a2a939ed404698ded7fb378bf301b5011f973361779a3a74f8c93"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.0",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/crates/node/engine/src/client.rs
+++ b/crates/node/engine/src/client.rs
@@ -25,7 +25,7 @@ use op_alloy_provider::ext::engine::OpEngineApi;
 use op_alloy_rpc_types::Transaction;
 use op_alloy_rpc_types_engine::{
     OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4, OpExecutionPayloadV4,
-    OpPayloadAttributes,
+    OpPayloadAttributes, ProtocolVersion, SuperchainSignal,
 };
 use std::sync::Arc;
 use thiserror::Error;
@@ -86,6 +86,26 @@ impl EngineClient {
     pub async fn syncing(&self) -> Result<SyncStatus, EngineClientError> {
         let status = <RootProvider<AnyNetwork>>::syncing(&self.engine).await?;
         Ok(status)
+    }
+
+    /// Signals the engine with the given [`SuperchainSignal`].
+    ///
+    /// This is an optional extension to the Engine API.
+    ///
+    /// Signals superchain information to the Engine: V1 signals which protocol version is
+    /// recommended and required.
+    ///
+    /// # Returns
+    ///
+    /// - *ProtocolVersion*: The latest supported OP-Stack protocol version of the execution engine.
+    ///
+    /// See: <https://specs.optimism.io/protocol/exec-engine.html#engine_signalsuperchainv1>
+    pub async fn signal(
+        &self,
+        signal: SuperchainSignal,
+    ) -> Result<ProtocolVersion, EngineClientError> {
+        let version = self.engine.client().request("engine_signalSuperchainV1", (signal,)).await?;
+        Ok(version)
     }
 
     /// Fetches the [`Block<T>`] for the given [`BlockNumberOrTag`].

--- a/crates/node/rpc/src/superchain.rs
+++ b/crates/node/rpc/src/superchain.rs
@@ -45,6 +45,14 @@ pub enum ProtocolVersion {
     V0(ProtocolVersionFormatV0),
 }
 
+impl From<ProtocolVersion> for op_alloy_rpc_types_engine::ProtocolVersion {
+    fn from(value: ProtocolVersion) -> Self {
+        match value {
+            ProtocolVersion::V0(value) => Self::V0(value.into()),
+        }
+    }
+}
+
 /// An error that can occur when encoding or decoding a ProtocolVersion.
 #[derive(Copy, thiserror::Error, Clone, Debug)]
 pub enum ProtocolVersionError {
@@ -201,6 +209,18 @@ pub struct ProtocolVersionFormatV0 {
     pub patch: u32,
     /// Identifies unstable versions that may not satisfy the above
     pub pre_release: u32,
+}
+
+impl From<ProtocolVersionFormatV0> for op_alloy_rpc_types_engine::ProtocolVersionFormatV0 {
+    fn from(value: ProtocolVersionFormatV0) -> Self {
+        Self {
+            build: value.build,
+            major: value.major,
+            minor: value.minor,
+            patch: value.patch,
+            pre_release: value.pre_release,
+        }
+    }
 }
 
 impl core::fmt::Display for ProtocolVersionFormatV0 {

--- a/crates/node/service/Cargo.toml
+++ b/crates/node/service/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 # workspace
 kona-p2p.workspace = true
 kona-engine.workspace = true
+kona-sources.workspace = true
 kona-genesis.workspace = true
 kona-derive.workspace = true
 kona-protocol.workspace = true

--- a/crates/node/service/src/actors/engine.rs
+++ b/crates/node/service/src/actors/engine.rs
@@ -200,7 +200,11 @@ impl NodeActor for EngineActor {
                         };
                         match client.signal(signal).await {
                             Ok(v) => info!(target: "engine", ?v, "[SUPERCHAIN::SIGNAL]"),
-                            Err(e) => error!(target: "engine", ?e, "Failed to send signal"),
+                            Err(e) => {
+                                // Since the `engine_signalSuperchainV1` endpoint is OPTIONAL,
+                                // a warning is logged instead of an error.
+                                warn!(target: "engine", ?e, "Failed to send superchain signal (OPTIONAL)");
+                            }
                         }
                     });
                 }

--- a/crates/node/service/src/actors/engine.rs
+++ b/crates/node/service/src/actors/engine.rs
@@ -8,6 +8,7 @@ use kona_engine::{
 };
 use kona_genesis::RollupConfig;
 use kona_protocol::OpAttributesWithParent;
+use kona_sources::RuntimeConfig;
 use op_alloy_rpc_types_engine::OpNetworkPayloadEnvelope;
 use std::sync::Arc;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
@@ -36,6 +37,8 @@ pub struct EngineActor {
     sync_complete_tx: UnboundedSender<()>,
     /// A flag to indicate whether to broadcast if syncing is complete.
     sync_complete_sent: bool,
+    /// A channel to receive [`RuntimeConfig`] from the runtime actor.
+    runtime_config_rx: UnboundedReceiver<RuntimeConfig>,
     /// A channel to receive [`OpAttributesWithParent`] from the derivation actor.
     attributes_rx: UnboundedReceiver<OpAttributesWithParent>,
     /// A channel to receive [`OpNetworkPayloadEnvelope`] from the network actor.
@@ -53,6 +56,7 @@ impl EngineActor {
         client: EngineClient,
         engine: Engine,
         sync_complete_tx: UnboundedSender<()>,
+        runtime_config_rx: UnboundedReceiver<RuntimeConfig>,
         attributes_rx: UnboundedReceiver<OpAttributesWithParent>,
         unsafe_block_rx: UnboundedReceiver<OpNetworkPayloadEnvelope>,
         cancellation: CancellationToken,
@@ -64,6 +68,7 @@ impl EngineActor {
             sync_complete_tx,
             sync_complete_sent: false,
             engine,
+            runtime_config_rx,
             attributes_rx,
             unsafe_block_rx,
             cancellation,
@@ -180,6 +185,24 @@ impl NodeActor for EngineActor {
                     self.engine.enqueue(task);
                     debug!(target: "engine", "Enqueued unsafe block task.");
                     self.check_sync();
+                }
+                runtime_config = self.runtime_config_rx.recv() => {
+                    let Some(config) = runtime_config else {
+                        error!(target: "engine", "Runtime config receiver closed unexpectedly, exiting node");
+                        continue;
+                    };
+                    let client = Arc::clone(&self.client);
+                    tokio::task::spawn(async move {
+                        debug!(target: "engine", config = ?config, "Received runtime config");
+                        let signal = op_alloy_rpc_types_engine::SuperchainSignal {
+                            recommended: config.recommended_protocol_version.into(),
+                            required: config.required_protocol_version.into(),
+                        };
+                        match client.signal(signal).await {
+                            Ok(v) => info!(target: "engine", ?v, "[SUPERCHAIN::SIGNAL]"),
+                            Err(e) => error!(target: "engine", ?e, "Failed to send signal"),
+                        }
+                    });
                 }
             }
         }

--- a/crates/node/service/src/actors/mod.rs
+++ b/crates/node/service/src/actors/mod.rs
@@ -5,6 +5,9 @@
 mod traits;
 pub use traits::NodeActor;
 
+mod runtime;
+pub use runtime::{RuntimeActor, RuntimeLauncher};
+
 mod engine;
 pub use engine::{EngineActor, EngineError, EngineLauncher};
 

--- a/crates/node/service/src/actors/runtime.rs
+++ b/crates/node/service/src/actors/runtime.rs
@@ -1,0 +1,104 @@
+//! Runtime Loading Actor
+
+use async_trait::async_trait;
+use kona_sources::{RuntimeConfig, RuntimeLoader, RuntimeLoaderError};
+use std::time::Duration;
+use tokio::sync::mpsc::UnboundedSender;
+use tokio_util::sync::CancellationToken;
+
+use crate::NodeActor;
+
+/// The Runtime Actor.
+///
+/// The runtime actor is responsible for loading the runtime config
+/// using the [`RuntimeLoader`].
+#[derive(Debug)]
+pub struct RuntimeActor {
+    /// The [`RuntimeLoader`].
+    loader: RuntimeLoader,
+    /// The interval at which to load the runtime.
+    interval: Duration,
+    /// A channel to send the loaded runtime config to the engine actor.
+    runtime_config_tx: UnboundedSender<RuntimeConfig>,
+    /// The cancellation token, shared between all tasks.
+    cancellation: CancellationToken,
+}
+
+impl RuntimeActor {
+    /// Constructs a new [`RuntimeActor`] from the given [`RuntimeLoader`].
+    pub const fn new(
+        loader: RuntimeLoader,
+        interval: Duration,
+        runtime_config_tx: UnboundedSender<RuntimeConfig>,
+        cancellation: CancellationToken,
+    ) -> Self {
+        Self { loader, interval, runtime_config_tx, cancellation }
+    }
+}
+
+/// The Runtime Launcher is a simple launcher for the [`RuntimeActor`].
+#[derive(Debug, Clone)]
+pub struct RuntimeLauncher {
+    /// The [`RuntimeLoader`].
+    loader: RuntimeLoader,
+    /// The interval at which to load the runtime.
+    interval: Option<Duration>,
+    /// The channel to send the [`RuntimeConfig`] to the engine actor.
+    tx: Option<UnboundedSender<RuntimeConfig>>,
+    /// The cancellation token.
+    cancellation: Option<CancellationToken>,
+}
+
+impl RuntimeLauncher {
+    /// Constructs a new [`RuntimeLoader`] from the given runtime loading interval.
+    pub const fn new(loader: RuntimeLoader, interval: Option<Duration>) -> Self {
+        Self { loader, interval, tx: None, cancellation: None }
+    }
+
+    /// Sets the runtime config tx channel.
+    pub fn with_tx(self, tx: UnboundedSender<RuntimeConfig>) -> Self {
+        Self { tx: Some(tx), ..self }
+    }
+
+    /// Sets the [`CancellationToken`] on the [`RuntimeLauncher`].
+    pub fn with_cancellation(self, cancellation: CancellationToken) -> Self {
+        Self { cancellation: Some(cancellation), ..self }
+    }
+
+    /// Launches the [`RuntimeActor`].
+    pub fn launch(self) -> Option<RuntimeActor> {
+        let cancellation = self.cancellation?;
+        let tx = self.tx?;
+        self.interval.map(|i| RuntimeActor::new(self.loader, i, tx, cancellation))
+    }
+}
+
+#[async_trait]
+impl NodeActor for RuntimeActor {
+    type InboundEvent = ();
+    type Error = RuntimeLoaderError;
+
+    async fn start(mut self) -> Result<(), Self::Error> {
+        let mut interval = tokio::time::interval(self.interval);
+        loop {
+            tokio::select! {
+                _ = self.cancellation.cancelled() => {
+                    warn!(target: "runtime", "RuntimeActor received shutdown signal.");
+                    return Ok(());
+                }
+                _ = interval.tick() => {
+                    let config = self.loader.load_latest().await?;
+                    debug!(target: "runtime", ?config, "Loaded latest runtime config");
+                    if let Err(e) = self.runtime_config_tx.send(config) {
+                        error!(target: "runtime", ?e, "Failed to send runtime config to the engine actor");
+                    }
+                }
+            }
+        }
+    }
+
+    async fn process(&mut self, e: Self::InboundEvent) -> Result<(), Self::Error> {
+        trace!(target: "runtime", ?e, "Runtime Actor received unexpected inbound event. Ignoring.");
+        Ok(())
+    }
+}

--- a/crates/node/service/src/lib.rs
+++ b/crates/node/service/src/lib.rs
@@ -19,7 +19,7 @@ mod actors;
 pub use actors::{
     DerivationActor, DerivationError, EngineActor, EngineError, EngineLauncher,
     InboundDerivationMessage, L1WatcherRpc, L1WatcherRpcError, NetworkActor, NetworkActorError,
-    NodeActor, RpcActor, RpcActorError,
+    NodeActor, RpcActor, RpcActorError, RuntimeActor, RuntimeLauncher,
 };
 
 mod sync_start;

--- a/crates/node/service/src/service/standard/node.rs
+++ b/crates/node/service/src/service/standard/node.rs
@@ -2,7 +2,8 @@
 
 use crate::{
     EngineLauncher, L1WatcherRpc, L2ForkchoiceState, NodeMode, RollupNodeBuilder, RollupNodeError,
-    RollupNodeService, SequencerNodeService, ValidatorNodeService, find_starting_forkchoice,
+    RollupNodeService, RuntimeLauncher, SequencerNodeService, ValidatorNodeService,
+    find_starting_forkchoice,
 };
 use alloy_primitives::Address;
 use alloy_provider::RootProvider;
@@ -48,6 +49,8 @@ pub struct RollupNode {
     pub(crate) p2p_config: Option<Config>,
     /// Whether p2p networking is entirely disabled.
     pub(crate) network_disabled: bool,
+    /// The [`RuntimeLauncher`] for the runtime loading service.
+    pub(crate) runtime_launcher: RuntimeLauncher,
 }
 
 impl RollupNode {
@@ -94,6 +97,10 @@ impl ValidatorNodeService for RollupNode {
             block_signer_tx,
             cancellation,
         )
+    }
+
+    fn runtime(&self) -> RuntimeLauncher {
+        self.runtime_launcher.clone()
     }
 
     fn engine(&self) -> EngineLauncher {


### PR DESCRIPTION
### Description

Wires up runtime loading as a lightweight actor in the `kona-node-service`.

Right now, the `OpEngineApi` doesn't support the `engine_signalSuperchainV1` endpoint.
I've added support in [this PR](https://github.com/alloy-rs/op-alloy/pull/512).
Instead of using this for now, I've added a method to the `EngineClient` to send the
signal to the engine client directly using the inner client `.request(..)`.

The interval at which the runtime config can be fetched follows how the `op-node`
configures runtime loading, through the `--l1.runtime-config-reload-interval` cli flag.

Closes #1307