### PR TITLE
feat(node/service): Flush Channel on Invalid Payloads

### DIFF
--- a/crates/node/engine/src/task_queue/tasks/build/error.rs
+++ b/crates/node/engine/src/task_queue/tasks/build/error.rs
@@ -38,6 +38,11 @@ pub enum BuildTaskError {
     /// A deposit-only payload failed to import.
     #[error("Deposit-only payload failed to import")]
     DepositOnlyPayloadFailed,
+
+    /// The payload is invalid, and the derivation pipeline must
+    /// be flushed post-holocene.
+    #[error("Invalid payload, must flush post-holocene")]
+    HoloceneInvalidFlush,
 }
 
 impl From<BuildTaskError> for EngineTaskError {
@@ -51,6 +56,7 @@ impl From<BuildTaskError> for EngineTaskError {
             BuildTaskError::GetPayloadFailed(_) => Self::Temporary(Box::new(value)),
             BuildTaskError::NewPayloadFailed(_) => Self::Temporary(Box::new(value)),
             BuildTaskError::InvalidForkchoiceState => Self::Reset(Box::new(value)),
+            BuildTaskError::HoloceneInvalidFlush => Self::Flush(Box::new(value)),
             BuildTaskError::FinalizedAheadOfUnsafe(_, _) => Self::Critical(Box::new(value)),
             BuildTaskError::DepositOnlyPayloadFailed => Self::Critical(Box::new(value)),
         }

--- a/crates/node/engine/src/task_queue/tasks/build/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/build/task.rs
@@ -245,7 +245,8 @@ impl BuildTask {
                 } else {
                     warn!(target: "engine_builder", "Payload import failed: {validation_error}");
                     warn!(target: "engine_builder", "Re-attempting payload import with deposits only.");
-                    unimplemented!("HOLOCENE: Re-attempt payload import with deposits only");
+                    // HOLOCENE: Re-attempt payload import with deposits only
+                    Err(BuildTaskError::HoloceneInvalidFlush)
                 }
             }
             s => {

--- a/crates/node/engine/src/task_queue/tasks/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/task.rs
@@ -92,6 +92,10 @@ impl EngineTaskExt for EngineTask {
                     warn!(target: "engine", "Engine requested derivation reset");
                     return Err(EngineTaskError::Reset(e));
                 }
+                EngineTaskError::Flush(e) => {
+                    warn!(target: "engine", "Engine requested derivation flush");
+                    return Err(EngineTaskError::Flush(e));
+                }
             }
         }
 
@@ -118,4 +122,7 @@ pub enum EngineTaskError {
     /// An error that requires a derivation pipeline reset.
     #[error("Derivation pipeline reset required: {0}")]
     Reset(Box<dyn std::error::Error>),
+    /// An error that requires the derivation pipeline to be flushed.
+    #[error("Derivation pipeline flush required: {0}")]
+    Flush(Box<dyn std::error::Error>),
 }

--- a/crates/node/service/src/actors/derivation.rs
+++ b/crates/node/service/src/actors/derivation.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use kona_derive::{
     errors::{PipelineError, PipelineErrorKind, ResetError},
     traits::{Pipeline, SignalReceiver},
-    types::{ActivationSignal, ResetSignal, StepResult},
+    types::{ActivationSignal, ResetSignal, Signal, StepResult},
 };
 use kona_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent};
 use thiserror::Error;
@@ -31,10 +31,29 @@ where
     l2_safe_head: L2BlockInfo,
     /// A receiver that tells derivation to begin.
     sync_complete_rx: UnboundedReceiver<()>,
