### PR TITLE
feat(executor): Public `compute_receipts_root` method

### DIFF
--- a/crates/proof/executor/src/builder/mod.rs
+++ b/crates/proof/executor/src/builder/mod.rs
@@ -4,4 +4,6 @@ mod core;
 pub use core::{BlockBuildingOutcome, StatelessL2Builder};
 
 mod assemble;
+pub use assemble::compute_receipts_root;
+
 mod env;

--- a/crates/proof/executor/src/lib.rs
+++ b/crates/proof/executor/src/lib.rs
@@ -16,7 +16,7 @@ mod db;
 pub use db::{NoopTrieDBProvider, TrieDB, TrieDBProvider};
 
 mod builder;
-pub use builder::{BlockBuildingOutcome, StatelessL2Builder};
+pub use builder::{BlockBuildingOutcome, StatelessL2Builder, compute_receipts_root};
 
 mod errors;
 pub use errors::{ExecutorError, ExecutorResult, TrieDBError, TrieDBResult};


### PR DESCRIPTION
This PR refactors `compute_receipts_root` as its own publicly exposed function outside of the `StatelessL2Builder` implementation to enable unvendored reuse by downstream packages such as [in Kailua](https://github.com/risc0/kailua/blob/15a2a8f8135eb25d055962ecde78ba3197844c99/crates/common/src/client/stitching.rs#L178).