### PR TITLE
fix(node/engine): Attributes Matching and Sync Status

### DIFF
--- a/crates/node/engine/src/attributes.rs
+++ b/crates/node/engine/src/attributes.rs
@@ -1,6 +1,6 @@
 //! Contains a utility method to check if attributes match a block.
 
-use alloy_eips::eip1559::BaseFeeParams;
+use alloy_eips::{Decodable2718, eip1559::BaseFeeParams};
 use alloy_network::TransactionResponse;
 use alloy_primitives::{Address, B256, Bytes};
 use alloy_rpc_types_eth::{Block, BlockTransactions, Withdrawals};
@@ -127,7 +127,6 @@ impl AttributesMatch {
                 "Checking attributes transaction against block transaction",
             );
             // Let's try to deserialize the attributes transaction
-            use alloy_eips::Decodable2718;
             let Ok(attr_tx) = OpTxEnvelope::decode_2718(&mut &attr_tx_bytes[..]) else {
                 error!(
                     "Impossible to deserialize transaction from attributes. If we have stored these attributes it means the transactions where well formatted. This is a bug"

--- a/crates/node/engine/src/attributes.rs
+++ b/crates/node/engine/src/attributes.rs
@@ -121,9 +121,10 @@ impl AttributesMatch {
         // beforehand.
         for (attr_tx_bytes, block_tx) in attributes_txs.iter().zip(block_txs) {
             debug!(
-                "Checking transaction {} against block transaction {}",
-                attr_tx_bytes,
-                block_tx.tx_hash()
+                target: "engine",
+                ?attr_tx_bytes,
+                block_tx_hash = %block_tx.tx_hash(),
+                "Checking attributes transaction against block transaction",
             );
             // Let's try to deserialize the attributes transaction
             use alloy_eips::Decodable2718;

--- a/crates/node/engine/src/task_queue/tasks/build/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/build/task.rs
@@ -74,6 +74,7 @@ impl BuildTask {
             &self.cfg,
             attributes_envelope.attributes.payload_attributes.timestamp,
         );
+        debug!(target: "engine_builder", ?forkchoice_version, "Forkchoice version");
         let update = match forkchoice_version {
             EngineForkchoiceVersion::V3 => {
                 engine_client

--- a/crates/node/engine/src/task_queue/tasks/insert/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/insert/task.rs
@@ -53,6 +53,7 @@ impl InsertUnsafeTask {
         status: &PayloadStatusEnum,
     ) -> bool {
         if self.sync_config.sync_mode == SyncMode::ExecutionLayer {
+            debug!(target: "engine", ?status, "Checking payload status");
             if matches!(status, PayloadStatusEnum::Valid) {
                 debug!(target: "engine", "Valid new payload status. Finished execution layer sync");
                 state.sync_status = SyncStatus::ExecutionLayerFinished;

--- a/crates/node/engine/src/task_queue/tasks/insert/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/insert/task.rs
@@ -54,6 +54,7 @@ impl InsertUnsafeTask {
     ) -> bool {
         if self.sync_config.sync_mode == SyncMode::ExecutionLayer {
             if matches!(status, PayloadStatusEnum::Valid) {
+                debug!(target: "engine", "Valid new payload status. Finished execution layer sync");
                 state.sync_status = SyncStatus::ExecutionLayerFinished;
             }
             return matches!(status, PayloadStatusEnum::Valid | PayloadStatusEnum::Syncing);
@@ -87,7 +88,8 @@ impl InsertUnsafeTask {
 impl EngineTaskExt for InsertUnsafeTask {
     async fn execute(&self, state: &mut EngineState) -> Result<(), EngineTaskError> {
         // If there is a finalized head block, transition to EL sync.
-        if state.sync_status == SyncStatus::ExecutionLayerStarted {
+        if state.sync_status == SyncStatus::ExecutionLayerWillStart {
+            debug!(target: "engine", "Checking finalized block");
             let finalized_block =
                 self.client.l2_block_info_by_label(BlockNumberOrTag::Finalized).await;
             match finalized_block {


### PR DESCRIPTION
### Description

Adds two small fixes to the `kona-node` for syncing.
1. The attributes transaction matching was incorrectly deserializing transactions using `serde_json` instead of the 2718 encoding.
2. The sync status used when inserting an unsafe payload was incorrect. For reference, see [the op-node](https://github.com/ethereum-optimism/optimism/blob/0c986c9b40b8aedfce663421d7074fb856229cde/op-node/rollup/engine/engine_controller.go#L375).