### PR TITLE
feat: Bump `kona-client` and `kona-host` versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4363,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "kona-client"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.15.10",
@@ -4590,7 +4590,7 @@ dependencies = [
 
 [[package]]
 name = "kona-host"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.15.10",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,8 +68,8 @@ lto = "fat"
 
 [workspace.dependencies]
 # Binaries
-kona-host = { path = "bin/host", version = "1.0.0", default-features = false }
-kona-client = { path = "bin/client", version = "1.0.0", default-features = false }
+kona-host = { path = "bin/host", version = "1.0.1", default-features = false }
+kona-client = { path = "bin/client", version = "1.0.1", default-features = false }
 
 # Protocol
 kona-comp = { path = "crates/protocol/comp", version = "0.3.0", default-features = false }

--- a/bin/client/Cargo.toml
+++ b/bin/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kona-client"
-version = "1.0.0"
+version = "1.0.1"
 publish = false
 edition.workspace = true
 authors.workspace = true

--- a/bin/host/Cargo.toml
+++ b/bin/host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kona-host"
-version = "1.0.0"
+version = "1.0.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Overview

Bumps `kona-client` and `kona-host` to `v1.0.0`