### PR TITLE
feat(node/l1_watcher): adds query handler for the l1 watcher

### DIFF
--- a/crates/node/rpc/src/l1_watcher.rs
+++ b/crates/node/rpc/src/l1_watcher.rs
@@ -1,0 +1,43 @@
+use kona_genesis::RollupConfig;
+use kona_protocol::BlockInfo;
+use tokio::sync::oneshot::Sender;
+
+/// The L1 watcher state accessible from RPC queries.
+#[derive(Debug, Clone)]
+pub struct L1State {
+    /// The current L1 block.
+    ///
+    /// This is the L1 block that the derivation process is last idled at.
+    /// This may not be fully derived into L2 data yet.
+    /// The safe L2 blocks were produced/included fully from the L1 chain up to _but excluding_
+    /// this L1 block. If the node is synced, this matches the `head_l1`, minus the verifier
+    /// confirmation distance.
+    pub current_l1: Option<BlockInfo>,
+    /// The current L1 finalized block.
+    ///
+    /// This is a legacy sync-status attribute. This is deprecated.
+    /// A previous version of the L1 finalization-signal was updated only after the block was
+    /// retrieved by number. This attribute just matches `finalized_l1` now.
+    pub current_l1_finalized: Option<BlockInfo>,
+    /// The L1 head block ref.
+    ///
+    /// The head is not guaranteed to build on the other L1 sync status fields,
+    /// as the node may be in progress of resetting to adapt to a L1 reorg.
+    pub head_l1: Option<BlockInfo>,
+    /// The L1 safe head block ref.
+    pub safe_l1: Option<BlockInfo>,
+    /// The finalized L1 block ref.
+    pub finalized_l1: Option<BlockInfo>,
+}
+
+/// A sender for L1 watcher queries.
+pub type L1WatcherQuerySender = tokio::sync::mpsc::Sender<L1WatcherQueries>;
+
+/// The inbound queries to the L1 watcher.
+#[derive(Debug)]
+pub enum L1WatcherQueries {
+    /// Get the rollup config from the L1 watcher.
+    Config(Sender<RollupConfig>),
+    /// Get a complete view of the L1 state.
+    L1State(Sender<L1State>),
+}

--- a/crates/node/rpc/src/lib.rs
+++ b/crates/node/rpc/src/lib.rs
@@ -50,3 +50,6 @@ pub use interop::{CheckAccessList, InteropTxValidator, InteropTxValidatorError};
 
 mod rollup;
 pub use rollup::RollupRpc;
+
+mod l1_watcher;
+pub use l1_watcher::{L1State, L1WatcherQueries, L1WatcherQuerySender};

--- a/crates/node/rpc/src/rollup.rs
+++ b/crates/node/rpc/src/rollup.rs
@@ -12,7 +12,9 @@ use kona_engine::EngineQuerySender;
 use kona_genesis::RollupConfig;
 use kona_protocol::SyncStatus;
 
-use crate::{OutputResponse, RollupNodeApiServer, SafeHeadResponse};
+use crate::{
+    OutputResponse, RollupNodeApiServer, SafeHeadResponse, l1_watcher::L1WatcherQuerySender,
+};
 
 /// RollupRpc
 ///
