### PR TITLE
feat(node/rpc): implement the rollup RPC endpoints

### DIFF
--- a/crates/node/engine/src/lib.rs
+++ b/crates/node/engine/src/lib.rs
@@ -35,4 +35,4 @@ mod kinds;
 pub use kinds::EngineKind;
 
 mod query;
-pub use query::{EngineQuerySender, EngineStateQuery};
+pub use query::{EngineQueries, EngineQueriesError, EngineQuerySender};

--- a/crates/node/engine/src/query.rs
+++ b/crates/node/engine/src/query.rs
@@ -1,18 +1,112 @@
+use std::sync::Arc;
+
+use alloy_eips::BlockNumberOrTag;
+use alloy_provider::Provider;
+use alloy_transport::{RpcError, TransportErrorKind};
+use kona_genesis::RollupConfig;
+use kona_protocol::{L2BlockInfo, OutputRoot, Predeploys};
 use tokio::sync::oneshot::Sender;
 
-use crate::EngineState;
+use crate::{EngineClient, EngineClientError, EngineState};
 
 /// The type of data that can be requested from the engine.
-pub type EngineQuerySender = tokio::sync::mpsc::Sender<EngineStateQuery>;
+pub type EngineQuerySender = tokio::sync::mpsc::Sender<EngineQueries>;
 
 /// Returns the full engine state.
 #[derive(Debug)]
-pub struct EngineStateQuery(Sender<EngineState>);
+pub enum EngineQueries {
+    /// Returns the rollup config.
+    Config(Sender<RollupConfig>),
+    /// Returns L2 engine state information.
+    State(Sender<EngineState>),
+    /// Returns the L2 output at the specified block with a tuple of the block info and associated
+    /// engine state.
+    OutputAtBlock {
+        /// The block number or tag of the block to retrieve the output for.
+        block: BlockNumberOrTag,
+        /// A channel to send back the output and engine state.
+        sender: Sender<(L2BlockInfo, OutputRoot, EngineState)>,
+    },
+}
 
