### PR TITLE
fix(node/engine): Derivation Sync Start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4975,6 +4975,7 @@ dependencies = [
 name = "kona-sources"
 version = "0.1.0"
 dependencies = [
+ "alloy-eips 0.15.10",
  "alloy-primitives",
  "alloy-provider",
  "alloy-transport",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4975,7 +4975,7 @@ dependencies = [
 name = "kona-sources"
 version = "0.1.0"
 dependencies = [
- "alloy-eips 0.15.10",
+ "alloy-eips 0.15.11",
  "alloy-primitives",
  "alloy-provider",
  "alloy-transport",

--- a/crates/node/service/src/lib.rs
+++ b/crates/node/service/src/lib.rs
@@ -21,6 +21,3 @@ pub use actors::{
     InboundDerivationMessage, L1WatcherRpc, L1WatcherRpcError, NetworkActor, NetworkActorError,
     NodeActor, RpcActor, RpcActorError, RuntimeActor, RuntimeLauncher,
 };
-
-mod sync_start;
-pub use sync_start::{L2ForkchoiceState, SyncStartError, find_starting_forkchoice};

--- a/crates/node/service/src/service/standard/error.rs
+++ b/crates/node/service/src/service/standard/error.rs
@@ -7,6 +7,7 @@ use kona_engine::EngineStateBuilderError;
 use kona_p2p::NetworkBuilderError;
 use kona_providers_alloy::AlloyChainProviderError;
 use kona_rpc::RpcLauncherError;
+use kona_sources::SyncStartError;
 
 /// Errors that can occur during the operation of the [`crate::RollupNode`].
 #[derive(thiserror::Error, Debug)]

--- a/crates/node/service/src/service/standard/error.rs
+++ b/crates/node/service/src/service/standard/error.rs
@@ -1,6 +1,5 @@
 //! Contains the error type for the [`crate::RollupNode`].
 
-use crate::SyncStartError;
 use jsonrpsee::server::RegisterMethodError;
 use kona_derive::errors::PipelineErrorKind;
 use kona_engine::EngineStateBuilderError;

--- a/crates/node/service/src/service/standard/node.rs
+++ b/crates/node/service/src/service/standard/node.rs
@@ -1,13 +1,13 @@
 //! Contains the [`RollupNode`] implementation.
 
 use crate::{
-    EngineLauncher, L1WatcherRpc, L2ForkchoiceState, NodeMode, RollupNodeBuilder, RollupNodeError,
-    RollupNodeService, RuntimeLauncher, SequencerNodeService, ValidatorNodeService,
-    find_starting_forkchoice,
+    EngineLauncher, L1WatcherRpc, NodeMode, RollupNodeBuilder, RollupNodeError, RollupNodeService,
+    RuntimeLauncher, SequencerNodeService, ValidatorNodeService,
 };
 use alloy_primitives::Address;
 use alloy_provider::RootProvider;
 use async_trait::async_trait;
+use kona_sources::L2ForkchoiceState;
 use op_alloy_network::Optimism;
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
@@ -145,12 +145,8 @@ impl ValidatorNodeService for RollupNode {
         );
 
         // Find the starting forkchoice state.
-        let starting_forkchoice = find_starting_forkchoice(
-            self.config.as_ref(),
-            &mut l1_derivation_provider,
-            &mut l2_derivation_provider,
-        )
-        .await?;
+        let starting_forkchoice =
+            L2ForkchoiceState::current(self.config.as_ref(), &mut l2_derivation_provider).await?;
 
         info!(
             target: "rollup_node",

--- a/crates/node/sources/Cargo.toml
+++ b/crates/node/sources/Cargo.toml
@@ -24,6 +24,7 @@ kona-protocol.workspace = true
 kona-providers-alloy.workspace = true
 
 # Alloy
+alloy-eips.workspace = true
 alloy-provider.workspace = true
 alloy-transport.workspace = true
 alloy-primitives.workspace = true

--- a/crates/node/sources/src/lib.rs
+++ b/crates/node/sources/src/lib.rs
@@ -10,6 +10,9 @@
 #[macro_use]
 extern crate tracing;
 
+mod sync;
+pub use sync::{L2ForkchoiceState, SyncStartError, find_starting_forkchoice};
+
 mod runtime;
 pub use runtime::{RuntimeConfig, RuntimeLoader, RuntimeLoaderError};
 

--- a/crates/node/sources/src/sync/error.rs
+++ b/crates/node/sources/src/sync/error.rs
@@ -1,0 +1,38 @@
+//! Contains the error types used for finding the starting forkchoice state.
+
+use alloy_primitives::B256;
+use alloy_transport::{RpcError, TransportErrorKind};
+use kona_providers_alloy::{AlloyChainProviderError, AlloyL2ChainProviderError};
+use thiserror::Error;
+
+/// An error that can occur during the sync start process.
+#[derive(Error, Debug)]
+pub enum SyncStartError {
+    /// An error occurred in the L1 chain provider.
+    #[error(transparent)]
+    L1ChainProvider(#[from] AlloyChainProviderError),
+    /// An error occurred in the L2 chain provider.
+    #[error(transparent)]
+    L2ChainProvider(#[from] AlloyL2ChainProviderError),
+    /// An rpc error occurred
+    #[error("An RPC error occurred: {0}")]
+    RpcError(#[from] RpcError<TransportErrorKind>),
+    /// Invalid L1 genesis hash.
+    #[error("Invalid L1 genesis hash. Expected {0}, Got {1}")]
+    InvalidL1GenesisHash(B256, B256),
+    /// Invalid L2 genesis hash.
+    #[error("Invalid L2 genesis hash. Expected {0}, Got {1}")]
+    InvalidL2GenesisHash(B256, B256),
+    /// Finalized block mismatch
+    #[error("Finalized block mismatch. Expected {0}, Got {1}")]
+    MismatchedFinalizedBlock(B256, B256),
+    /// L1 origin mismatch.
+    #[error("L1 origin mismatch")]
+    L1OriginMismatch,
+    /// Non-zero sequence number.
+    #[error("Non-zero sequence number for block with different L1 origin")]
+    NonZeroSequenceNumber,
+    /// Inconsistent sequence number.
+    #[error("Inconsistent sequence number; Must monotonically increase.")]
+    InconsistentSequenceNumber,
+}

--- a/crates/node/sources/src/sync/forkchoice.rs
+++ b/crates/node/sources/src/sync/forkchoice.rs
@@ -1,0 +1,64 @@
+//! Contains the forkchoice state for the L2.
+
+use crate::SyncStartError;
+use alloy_eips::BlockNumberOrTag;
+use kona_genesis::RollupConfig;
+use kona_protocol::L2BlockInfo;
+use kona_providers_alloy::AlloyL2ChainProvider;
+use std::fmt::Display;
+
+/// An unsafe, safe, and finalized [L2BlockInfo] returned by the [crate::find_starting_forkchoice]
+/// function.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct L2ForkchoiceState {
+    /// The unsafe L2 block.
+    pub un_safe: L2BlockInfo,
+    /// The safe L2 block.
+    pub safe: L2BlockInfo,
+    /// The finalized L2 block.
+    pub finalized: L2BlockInfo,
+}
+
+impl Display for L2ForkchoiceState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "FINALIZED: {} (#{}) | SAFE: {} (#{}) | UNSAFE: {} (#{})",
+            self.finalized.block_info.hash,
+            self.finalized.block_info.number,
+            self.safe.block_info.hash,
+            self.safe.block_info.number,
+            self.un_safe.block_info.hash,
+            self.un_safe.block_info.number,
+        )
+    }
+}
+
+impl L2ForkchoiceState {
+    /// Fetches the current forkchoice state of the L2 execution layer.
+    ///
+    /// - The finalized block may not always be available. If it is not, we fall back to genesis.
+    /// - The safe block may not always be available. If it is not, we fall back to the finalized
+    ///   block.
+    /// - The unsafe block is always assumed to be available.
+    pub async fn current(
+        cfg: &RollupConfig,
+        l2_provider: &mut AlloyL2ChainProvider,
+    ) -> Result<Self, SyncStartError> {
+        let finalized = match l2_provider.block_info_by_id(BlockNumberOrTag::Finalized.into()).await
+        {
+            Ok(Some(block)) => block,
+            Ok(None) => l2_provider.block_info_by_id(cfg.genesis.l2.number.into()).await?.unwrap(),
+            Err(e) => return Err(SyncStartError::RpcError(e)),
+        };
+        let safe = match l2_provider.block_info_by_id(BlockNumberOrTag::Safe.into()).await {
+            Ok(Some(block)) => block,
+            Ok(None) => finalized,
+            Err(e) => return Err(SyncStartError::RpcError(e)),
+        };
+        let un_safe =
+            l2_provider.block_info_by_id(BlockNumberOrTag::Latest.into()).await.unwrap().unwrap();
+
+        Ok(Self { un_safe, safe, finalized })
+    }
+}


### PR DESCRIPTION
### Description

Fixes derivation to use the engine safe head instead of keeping its own local view.