@@ -21,14 +23,16 @@ use crate::{OutputResponse, RollupNodeApiServer, SafeHeadResponse};
 pub struct RollupRpc {
     /// The channel to send [`kona_engine::EngineStateQuery`]s.
     pub engine_sender: EngineQuerySender,
+    /// The channel to send [`crate::L1WatcherQueries`]s.
+    pub l1_watcher_sender: L1WatcherQuerySender,
     // TODO(@theochap): Add channels to send requests to the derivation actor and the
     // l1 watcher.
 }
 
 impl RollupRpc {
     /// Constructs a new [`RollupRpc`] given a sender channel.
-    pub const fn new(sender: EngineQuerySender) -> Self {
-        Self { engine_sender: sender }
+    pub const fn new(sender: EngineQuerySender, l1_watcher_sender: L1WatcherQuerySender) -> Self {
+        Self { engine_sender: sender, l1_watcher_sender }
     }
 }
 

--- a/crates/node/service/src/actors/l1_watcher_rpc.rs
+++ b/crates/node/service/src/actors/l1_watcher_rpc.rs
@@ -1,6 +1,7 @@
 //! [NodeActor] implementation for an L1 chain watcher that checks for L1 head updates over RPC.
 
 use crate::NodeActor;
+use alloy_eips::BlockId;
 use alloy_primitives::{Address, B256};
 use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_types_eth::Log;
@@ -8,11 +9,13 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use kona_genesis::{RollupConfig, SystemConfigLog, SystemConfigUpdate, UnsafeBlockSignerUpdate};
 use kona_protocol::BlockInfo;
+use kona_rpc::{L1State, L1WatcherQueries};
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::{
     select,
     sync::mpsc::{UnboundedSender, error::SendError},
+    task::JoinHandle,
 };
 use tokio_util::sync::CancellationToken;
 
@@ -25,24 +28,40 @@ pub struct L1WatcherRpc {
     config: Arc<RollupConfig>,
     /// The L1 provider.
     l1_provider: RootProvider,
+    /// The latest L1 head sent to the derivation pipeline and watcher. Can be subscribed to, in
+    /// order to get the state from the external watcher.
+    latest_head: tokio::sync::watch::Sender<Option<BlockInfo>>,
     /// The outbound event sender.
     head_sender: UnboundedSender<BlockInfo>,
     /// The block signer sender.
     block_signer_sender: UnboundedSender<Address>,
     /// The cancellation token, shared between all tasks.
     cancellation: CancellationToken,
+    /// Inbound queries to the L1 watcher.
+    inbound_queries: Option<tokio::sync::mpsc::Receiver<L1WatcherQueries>>,
 }
 
 impl L1WatcherRpc {
     /// Creates a new [`L1WatcherRpc`] instance.
-    pub const fn new(
+    pub fn new(
         config: Arc<RollupConfig>,
         l1_provider: RootProvider,
         head_sender: UnboundedSender<BlockInfo>,
         block_signer_sender: UnboundedSender<Address>,
         cancellation: CancellationToken,
+        // Can be None if we disable communication with the L1 watcher.
+        inbound_queries: Option<tokio::sync::mpsc::Receiver<L1WatcherQueries>>,
     ) -> Self {
-        Self { config, l1_provider, head_sender, block_signer_sender, cancellation }
+        let (head_updates, _) = tokio::sync::watch::channel(None);
+        Self {
+            config,
+            l1_provider,
+            head_sender,
+            latest_head: head_updates,
+            block_signer_sender,
+            cancellation,
+            inbound_queries,
+        }
     }
 
     /// Fetches logs for the given block hash.
@@ -83,6 +102,66 @@ impl L1WatcherRpc {
 
         Ok(head_block_info)
     }
+
+    /// Spins up a task to process inbound queries.
+    fn start_query_processor(
+        &self,
+        mut inbound_queries: tokio::sync::mpsc::Receiver<L1WatcherQueries>,
+    ) -> JoinHandle<()> {
+        // Start the inbound query processor in a separate task to avoid blocking the main task.
+        // We can cheaply clone the l1 provider here because it is an Arc.
+        let l1_provider = self.l1_provider.clone();
+        let head_updates_recv = self.latest_head.subscribe();
+        let rollup_config = self.config.clone();
+
+        tokio::spawn(async move {
+            while let Some(query) = inbound_queries.recv().await {
+                match query {
+                    L1WatcherQueries::Config(sender) => {
+                        if let Err(e) = sender.send((*rollup_config).clone()) {
+                            warn!(target: "l1_watcher", error = ?e, "Failed to send L1 config to the query sender");
+                        }
+                    }
+                    L1WatcherQueries::L1State(sender) => {
+                        let current_l1 = *head_updates_recv.borrow();
+
+                        let head_l1 = match l1_provider.get_block(BlockId::latest()).await {
+                            Ok(block) => block,
+                            Err(e) => {
+                                warn!(target: "l1_watcher", error = ?e, "failed to query l1 provider for latest head block");
+                                None
+                            }}.map(|block| block.into_consensus().into());
+
+                        let finalized_l1 = match l1_provider.get_block(BlockId::finalized()).await {
+                            Ok(block) => block,
+                            Err(e) => {
+                                warn!(target: "l1_watcher", error = ?e, "failed to query l1 provider for latest finalized block");
+                                None
+                            }}.map(|block| block.into_consensus().into());
+
+                        let safe_l1 = match l1_provider.get_block(BlockId::safe()).await {
+                            Ok(block) => block,
+                            Err(e) => {
+                                warn!(target: "l1_watcher", error = ?e, "failed to query l1 provider for latest safe block");
+                                None
+                            }}.map(|block| block.into_consensus().into());
+
+                        if let Err(e) = sender.send(L1State {
+                            current_l1,
+                            current_l1_finalized: finalized_l1,
+                            head_l1,
+                            safe_l1,
+                            finalized_l1,
+                        }) {
+                            warn!(target: "l1_watcher", error = ?e, "Failed to send L1 state to the query sender");
+                        }
+                    }
+                }
+            }
+
+            error!(target: "l1_watcher", "L1 watcher query channel closed unexpectedly, exiting query processor task.");
+        })
+    }
 }
 
 #[async_trait]
@@ -99,6 +178,11 @@ impl NodeActor for L1WatcherRpc {
             .into_stream()
             .flat_map(futures::stream::iter);
 
+        let inbound_queries = std::mem::take(&mut self.inbound_queries);
+        let inbound_query_processor =
+            inbound_queries.map(|queries| self.start_query_processor(queries));
+
+        // Start the main processing loop.
         loop {
             select! {
                 _ = self.cancellation.cancelled() => {
@@ -107,6 +191,10 @@ impl NodeActor for L1WatcherRpc {
                         target: "l1_watcher",
                         "Received shutdown signal. Exiting L1 watcher task."
                     );
+
+                    // Kill the inbound query processor.
+                    if let Some(inbound_query_processor) = inbound_query_processor { inbound_query_processor.abort() }
+
                     return Ok(());
                 }
                 new_head = unsafe_head_stream.next() => match new_head {
@@ -120,6 +208,7 @@ impl NodeActor for L1WatcherRpc {
                         // Send the head update event to all consumers.
                         let head_block_info = self.block_info_by_hash(new_head).await?;
                         self.head_sender.send(head_block_info)?;
+                        self.latest_head.send_replace(Some(head_block_info));
 
                         // For each log, attempt to construct a `SystemConfigLog`.
                         // Build the `SystemConfigUpdate` from the log.

--- a/crates/node/service/src/service/standard/node.rs
+++ b/crates/node/service/src/service/standard/node.rs
@@ -22,7 +22,7 @@ use kona_providers_alloy::{
     AlloyChainProvider, AlloyL2ChainProvider, OnlineBeaconClient, OnlineBlobProvider,
     OnlinePipeline,
 };
-use kona_rpc::{NetworkRpc, RpcLauncher};
+use kona_rpc::{L1WatcherQueries, NetworkRpc, RpcLauncher};
 
 /// The size of the cache used in the derivation pipeline's providers.
 const DERIVATION_PROVIDER_CACHE_SIZE: usize = 1024;
@@ -89,6 +89,7 @@ impl ValidatorNodeService for RollupNode {
         new_da_tx: UnboundedSender<BlockInfo>,
         block_signer_tx: UnboundedSender<Address>,
         cancellation: CancellationToken,
+        l1_watcher_inbound_queries: Option<tokio::sync::mpsc::Receiver<L1WatcherQueries>>,
     ) -> Self::DataAvailabilityWatcher {
         L1WatcherRpc::new(
             self.config.clone(),
@@ -96,6 +97,7 @@ impl ValidatorNodeService for RollupNode {
             new_da_tx,
             block_signer_tx,
             cancellation,
+            l1_watcher_inbound_queries,
         )
     }
 


### PR DESCRIPTION
## Description
This PR adds an external query handler for the DA watcher. In particular it ensures we can get the necessary data to implement the rollup RPC endpoints.
This query handler makes sure we can access the DA watcher's state through external actors

Progress towards #1653

Depends on #1664