### PR TITLE
fix(node/engine): Round Robin Task Execution

### DIFF
--- a/crates/node/engine/src/attributes.rs
+++ b/crates/node/engine/src/attributes.rs
@@ -136,7 +136,7 @@ impl AttributesMatch {
             };
 
             if &attr_tx != block_tx.inner.inner.inner() {
-                // Transaction mismatch!
+                debug!(target: "engine", ?attr_tx, ?block_tx, "Transaction mismatch");
                 return AttributesMismatch::TransactionContent(attr_tx.tx_hash(), block_tx.tx_hash())
                     .into()
             }

--- a/crates/node/engine/src/attributes.rs
+++ b/crates/node/engine/src/attributes.rs
@@ -127,7 +127,7 @@ impl AttributesMatch {
                 "Checking attributes transaction against block transaction",
             );
             // Let's try to deserialize the attributes transaction
-            let Ok(attr_tx) = OpTxEnvelope::decode_2718(&mut &attr_tx_bytes[..]) else {
+            let Ok(mut attr_tx) = OpTxEnvelope::decode_2718(&mut &attr_tx_bytes[..]) else {
                 error!(
                     "Impossible to deserialize transaction from attributes. If we have stored these attributes it means the transactions where well formatted. This is a bug"
                 );
@@ -135,7 +135,28 @@ impl AttributesMatch {
                 return AttributesMismatch::MalformedAttributesTransaction.into();
             };
 
-            if &attr_tx != block_tx.inner.inner.inner() {
+            // Unfortunate case where we need to touch the inside of the deposit transaction.
+            //
+            // Since `None` is functionally equivalent to `Some(0)` in revm, we need to make sure
+            // that the attributes produced by the derivation pipeline are consistent with the block
+            // received over the engine api. All we need to do here is set the mint value to be
+            // `Some(0)` in the case where it is `None` and the block is `Some(0)`.
+            //
+            // Notice, we *cannot* set the attributes `mint` to `Some(0)` if it already is `Some` in
+            // case there is truly a mismatch.
+            let block_tx = block_tx.inner.inner.inner();
+            let block_none =
+                if let OpTxEnvelope::Deposit(inner) = &block_tx { inner.mint } else { None };
+            if let OpTxEnvelope::Deposit(inner) = &attr_tx {
+                if block_none == Some(0) {
+                    trace!(target: "engine", "Found `mint` mismatch. Setting attributes `mint` to `Some(0)`");
+                    let mut inner = inner.clone().into_inner();
+                    inner.mint = Some(0);
+                    attr_tx = OpTxEnvelope::Deposit(alloy_primitives::Sealed::new(inner));
+                }
+            }
+
+            if &attr_tx != block_tx {
                 debug!(target: "engine", ?attr_tx, ?block_tx, "Transaction mismatch");
                 return AttributesMismatch::TransactionContent(attr_tx.tx_hash(), block_tx.tx_hash())
                     .into()

--- a/crates/node/engine/src/attributes.rs
+++ b/crates/node/engine/src/attributes.rs
@@ -127,7 +127,7 @@ impl AttributesMatch {
                 "Checking attributes transaction against block transaction",
             );
             // Let's try to deserialize the attributes transaction
-            let Ok(mut attr_tx) = OpTxEnvelope::decode_2718(&mut &attr_tx_bytes[..]) else {
+            let Ok(attr_tx) = OpTxEnvelope::decode_2718(&mut &attr_tx_bytes[..]) else {
                 error!(
                     "Impossible to deserialize transaction from attributes. If we have stored these attributes it means the transactions where well formatted. This is a bug"
                 );

--- a/crates/node/engine/src/attributes.rs
+++ b/crates/node/engine/src/attributes.rs
@@ -127,7 +127,7 @@ impl AttributesMatch {
                 "Checking attributes transaction against block transaction",
             );
             // Let's try to deserialize the attributes transaction
-            let Ok(attr_tx) = OpTxEnvelope::decode_2718(&mut &attr_tx_bytes[..]) else {
+            let Ok(mut attr_tx) = OpTxEnvelope::decode_2718(&mut &attr_tx_bytes[..]) else {
                 error!(
                     "Impossible to deserialize transaction from attributes. If we have stored these attributes it means the transactions where well formatted. This is a bug"
                 );

--- a/crates/node/engine/src/lib.rs
+++ b/crates/node/engine/src/lib.rs
@@ -12,8 +12,8 @@ extern crate tracing;
 mod task_queue;
 pub use task_queue::{
     BuildTask, BuildTaskError, ConsolidateTask, ConsolidateTaskError, Engine, EngineTask,
-    EngineTaskError, EngineTaskExt, ForkchoiceTask, ForkchoiceTaskError, InsertUnsafeTask,
-    InsertUnsafeTaskError,
+    EngineTaskError, EngineTaskExt, EngineTaskType, ForkchoiceTask, ForkchoiceTaskError,
+    InsertUnsafeTask, InsertUnsafeTaskError,
 };
 
 mod attributes;

--- a/crates/node/engine/src/task_queue/core.rs
+++ b/crates/node/engine/src/task_queue/core.rs
@@ -85,6 +85,7 @@ impl Engine {
                     self.tasks.remove(&ty);
                 }
             };
+            self.cursor = self.cursor.next();
         }
     }
 }

--- a/crates/node/engine/src/task_queue/core.rs
+++ b/crates/node/engine/src/task_queue/core.rs
@@ -70,6 +70,7 @@ impl Engine {
                 // No more tasks to_process..
                 continue;
             };
+            self.cursor = self.cursor.next();
             match task.execute(&mut self.state).await {
                 Ok(_) => {}
                 Err(EngineTaskError::Reset(e)) => {
@@ -85,7 +86,6 @@ impl Engine {
                     self.tasks.remove(&ty);
                 }
             };
-            self.cursor = self.cursor.next();
         }
     }
 }

--- a/crates/node/engine/src/task_queue/tasks/consolidate/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/consolidate/task.rs
@@ -77,10 +77,22 @@ impl ConsolidateTask {
         // If this is successful, the forkchoice change synchronizes.
         // Otherwise, the attributes need to be processed.
         if crate::AttributesMatch::check(&self.cfg, &self.attributes, &block).is_match() {
+            debug!(
+                target: "engine",
+                attributes = ?self.attributes,
+                block_hash = %block.header.hash,
+                "Consolidating engine state",
+            );
             return self.execute_forkchoice_task(state).await;
         }
 
         // Otherwise, the attributes need to be processed.
+        debug!(
+            target: "engine",
+            attributes = ?self.attributes,
+            block_hash = %block.header.hash,
+            "No consolidation needed executing build task",
+        );
         self.execute_build_task(state).await
     }
 }

--- a/crates/node/engine/src/task_queue/tasks/mod.rs
+++ b/crates/node/engine/src/task_queue/tasks/mod.rs
@@ -1,7 +1,7 @@
 //! Tasks to update the engine state.
 
 mod task;
-pub use task::{EngineTask, EngineTaskError, EngineTaskExt};
+pub use task::{EngineTask, EngineTaskError, EngineTaskExt, EngineTaskType};
 
 mod forkchoice;
 pub use forkchoice::{ForkchoiceTask, ForkchoiceTaskError};

--- a/crates/node/engine/src/task_queue/tasks/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/task.rs
@@ -7,6 +7,34 @@ use crate::EngineState;
 use async_trait::async_trait;
 use thiserror::Error;
 
+/// The type of engine task.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum EngineTaskType {
+    /// Perform a `engine_forkchoiceUpdated` call with the current [EngineState]'s forkchoice,
+    /// and no payload attributes.
+    ForkchoiceUpdate,
+    /// Inserts an unsafe payload into the execution engine.
+    InsertUnsafe,
+    /// Builds a new block with the given attributes, and inserts it into the execution engine.
+    BuildBlock,
+    /// Performs consolidation on the engine state, reverting to payload attribute processing
+    /// via the [`BuildTask`] if consolidation fails.
+    Consolidate,
+}
+
+impl EngineTaskType {
+    /// Returns the next task type in a round-robin fashion.
+    pub const fn next(&self) -> Self {
+        match self {
+            Self::ForkchoiceUpdate => Self::InsertUnsafe,
+            Self::InsertUnsafe => Self::BuildBlock,
+            Self::BuildBlock => Self::Consolidate,
+            Self::Consolidate => Self::ForkchoiceUpdate,
+        }
+    }
+}
+
 /// Tasks that may be inserted into and executed by the [Engine].
 ///
 /// [Engine]: crate::Engine