-impl EngineStateQuery {
+/// An error that can occur when querying the engine.
+#[derive(Debug, thiserror::Error)]
+pub enum EngineQueriesError {
+    /// The output channel was closed unexpectedly. Impossible to send query response.
+    #[error("Output channel closed unexpectedly. Impossible to send query response")]
+    OutputChannelClosed,
+    /// Failed to retrieve the L2 block by label.
+    #[error("Failed to retrieve L2 block by label: {0}")]
+    BlockRetrievalFailed(#[from] EngineClientError),
+    /// No block withdrawals root while Isthmus is active.
+    #[error("No block withdrawals root while Isthmus is active")]
+    NoWithdrawalsRoot,
+    /// No L2 block found for block number or tag.
+    #[error("No L2 block found for block number or tag: {0}")]
+    NoL2BlockFound(BlockNumberOrTag),
+    /// Impossible to retrieve L2 withdrawals root from state.
+    #[error("Impossible to retrieve L2 withdrawals root from state. {0}")]
+    FailedToRetrieveWithdrawalsRoot(#[from] RpcError<TransportErrorKind>),
+}
+
+impl EngineQueries {
     /// Handles the engine query request.
-    pub fn handle(self, state_recv: &tokio::sync::watch::Receiver<EngineState>) -> Option<()> {
+    pub async fn handle(
+        self,
+        state_recv: &tokio::sync::watch::Receiver<EngineState>,
+        client: &Arc<EngineClient>,
+        rollup_config: &Arc<RollupConfig>,
+    ) -> Result<(), EngineQueriesError> {
         let state = *state_recv.borrow();
-        self.0.send(state).ok()
+        match self {
+            Self::Config(sender) => sender
+                .send((**rollup_config).clone())
+                .map_err(|_| EngineQueriesError::OutputChannelClosed),
+            Self::State(sender) => {
+                sender.send(state).map_err(|_| EngineQueriesError::OutputChannelClosed)
+            }
+            Self::OutputAtBlock { block, sender } => {
+                // TODO(@theochap): it is not very efficient to fetch the block info and the full
+                // block with two separate RPC calls. We can get the block info from
+                // the full block by using the `from_rpc_block_and_genesis` method which requires
+                // accessing the `ChainGenesis` struct.
+                let (output_block, output_block_info) = tokio::try_join!(
+                    client.l2_block_by_label(block),
+                    client.l2_block_info_by_label(block)
+                )?;
+
+                let output_block = output_block.ok_or(EngineQueriesError::NoL2BlockFound(block))?;
+                let output_block_info =
+                    output_block_info.ok_or(EngineQueriesError::NoL2BlockFound(block))?;
+
+                let state_root = output_block.header.state_root;
+
+                let message_passer_storage_root =
+                    if rollup_config.is_isthmus_active(output_block.header.timestamp) {
+                        output_block
+                            .header
+                            .withdrawals_root
+                            .ok_or(EngineQueriesError::NoWithdrawalsRoot)?
+                    } else {
+                        // Fetch the storage root for the L2 head block.
+                        let l2_to_l1_message_passer = client
+                            .get_proof(Predeploys::L2_TO_L1_MESSAGE_PASSER, Default::default())
+                            .block_id(block.into())
+                            .await?;
+
+                        l2_to_l1_message_passer.storage_hash
+                    };
+
+                let output_response_v0 = OutputRoot::from_parts(
+                    state_root,
+                    message_passer_storage_root,
+                    output_block.header.hash,
+                );
+
+                sender
+                    .send((output_block_info, output_response_v0, state))
+                    .map_err(|_| EngineQueriesError::OutputChannelClosed)
+            }
+        }
     }
 }

--- a/crates/node/rpc/src/output.rs
+++ b/crates/node/rpc/src/output.rs
@@ -1,7 +1,7 @@
 //! Output Types
 
 use alloy_primitives::B256;
-use kona_protocol::{L2BlockInfo, SyncStatus};
+use kona_protocol::{L2BlockInfo, OutputRoot, SyncStatus};
 
 /// An [output response][or] for Optimism Rollup.
 ///
@@ -21,4 +21,18 @@ pub struct OutputResponse {
     pub state_root: B256,
     /// The status of the node sync.
     pub sync_status: SyncStatus,
+}
+
+impl OutputResponse {
+    /// Builds an [`OutputResponse`] from its parts.
+    pub fn from_v0(v0: OutputRoot, sync_status: SyncStatus, block_ref: L2BlockInfo) -> Self {
+        Self {
+            version: v0.version(),
+            output_root: v0.hash(),
+            block_ref,
+            withdrawal_storage_root: v0.bridge_storage_root,
+            state_root: v0.state_root,
+            sync_status,
+        }
+    }
 }

--- a/crates/node/rpc/src/rollup.rs
+++ b/crates/node/rpc/src/rollup.rs
@@ -8,12 +8,13 @@ use jsonrpsee::{
     core::RpcResult,
     types::{ErrorCode, ErrorObject},
 };
-use kona_engine::EngineQuerySender;
+use kona_engine::{EngineQueries, EngineQuerySender, EngineState};
 use kona_genesis::RollupConfig;
 use kona_protocol::SyncStatus;
 
 use crate::{
-    OutputResponse, RollupNodeApiServer, SafeHeadResponse, l1_watcher::L1WatcherQuerySender,
+    L1State, L1WatcherQueries, OutputResponse, RollupNodeApiServer, SafeHeadResponse,
+    l1_watcher::L1WatcherQuerySender,
 };
 
 /// RollupRpc
@@ -21,12 +22,10 @@ use crate::{
 /// This is a server implementation of [`crate::RollupNodeApiServer`].
 #[derive(Debug)]
 pub struct RollupRpc {
-    /// The channel to send [`kona_engine::EngineStateQuery`]s.
+    /// The channel to send [`kona_engine::EngineQueries`]s.
     pub engine_sender: EngineQuerySender,
     /// The channel to send [`crate::L1WatcherQueries`]s.
     pub l1_watcher_sender: L1WatcherQuerySender,
-    // TODO(@theochap): Add channels to send requests to the derivation actor and the
-    // l1 watcher.
 }
 
 impl RollupRpc {
@@ -34,40 +33,115 @@ impl RollupRpc {
     pub const fn new(sender: EngineQuerySender, l1_watcher_sender: L1WatcherQuerySender) -> Self {
         Self { engine_sender: sender, l1_watcher_sender }
     }
+
+    // Important note: we zero-out the fields that can't be derived yet to follow op-node's
+    // behaviour.
+    fn sync_status_from_actor_queries(
+        l1_sync_status: L1State,
+        l2_sync_status: EngineState,
+    ) -> SyncStatus {
+        SyncStatus {
+            current_l1: l1_sync_status.current_l1.unwrap_or_default(),
+            current_l1_finalized: l1_sync_status.current_l1_finalized.unwrap_or_default(),
+            head_l1: l1_sync_status.head_l1.unwrap_or_default(),
+            safe_l1: l1_sync_status.safe_l1.unwrap_or_default(),
+            finalized_l1: l1_sync_status.finalized_l1.unwrap_or_default(),
+            unsafe_l2: l2_sync_status.unsafe_head(),
+            cross_unsafe_l2: l2_sync_status.cross_unsafe_head(),
+            local_safe_l2: l2_sync_status.local_safe_head(),
+            safe_l2: l2_sync_status.safe_head(),
+            finalized_l2: l2_sync_status.finalized_head(),
+            pending_safe_l2: l2_sync_status.pending_safe_head(),
+        }
+    }
 }
 
 #[async_trait]
 impl RollupNodeApiServer for RollupRpc {
-    async fn op_output_at_block(&self, _block_num: BlockNumberOrTag) -> RpcResult<OutputResponse> {
+    async fn op_output_at_block(&self, block_num: BlockNumberOrTag) -> RpcResult<OutputResponse> {
         // TODO(@theochap): add metrics
-        // TODO(@theochap): implement this RPC endpoint.
-        return Err(ErrorObject::from(ErrorCode::MethodNotFound));
+
+        let (output_send, output_recv) = tokio::sync::oneshot::channel();
+        let (l1_sync_status_send, l1_sync_status_recv) = tokio::sync::oneshot::channel();
+
+        let ((l2_block_info, output_root, l2_sync_status), l1_sync_status) = tokio::try_join!(
+            async {
+                self.engine_sender
+                    .send(EngineQueries::OutputAtBlock { block: block_num, sender: output_send })
+                    .await
+                    .map_err(|_| ErrorObject::from(ErrorCode::InternalError))?;
+
+                output_recv.await.map_err(|_| ErrorObject::from(ErrorCode::InternalError))
+            },
+            async {
+                self.l1_watcher_sender
+                    .send(L1WatcherQueries::L1State(l1_sync_status_send))
+                    .await
+                    .map_err(|_| ErrorObject::from(ErrorCode::InternalError))?;
+
+                l1_sync_status_recv.await.map_err(|_| ErrorObject::from(ErrorCode::InternalError))
+            }
+        )?;
+
+        let sync_status = Self::sync_status_from_actor_queries(l1_sync_status, l2_sync_status);
+
+        Ok(OutputResponse::from_v0(output_root, sync_status, l2_block_info))
     }
 
+    /// This RPC endpoint is not supported. It is not necessary to track the safe head for every L1
+    /// block post-interop anymore so we can remove this method from the rpc interface.
     async fn op_safe_head_at_l1_block(
         &self,
         _block_num: BlockNumberOrTag,
     ) -> RpcResult<SafeHeadResponse> {
         // TODO(@theochap): add metrics
-        // TODO(@theochap): implement this RPC endpoint.
         return Err(ErrorObject::from(ErrorCode::MethodNotFound));
     }
 
     async fn op_sync_status(&self) -> RpcResult<SyncStatus> {
         // TODO(@theochap): add metrics
-        // TODO(@theochap): implement this RPC endpoint.
-        return Err(ErrorObject::from(ErrorCode::MethodNotFound));
+
+        let (l1_sync_status_send, l1_sync_status_recv) = tokio::sync::oneshot::channel();
+        let (l2_sync_status_send, l2_sync_status_recv) = tokio::sync::oneshot::channel();
+
+        let (l1_sync_status, l2_sync_status) = tokio::try_join!(
+            async {
+                self.l1_watcher_sender
+                    .send(L1WatcherQueries::L1State(l1_sync_status_send))
+                    .await
+                    .map_err(|_| ErrorObject::from(ErrorCode::InternalError))?;
+                l1_sync_status_recv.await.map_err(|_| ErrorObject::from(ErrorCode::InternalError))
+            },
+            async {
+                self.engine_sender
+                    .send(EngineQueries::State(l2_sync_status_send))
+                    .await
+                    .map_err(|_| ErrorObject::from(ErrorCode::InternalError))?;
+                l2_sync_status_recv.await.map_err(|_| ErrorObject::from(ErrorCode::InternalError))
+            }
+        )
+        .map_err(|_| ErrorObject::from(ErrorCode::InternalError))?;
+
+        return Ok(Self::sync_status_from_actor_queries(l1_sync_status, l2_sync_status));
     }
 
     async fn op_rollup_config(&self) -> RpcResult<RollupConfig> {
         // TODO(@theochap): add metrics
-        // TODO(@theochap): implement this RPC endpoint.
-        return Err(ErrorObject::from(ErrorCode::MethodNotFound));
+
+        let (rollup_config_send, rollup_config_recv) = tokio::sync::oneshot::channel();
+        let Ok(()) = self.engine_sender.send(EngineQueries::Config(rollup_config_send)).await
+        else {
+            return Err(ErrorObject::from(ErrorCode::InternalError));
+        };
+
+        Ok(rollup_config_recv.await.map_err(|_| ErrorObject::from(ErrorCode::InternalError))?)
     }
 
     async fn op_version(&self) -> RpcResult<String> {
         // TODO(@theochap): add metrics
-        // TODO(@theochap): implement this RPC endpoint.
-        return Err(ErrorObject::from(ErrorCode::MethodNotFound));
+
+        const RPC_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+        return Ok(RPC_VERSION.to_string());
     }
 }

--- a/crates/node/service/src/actors/derivation.rs
+++ b/crates/node/service/src/actors/derivation.rs
@@ -61,6 +61,7 @@ where
     pub attributes_out: UnboundedSender<OpAttributesWithParent>,
     /// The receiver for L1 head update notifications.
     l1_head_updates: UnboundedReceiver<BlockInfo>,
+
     /// The cancellation token, shared between all tasks.
     cancellation: CancellationToken,
 }

--- a/crates/protocol/protocol/src/output_root.rs
+++ b/crates/protocol/protocol/src/output_root.rs
@@ -30,6 +30,12 @@ impl OutputRoot {
     /// commitment.
     pub const VERSION: u8 = 0;
 
+    /// Returns the version of the [`OutputRoot`]. Currently, the protocol only supports the version
+    /// number 0.
+    pub const fn version(&self) -> B256 {
+        B256::ZERO
+    }
+
     /// Constructs a V0 [`OutputRoot`] from its parts.
     pub const fn from_parts(state_root: B256, bridge_storage_root: B256, block_hash: B256) -> Self {
         Self { state_root, bridge_storage_root, block_hash }


### PR DESCRIPTION
## Description
This PR fully implements the rollup RPC endpoints for the `kona-node`. Following the suggestion of the op-node's team I have not implemented the `optimism_safeHeadAtL1Block` endpoint as it is not required post-interop.

Merging this will close #1653

Depends on #1692 and #1664