### PR TITLE
chore(meta): Add chainsafe as supervisor code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @clabby @refcell @emhane @theochap
+bin/supervisor @dhyaniarun1993 @itschaindev @sadiq1971


### PR DESCRIPTION
Enables automatic review notifications for all prs to `bin/supervisor` for @dhyaniarun1993 @itschaindev @sadiq1971 as code owners