+    /// A receiver that sends a [`Signal`] to the derivation pipeline.
+    ///
+    /// The derivation actor steps over the derivation pipeline to generate
+    /// [`OpAttributesWithParent`]. These attributes then need to be executed
+    /// via the engine api, which is done by sending them through the
+    /// [`Self::attributes_out`] channel.
+    ///
+    /// When the engine api receives an `INVALID` response for a new block (
+    /// the new [`OpAttributesWithParent`]) during block building, the payload
+    /// is reduced to "deposits-only". When this happens, the channel and
+    /// remaining buffered batches need to be flushed out of the derivation
+    /// pipeline.
+    ///
+    /// This channel allows the engine to send a [`Signal::FlushChannel`]
+    /// message back to the derivation pipeline when an `INVALID` response
+    /// occurs.
+    ///
+    /// Specs: <https://specs.optimism.io/protocol/derivation.html#l1-sync-payload-attributes-processing>
+    derivation_signal_rx: UnboundedReceiver<Signal>,
     /// A flag indicating whether the derivation pipeline is ready to start.
     engine_ready: bool,
     /// The sender for derived [OpAttributesWithParent]s produced by the actor.
-    attributes_out: UnboundedSender<OpAttributesWithParent>,
+    pub attributes_out: UnboundedSender<OpAttributesWithParent>,
     /// The receiver for L1 head update notifications.
     l1_head_updates: UnboundedReceiver<BlockInfo>,
     /// The cancellation token, shared between all tasks.
@@ -50,6 +69,7 @@ where
         pipeline: P,
         l2_safe_head: L2BlockInfo,
         sync_complete_rx: UnboundedReceiver<()>,
+        derivation_signal_rx: UnboundedReceiver<Signal>,
         attributes_out: UnboundedSender<OpAttributesWithParent>,
         l1_head_updates: UnboundedReceiver<BlockInfo>,
         cancellation: CancellationToken,
@@ -58,10 +78,21 @@ where
             pipeline,
             l2_safe_head,
             sync_complete_rx,
+            derivation_signal_rx,
             engine_ready: false,
             attributes_out,
             l1_head_updates,
             cancellation,
+        }
+    }
+
+    /// Handles a [`Signal`] received over the derivation signal receiver channel.
+    async fn signal(&mut self, signal: Signal) {
+        match self.pipeline.signal(signal).await {
+            Ok(_) => info!(target: "derivation", ?signal, "[SIGNAL] Executed Successfully"),
+            Err(e) => {
+                error!(target: "derivation", ?e, ?signal, "Failed to signal derivation pipeline")
+            }
         }
     }
 
@@ -203,6 +234,18 @@ where
 
                     self.process(InboundDerivationMessage::NewDataAvailable).await?;
                 }
+                signal = self.derivation_signal_rx.recv() => {
+                    let Some(signal) = signal else {
+                        error!(
+                            target: "derivation",
+                            ?signal,
+                            "DerivationActor failed to receive signal"
+                        );
+                        return Err(DerivationError::SignalReceiveFailed);
+                    };
+
+                    self.signal(signal).await;
+                }
             }
         }
     }
