### PR TITLE
chore(kona/kurtosis): update the link to the optimism-package repo

### DIFF
--- a/.config/optimism_package.json
+++ b/.config/optimism_package.json
@@ -1,4 +1,4 @@
 {
-  "repository": "https://github.com/theochap/optimism-package",
-  "branch": "theo/kona-node-integration"
+  "repository": "https://github.com/ethpandaops/optimism-package",
+  "branch": "main"
 }


### PR DESCRIPTION
## Description
Now that https://github.com/ethpandaops/optimism-package/pull/229 has been merged, we can track the `optimism-package` repo directly to get the most recent updates