### PR TITLE
feat(node/engine): transmit the most recent version of the `EngineState` over watch channels to the engine actor

### DIFF
--- a/crates/node/service/src/actors/engine.rs
+++ b/crates/node/service/src/actors/engine.rs
@@ -3,8 +3,8 @@
 use alloy_rpc_types_engine::JwtSecret;
 use async_trait::async_trait;
 use kona_engine::{
-    ConsolidateTask, Engine, EngineClient, EngineStateBuilder, EngineStateBuilderError, EngineTask,
-    InsertUnsafeTask, SyncConfig,
+    ConsolidateTask, Engine, EngineClient, EngineState, EngineStateBuilder,
+    EngineStateBuilderError, EngineTask, InsertUnsafeTask, SyncConfig,
 };
 use kona_genesis::RollupConfig;
 use kona_protocol::OpAttributesWithParent;
@@ -32,6 +32,9 @@ pub struct EngineActor {
     pub client: Arc<EngineClient>,
     /// The [`Engine`].
     pub engine: Engine,
+    /// A channel to receive engine state updates.
+    #[allow(unused)]
+    engine_state_recv: tokio::sync::watch::Receiver<EngineState>,
     /// A channel to send a signal that syncing is complete.
     /// Informs the derivation actor to start.
     sync_complete_tx: UnboundedSender<()>,
@@ -55,6 +58,7 @@ impl EngineActor {
         sync: SyncConfig,
         client: EngineClient,
         engine: Engine,
+        engine_state_recv: tokio::sync::watch::Receiver<EngineState>,
         sync_complete_tx: UnboundedSender<()>,
         runtime_config_rx: UnboundedReceiver<RuntimeConfig>,
         attributes_rx: UnboundedReceiver<OpAttributesWithParent>,
@@ -68,6 +72,7 @@ impl EngineActor {
             sync_complete_tx,
             sync_complete_sent: false,
             engine,
+            engine_state_recv,
             runtime_config_rx,
             attributes_rx,
             unsafe_block_rx,
@@ -114,10 +119,15 @@ pub struct EngineLauncher {
 }
 
 impl EngineLauncher {
-    /// Launches the [`Engine`].
-    pub async fn launch(self) -> Result<Engine, EngineStateBuilderError> {
+    /// Launches the [`Engine`]. Returns the [`Engine`] and a channel to receive engine state
+    /// updates.
+    pub async fn launch(
+        self,
+    ) -> Result<(Engine, tokio::sync::watch::Receiver<EngineState>), EngineStateBuilderError> {
         let state = self.state_builder().build().await?;
-        Ok(Engine::new(state))
+        let (engine_state_send, engine_state_recv) = tokio::sync::watch::channel(state);
+
+        Ok((Engine::new(state, engine_state_send), engine_state_recv))
     }
 
     /// Returns the [`EngineClient`].

--- a/crates/node/service/src/service/validator.rs
+++ b/crates/node/service/src/service/validator.rs
@@ -127,13 +127,12 @@ pub trait ValidatorNodeService {
         let launcher = self.engine();
         let client = launcher.client();
         let sync = launcher.sync.clone();
-        let (engine, engine_state_recv) = launcher.launch().await?;
+        let engine = launcher.launch().await?;
         let engine = EngineActor::new(
             std::sync::Arc::new(self.config().clone()),
             sync,
             client,
             engine,
-            engine_state_recv,
             sync_complete_tx,
             runtime_config_rx,
             derived_payload_rx,

--- a/crates/node/service/src/service/validator.rs
+++ b/crates/node/service/src/service/validator.rs
@@ -127,12 +127,13 @@ pub trait ValidatorNodeService {
         let launcher = self.engine();
         let client = launcher.client();
         let sync = launcher.sync.clone();
-        let engine = launcher.launch().await?;
+        let (engine, engine_state_recv) = launcher.launch().await?;
         let engine = EngineActor::new(
             std::sync::Arc::new(self.config().clone()),
             sync,
             client,
             engine,
+            engine_state_recv,
             sync_complete_tx,
             runtime_config_rx,
             derived_payload_rx,


### PR DESCRIPTION
## Description
This PR transmits the most recent version of the `Engine` state over watch channels to the `EngineActor`. This will allow us to read the state with `RPC` handlers without blocking the `EngineTask` runner.