@@ -251,4 +294,7 @@ pub enum DerivationError {
     /// An error originating from the broadcast sender.
     #[error("Failed to send event to broadcast sender")]
     Sender(#[from] Box<SendError<OpAttributesWithParent>>),
+    /// An error from the signal receiver.
+    #[error("Failed to receive signal")]
+    SignalReceiveFailed,
 }

--- a/crates/node/service/src/actors/engine.rs
+++ b/crates/node/service/src/actors/engine.rs
@@ -2,9 +2,10 @@
 
 use alloy_rpc_types_engine::JwtSecret;
 use async_trait::async_trait;
+use kona_derive::types::Signal;
 use kona_engine::{
     ConsolidateTask, Engine, EngineClient, EngineStateBuilder, EngineStateBuilderError, EngineTask,
-    InsertUnsafeTask, SyncConfig,
+    EngineTaskError, InsertUnsafeTask, SyncConfig,
 };
 use kona_genesis::RollupConfig;
 use kona_protocol::OpAttributesWithParent;
@@ -35,6 +36,9 @@ pub struct EngineActor {
     /// A channel to send a signal that syncing is complete.
     /// Informs the derivation actor to start.
     sync_complete_tx: UnboundedSender<()>,
+    /// A way for the engine actor to signal back to the derivation actor
+    /// if a block building task produced an `INVALID` response.
+    derivation_signal_tx: UnboundedSender<Signal>,
     /// A channel to receive [`RuntimeConfig`] from the runtime actor.
     runtime_config_rx: UnboundedReceiver<RuntimeConfig>,
     /// A channel to receive [`OpAttributesWithParent`] from the derivation actor.
@@ -54,6 +58,7 @@ impl EngineActor {
         client: EngineClient,
         engine: Engine,
         sync_complete_tx: UnboundedSender<()>,
+        derivation_signal_tx: UnboundedSender<Signal>,
         runtime_config_rx: UnboundedReceiver<RuntimeConfig>,
         attributes_rx: UnboundedReceiver<OpAttributesWithParent>,
         unsafe_block_rx: UnboundedReceiver<OpNetworkPayloadEnvelope>,
@@ -64,6 +69,7 @@ impl EngineActor {
             sync: Arc::new(sync),
             client: Arc::new(client),
             sync_complete_tx,
+            derivation_signal_tx,
             engine,
             runtime_config_rx,
             attributes_rx,
@@ -149,9 +155,24 @@ impl NodeActor for EngineActor {
                     return Ok(());
                 }
                 res = self.engine.drain() => {
-                    if let Err(e) = res {
-                        warn!(target: "engine", "Encountered error draining engine api tasks: {:?}", e);
-                    }
+                    match res {
+                        Ok(_) => trace!(target: "engine", "[ENGINE] tasks drained"),
+                        Err(EngineTaskError::Flush(e)) => {
+                            // This error is encountered when the payload is marked INVALID
+                            // by the engine api. Post-holocene, the payload is replaced by
+                            // a "deposits-only" block and re-executed. At the same time,
+                            // the channel and any remaining buffered batches are flushed.
+                            warn!(target: "engine", ?e, "[HOLOCENE] Invalid payload, Flushing derivation pipeline.");
+                            match self.derivation_signal_tx.send(Signal::FlushChannel) {
+                                Ok(_) => debug!(target: "engine", "[SENT] flush signal to derivation actor"),
+                                Err(e) => {
+                                    error!(target: "engine", ?e, "[ENGINE] Failed to send flush signal to the derivation actor.");
+                                    self.cancellation.cancel();
+                                    return Err(EngineError::ChannelClosed);
+                                }
+                            }
+                        }
+                        Err(e) => warn!(target: "engine", ?e, "Error draining engine tasks"),                    }
                 }
                 attributes = self.attributes_rx.recv() => {
                     let Some(attributes) = attributes else {

--- a/crates/node/service/src/service/validator.rs
+++ b/crates/node/service/src/service/validator.rs
@@ -102,6 +102,7 @@ pub trait ValidatorNodeService {
         let (unsafe_block_tx, unsafe_block_rx) = mpsc::unbounded_channel();
         let (sync_complete_tx, sync_complete_rx) = mpsc::unbounded_channel();
         let (runtime_config_tx, runtime_config_rx) = mpsc::unbounded_channel();
+        let (derivation_signal_tx, derivation_signal_rx) = mpsc::unbounded_channel();
 
         let (block_signer_tx, block_signer_rx) = mpsc::unbounded_channel();
         let da_watcher =
@@ -112,6 +113,7 @@ pub trait ValidatorNodeService {
             derivation_pipeline,
             l2_forkchoice_state.safe,
             sync_complete_rx,
+            derivation_signal_rx,
             derived_payload_tx,
             new_head_rx,
             cancellation.clone(),
@@ -134,6 +136,7 @@ pub trait ValidatorNodeService {
             client,
             engine,
             sync_complete_tx,
+            derivation_signal_tx,
             runtime_config_rx,
             derived_payload_rx,
             unsafe_block_rx,


### PR DESCRIPTION
### Description

Wires up the engine actor to send a signal to the derivation actor.

This is necessary when the engine api marks a payload `INVALID`.
Post-Holocene, the payload becomes deposit-only and is re-executed.
At the same time, the derivation pipeline needs to be flushed, so
the channel and remaining buffered batches are cleared.

Makes progress on #1239