### PR TITLE
fix(node/service): EL Sync Only

### DIFF
--- a/crates/node/engine/src/kinds.rs
+++ b/crates/node/engine/src/kinds.rs
@@ -22,6 +22,10 @@ impl EngineKind {
     pub const KINDS: [Self; 3] = [Self::Geth, Self::Reth, Self::Erigon];
 
     /// Returns whether the engine client kind supports post finalization EL sync.
+    #[deprecated(
+        since = "0.1.0",
+        note = "Node behavior is now equivalent across all engine client types."
+    )]
     pub const fn supports_post_finalization_elsync(self) -> bool {
         match self {
             Self::Geth => false,

--- a/crates/node/engine/src/state/builder.rs
+++ b/crates/node/engine/src/state/builder.rs
@@ -64,7 +64,7 @@ impl EngineStateBuilder {
         Ok(self)
     }
 
-    /// Initilizes the safe head block info if it is not already set.
+    /// Initializes the safe head block info if it is not already set.
     fn init_safe_head(&mut self) -> Result<&mut Self, EngineStateBuilderError> {
         if self.safe_head.is_none() {
             self.safe_head = Some(Default::default());

--- a/crates/node/engine/src/state/builder.rs
+++ b/crates/node/engine/src/state/builder.rs
@@ -64,35 +64,18 @@ impl EngineStateBuilder {
         Ok(self)
     }
 
-    /// Fetches the safe head block info if it is not already set.
-    async fn fetch_safe_head(&mut self) -> Result<&mut Self, EngineStateBuilderError> {
+    /// Initilizes the safe head block info if it is not already set.
+    fn init_safe_head(&mut self) -> Result<&mut Self, EngineStateBuilderError> {
         if self.safe_head.is_none() {
-            self.safe_head = match self.client.l2_block_info_by_label(BlockNumberOrTag::Safe).await
-            {
-                Ok(Some(safe_head)) => Some(safe_head),
-                Ok(None) => {
-                    debug!(target: "engine", "No safe head, using empty block info to kick off EL sync");
-                    Some(Default::default())
-                }
-                Err(e) => return Err(e.into()),
-            };
+            self.safe_head = Some(Default::default());
         }
         Ok(self)
     }
 
-    /// Fetches the finalized head block info if it is not already set.
-    async fn fetch_finalized_head(&mut self) -> Result<&mut Self, EngineStateBuilderError> {
+    /// Initializes the finalized head block info if it is not already set.
+    fn init_finalized_head(&mut self) -> Result<&mut Self, EngineStateBuilderError> {
         if self.finalized_head.is_none() {
-            match self.client.l2_block_info_by_label(BlockNumberOrTag::Finalized).await {
-                Ok(Some(finalized_head)) => {
-                    self.finalized_head = Some(finalized_head);
-                }
-                Ok(None) => {
-                    debug!(target: "engine", "No finalized head, using empty block info to kick off EL sync");
-                    self.finalized_head = Some(Default::default());
-                }
-                Err(e) => return Err(e.into()),
-            }
+            self.finalized_head = Some(Default::default());
         }
         Ok(self)
     }
@@ -109,10 +92,10 @@ impl EngineStateBuilder {
         debug!(target: "engine", "Building engine state");
         builder.fetch_unsafe_head().await?;
         debug!(target: "engine", "Fetched unsafe head: {:?}", builder.unsafe_head);
-        builder.fetch_finalized_head().await?;
-        debug!(target: "engine", "Fetched finalized head: {:?}", builder.finalized_head);
-        builder.fetch_safe_head().await?;
-        debug!(target: "engine", "Fetched safe head: {:?}", builder.safe_head);
+        builder.init_finalized_head()?;
+        debug!(target: "engine", "Initialized finalized head: {:?}", builder.finalized_head);
+        builder.init_safe_head()?;
+        debug!(target: "engine", "Initialized safe head: {:?}", builder.safe_head);
 
         let unsafe_head = builder.unsafe_head.ok_or(EngineStateBuilderError::MissingUnsafeHead)?;
         let finalized_head =

--- a/crates/node/service/src/actors/engine.rs
+++ b/crates/node/service/src/actors/engine.rs
@@ -4,7 +4,7 @@ use alloy_rpc_types_engine::JwtSecret;
 use async_trait::async_trait;
 use kona_engine::{
     ConsolidateTask, Engine, EngineClient, EngineStateBuilder, EngineStateBuilderError, EngineTask,
-    InsertUnsafeTask, SyncConfig,
+    InsertUnsafeTask,
 };
 use kona_genesis::RollupConfig;
 use kona_protocol::OpAttributesWithParent;
@@ -26,8 +26,6 @@ use crate::NodeActor;
 pub struct EngineActor {
     /// The [`RollupConfig`] used to build tasks.
     pub config: Arc<RollupConfig>,
-    /// The [`SyncConfig`] for engine api tasks.
-    pub sync: Arc<SyncConfig>,
     /// An [`EngineClient`] used for creating engine tasks.
     pub client: Arc<EngineClient>,
     /// The [`Engine`].
@@ -50,7 +48,6 @@ impl EngineActor {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: Arc<RollupConfig>,
-        sync: SyncConfig,
         client: EngineClient,
         engine: Engine,
         sync_complete_tx: UnboundedSender<()>,
@@ -61,7 +58,6 @@ impl EngineActor {
     ) -> Self {
         Self {
             config,
-            sync: Arc::new(sync),
             client: Arc::new(client),
             sync_complete_tx,
             engine,
@@ -100,8 +96,6 @@ impl EngineActor {
 pub struct EngineLauncher {
     /// The [`RollupConfig`].
     pub config: Arc<RollupConfig>,
-    /// The [`SyncConfig`] for engine tasks.
-    pub sync: SyncConfig,
     /// The engine rpc url.
     pub engine_url: Url,
     /// The l2 rpc url.
@@ -178,7 +172,6 @@ impl NodeActor for EngineActor {
                     let hash = envelope.payload_hash;
                     let task = InsertUnsafeTask::new(
                         Arc::clone(&self.client),
-                        Arc::clone(&self.sync),
                         Arc::clone(&self.config),
                         envelope,
                     );

--- a/crates/node/service/src/service/standard/builder.rs
+++ b/crates/node/service/src/service/standard/builder.rs
@@ -15,7 +15,6 @@ use std::sync::Arc;
 use tower::ServiceBuilder;
 use url::Url;
 
-use kona_engine::SyncConfig;
 use kona_genesis::RollupConfig;
 use kona_p2p::Config;
 use kona_providers_alloy::OnlineBeaconClient;
@@ -26,8 +25,6 @@ use kona_rpc::RpcConfig;
 pub struct RollupNodeBuilder {
     /// The rollup configuration.
     config: RollupConfig,
-    /// The sync configuration.
-    sync_config: Option<SyncConfig>,
     /// The L1 EL provider RPC URL.
     l1_provider_rpc_url: Option<Url>,
     /// The L1 beacon API URL.
@@ -59,11 +56,6 @@ impl RollupNodeBuilder {
     /// Sets the mode on the [`RollupNodeBuilder`].
     pub fn with_mode(self, mode: NodeMode) -> Self {
         Self { mode, ..self }
-    }
-
-    /// Appends a [`SyncConfig`] to the builder.
-    pub fn with_sync_config(self, sync_config: SyncConfig) -> Self {
-        Self { sync_config: Some(sync_config), ..self }
     }
 
     /// Appends an L1 EL provider RPC URL to the builder.
@@ -146,7 +138,6 @@ impl RollupNodeBuilder {
         let config = Arc::new(self.config);
         let engine_launcher = EngineLauncher {
             config: Arc::clone(&config),
-            sync: self.sync_config.expect("missing sync config"),
             l2_rpc_url,
             engine_url: self.l2_engine_rpc_url.expect("missing l2 engine rpc url"),
             jwt_secret,

--- a/crates/node/service/src/service/validator.rs
+++ b/crates/node/service/src/service/validator.rs
@@ -126,11 +126,9 @@ pub trait ValidatorNodeService {
 
         let launcher = self.engine();
         let client = launcher.client();
-        let sync = launcher.sync.clone();
         let engine = launcher.launch().await?;
         let engine = EngineActor::new(
             std::sync::Arc::new(self.config().clone()),
-            sync,
             client,
             engine,
             sync_complete_tx,


### PR DESCRIPTION
### Description

Makes `kona-node` slightly more opinionated by only supporting EL sync.

Previously, the node broke since it couldn't kick off EL sync post-finalization.
Since the finalized and safe heads were populated using the execution engine, a
forkchoice state that kicks off EL sync (zero hash in finalized) wasn't constructed.

This PR removes the unused CL sync, deprecating the `--l2.enginekind` flag, and
moves the `kona-node` over to only support EL sync by initializing finalized
and safe heads to zero on startup, like the `op-node` does. This allows the first
unsafe insert task to kick off el sync.