@@ -32,6 +60,16 @@ impl EngineTask {
             Self::InsertUnsafe(task) => task.execute(state).await,
             Self::BuildBlock(task) => task.execute(state).await,
             Self::Consolidate(task) => task.execute(state).await,
+        }
+    }
+
+    /// Returns the [`EngineTaskType`] for the [`EngineTask`].
+    pub const fn ty(&self) -> EngineTaskType {
+        match &self {
+            Self::ForkchoiceUpdate(_) => EngineTaskType::ForkchoiceUpdate,
+            Self::InsertUnsafe(_) => EngineTaskType::InsertUnsafe,
+            Self::BuildBlock(_) => EngineTaskType::BuildBlock,
+            Self::Consolidate(_) => EngineTaskType::Consolidate,
         }
     }
 }

--- a/crates/node/service/src/actors/engine.rs
+++ b/crates/node/service/src/actors/engine.rs
@@ -91,7 +91,7 @@ impl EngineActor {
                     return;
                 }
                 // If the sync status is `None`, begin derivation.
-                info!(target: "engine", "Engine finished syncing, starting derivation.");
+                trace!(target: "engine", "Sending signal to start derivation");
                 channel.send(()).ok();
             }
         });
@@ -175,6 +175,7 @@ impl NodeActor for EngineActor {
                         self.cancellation.cancel();
                         return Err(EngineError::ChannelClosed);
                     };
