### PR TITLE
fix(node/service): Mark Engine Ready on Sender

### DIFF
--- a/crates/node/service/src/actors/derivation.rs
+++ b/crates/node/service/src/actors/derivation.rs
@@ -188,6 +188,7 @@ where
                     }
                     info!(target: "derivation", "Engine finished syncing, starting derivation.");
                     self.engine_ready = true;
+                    self.sync_complete_rx.close();
                     // Optimistically process the first message.
                     self.process(InboundDerivationMessage::NewDataAvailable).await?;
                 }


### PR DESCRIPTION
### Description

Previously, the engine ready signal when sync is complete was continuously being sent because there was no way to tell if it had been received.

This PR closes the channel. When the channel is closed by the receiver after it has been marked `engine_ready`, no more engine ready signals are sent.