### PR TITLE
chore(meta): Add chainsafe as code owners of `kona-supervisor`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 * @clabby @refcell @emhane @theochap
 bin/supervisor @dhyaniarun1993 @itschaindev @sadiq1971
+crates/supervisor @dhyaniarun1993 @itschaindev @sadiq1971


### PR DESCRIPTION
Adds @dhyaniarun1993 @itschaindev @sadiq1971 as code owners for new crate `kona-supervisor`