+                    let hash = envelope.payload_hash;
                     let task = InsertUnsafeTask::new(
                         Arc::clone(&self.client),
                         Arc::clone(&self.sync),
@@ -183,7 +184,7 @@ impl NodeActor for EngineActor {
                     );
                     let task = EngineTask::InsertUnsafe(task);
                     self.engine.enqueue(task);
-                    debug!(target: "engine", "Enqueued unsafe block task.");
+                    debug!(target: "engine", ?hash, "Enqueued unsafe block task.");
                     self.check_sync();
                 }
                 Some(config) = self.runtime_config_rx.recv() => {

--- a/crates/protocol/protocol/src/deposits.rs
+++ b/crates/protocol/protocol/src/deposits.rs
@@ -203,7 +203,11 @@ pub(crate) fn unmarshal_deposit_version0(
 
     // 0 mint is represented as nil to skip minting code
     if mint == 0 {
-        tx.mint = None;
+        // Since `None` is functionally equivalent to `Some(0)` in revm, we need to make sure
+        // that the attributes produced by the derivation pipeline are consistent with the block
+        // received over the engine api. Instead of setting `mint` to `None`, we set it to
+        // `Some(0)` to ensure that the produced attributes are consistent.
+        tx.mint = Some(0);
     } else {
         tx.mint = Some(mint);
     }


### PR DESCRIPTION
### Description

Allows tasks to be processed in a round-robin fashion based on their type.

Since consolidation tasks may need to wait for data in the derivation pipeline, we still want the engine to execute unsafe payload tasks in the meantime.

This round-robin type-based policy preserves strict ordering of the different task types, while allowing progress to be made on different tasks.