### PR TITLE
feat(supervisor/service): l1 watcher for supervisor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5090,10 +5090,21 @@ dependencies = [
 name = "kona-supervisor-service"
 version = "0.1.0"
 dependencies = [
+ "alloy-eips 0.15.10",
+ "alloy-primitives",
+ "alloy-provider",
  "anyhow",
+ "async-trait",
+ "futures",
  "jsonrpsee 0.25.1",
+ "kona-genesis",
+ "kona-protocol",
+ "kona-rpc",
  "kona-supervisor-core",
  "kona-supervisor-rpc",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/crates/supervisor/service/Cargo.toml
+++ b/crates/supervisor/service/Cargo.toml
@@ -21,3 +21,14 @@ kona-supervisor-rpc = { workspace = true, features = ["jsonrpsee"] }
 jsonrpsee = { workspace = true, features = ["macros", "server"] }
 anyhow = { workspace = true }
 tracing = { workspace = true}
+alloy-eips = { workspace = true }
+alloy-primitives = { workspace = true }
+alloy-provider = { workspace = true }
+async-trait = { workspace = true }
+futures = { workspace = true }
+kona-genesis = { workspace = true }
+kona-protocol = { workspace = true }
+kona-rpc = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync", "macros"] }
+tokio-util = { workspace = true }

--- a/crates/supervisor/service/src/actors/l1_watcher_rpc.rs
+++ b/crates/supervisor/service/src/actors/l1_watcher_rpc.rs
@@ -1,0 +1,221 @@
+//! [SupervisorActor] implementation for an L1 chain watcher that checks for L1 head updates over RPC.
+
+use crate::actors::traits::SupervisorActor;
+use alloy_eips::BlockId;
+use alloy_primitives::B256;
+use alloy_provider::{Provider, RootProvider};
+use async_trait::async_trait;
+use futures::StreamExt;
+use kona_genesis::RollupConfig;
+use kona_protocol::BlockInfo;
+use kona_rpc::{L1State, L1WatcherQueries};
+use std::sync::Arc;
+use thiserror::Error;
+use tokio::{
+    select,
+    sync::mpsc::{UnboundedSender, error::SendError},
+    task::JoinHandle,
+};
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, warn};
+
+/// An L1 chain watcher that checks for L1 head updates over RPC.
+#[derive(Debug)]
+pub struct L1WatcherRpc {
+    /// The [`RollupConfig`] to tell if ecotone is active.
+    /// This is used to determine if the L1 watcher should
+    /// check for unsafe block signer updates.
+    config: Arc<RollupConfig>,
+    /// The L1 provider.
+    l1_provider: RootProvider,
+    /// The latest L1 head sent to the derivation pipeline and watcher. Can be subscribed to, in
+    /// order to get the state from the external watcher.
+    latest_head: tokio::sync::watch::Sender<Option<BlockInfo>>,
+    /// The outbound event sender.
+    head_sender: UnboundedSender<BlockInfo>,
+    /// The cancellation token, shared between all tasks.
+    cancellation: CancellationToken,
+    /// Inbound queries to the L1 watcher.
+    inbound_queries: Option<tokio::sync::mpsc::Receiver<L1WatcherQueries>>,
+}
+
+impl L1WatcherRpc {
+    /// Creates a new [`L1WatcherRpc`] instance.
+    pub fn new(
+        config: Arc<RollupConfig>,
+        l1_provider: RootProvider,
+        head_sender: UnboundedSender<BlockInfo>,
+        cancellation: CancellationToken,
+        // Can be None if we disable communication with the L1 watcher.
+        inbound_queries: Option<tokio::sync::mpsc::Receiver<L1WatcherQueries>>,
+    ) -> Self {
+        let (head_updates, _) = tokio::sync::watch::channel(None);
+        Self {
+            config,
+            l1_provider,
+            head_sender,
+            latest_head: head_updates,
+            cancellation,
+            inbound_queries,
+        }
+    }
+
+    /// Fetches the block info for the current L1 head.
+    async fn block_info_by_hash(
+        &mut self,
+        block_hash: B256,
+    ) -> Result<BlockInfo, L1WatcherRpcError<BlockInfo>> {
+        // Fetch the block of the current unsafe L1 head.
+        let block = self
+            .l1_provider
+            .get_block_by_hash(block_hash)
+            .await
+            .map_err(|e| L1WatcherRpcError::Transport(e.to_string()))?
+            .ok_or(L1WatcherRpcError::L1BlockNotFound(block_hash))?;
+
+        // Update the last observed head. The producer does not care about re-orgs, as this is
+        // handled downstream by receivers of the head update signal.
+        let head_block_info = BlockInfo {
+            hash: block.header.hash,
+            number: block.header.number,
+            parent_hash: block.header.parent_hash,
+            timestamp: block.header.timestamp,
+        };
+
+        Ok(head_block_info)
+    }
+
+    /// Spins up a task to process inbound queries.
+    fn start_query_processor(
+        &self,
+        mut inbound_queries: tokio::sync::mpsc::Receiver<L1WatcherQueries>,
+    ) -> JoinHandle<()> {
+        // Start the inbound query processor in a separate task to avoid blocking the main task.
+        // We can cheaply clone the l1 provider here because it is an Arc.
+        let l1_provider = self.l1_provider.clone();
+        let head_updates_recv = self.latest_head.subscribe();
+        let rollup_config = self.config.clone();
+
+        tokio::spawn(async move {
+            while let Some(query) = inbound_queries.recv().await {
+                match query {
+                    L1WatcherQueries::Config(sender) => {
+                        if let Err(e) = sender.send((*rollup_config).clone()) {
+                            warn!(target: "l1_watcher", error = ?e, "Failed to send L1 config to the query sender");
+                        }
+                    }
+                    L1WatcherQueries::L1State(sender) => {
+                        let current_l1 = *head_updates_recv.borrow();
+
+                        let head_l1 = match l1_provider.get_block(BlockId::latest()).await {
+                            Ok(block) => block,
+                            Err(e) => {
+                                warn!(target: "l1_watcher", error = ?e, "failed to query l1 provider for latest head block");
+                                None
+                            }}.map(|block| block.into_consensus().into());
+
+                        let finalized_l1 = match l1_provider.get_block(BlockId::finalized()).await {
+                            Ok(block) => block,
+                            Err(e) => {
+                                warn!(target: "l1_watcher", error = ?e, "failed to query l1 provider for latest finalized block");
+                                None
+                            }}.map(|block| block.into_consensus().into());
+
+                        let safe_l1 = match l1_provider.get_block(BlockId::safe()).await {
+                            Ok(block) => block,
+                            Err(e) => {
+                                warn!(target: "l1_watcher", error = ?e, "failed to query l1 provider for latest safe block");
+                                None
+                            }}.map(|block| block.into_consensus().into());
+
+                        if let Err(e) = sender.send(L1State {
+                            current_l1,
+                            current_l1_finalized: finalized_l1,
+                            head_l1,
+                            safe_l1,
+                            finalized_l1,
+                        }) {
+                            warn!(target: "l1_watcher", error = ?e, "Failed to send L1 state to the query sender");
+                        }
+                    }
+                }
+            }
+
+            error!(target: "l1_watcher", "L1 watcher query channel closed unexpectedly, exiting query processor task.");
+        })
+    }
+}
+
+#[async_trait]
+impl SupervisorActor for L1WatcherRpc {
+    type InboundEvent = ();
+    type Error = L1WatcherRpcError<BlockInfo>;
+
+    async fn start(mut self) -> Result<(), Self::Error> {
+        let mut unsafe_head_stream = self
+            .l1_provider
+            .watch_blocks()
+            .await
+            .map_err(|e| L1WatcherRpcError::Transport(e.to_string()))?
+            .into_stream()
+            .flat_map(futures::stream::iter);
+
+        let inbound_queries = std::mem::take(&mut self.inbound_queries);
+        let inbound_query_processor =
+            inbound_queries.map(|queries| self.start_query_processor(queries));
+
+        // Start the main processing loop.
+        loop {
+            select! {
+                _ = self.cancellation.cancelled() => {
+                    // Exit the task on cancellation.
+                    info!(
+                        target: "l1_watcher",
+                        "Received shutdown signal. Exiting L1 watcher task."
+                    );
+
+                    // Kill the inbound query processor.
+                    if let Some(inbound_query_processor) = inbound_query_processor { inbound_query_processor.abort() }
+
+                    return Ok(());
+                }
+                new_head = unsafe_head_stream.next() => match new_head {
+                    None => {
+                        // The stream ended, which should never happen.
+                        return Err(L1WatcherRpcError::Transport(
+                            "L1 block stream ended unexpectedly".to_string(),
+                        ));
+                    }
+                    Some(new_head) => {
+                        // Send the head update event to all consumers.
+                        let head_block_info = self.block_info_by_hash(new_head).await?;
+                        self.head_sender.send(head_block_info)?;
+                        self.latest_head.send_replace(Some(head_block_info));
+                    },
+                }
+            }
+        }
+    }
+
+    async fn process(&mut self, _msg: Self::InboundEvent) -> Result<(), Self::Error> {
+        // The L1 watcher does not process any incoming messages.
+        Ok(())
+    }
+}
+
+/// The error type for the [L1WatcherRpc].
+#[derive(Error, Debug)]
+pub enum L1WatcherRpcError<T> {
+    /// Error sending the head update event.
+    #[error("Error sending the head update event: {0}")]
+    SendError(#[from] SendError<T>),
+    /// Error in the transport layer.
+    #[error("Transport error: {0}")]
+    Transport(String),
+    /// The L1 block was not found.
+    #[error("L1 block not found: {0}")]
+    L1BlockNotFound(B256),
+    /// Nothing to update.
+    #[error("Nothing to update; L1 head is the same as the last observed head")]
+    NothingToUpdate,
+} 

--- a/crates/supervisor/service/src/actors/mod.rs
+++ b/crates/supervisor/service/src/actors/mod.rs
@@ -1,0 +1,9 @@
+//! [SupervisorActor] services for the supervisor.
+//!
+//! [SupervisorActor]: super::SupervisorActor
+
+mod traits;
+pub use traits::SupervisorActor;
+
+mod l1_watcher_rpc;
+pub use l1_watcher_rpc::{L1WatcherRpc, L1WatcherRpcError};

--- a/crates/supervisor/service/src/actors/traits.rs
+++ b/crates/supervisor/service/src/actors/traits.rs
@@ -1,22 +1,15 @@
-//! This crate contains the core logic for the Optimism Supervisor component.
-
-/// Contains the main Supervisor struct and its implementation.
-mod supervisor;
-pub use supervisor::{Supervisor, SupervisorError, SupervisorService};
-
-mod rpc;
-pub use rpc::SupervisorRpc;
+//! [SupervisorActor] trait.
 
 use async_trait::async_trait;
 
-/// The [NodeActor] is an actor-like service for the supervisor.
+/// The [SupervisorActor] is an actor-like service for the supervisor.
 ///
 /// Actors may:
 /// - Handle incoming messages.
 ///     - Perform background tasks.
 /// - Emit new events for other actors to process.
 #[async_trait]
-pub trait NodeActor {
+pub trait SupervisorActor {
     /// The event type received by the actor.
     type InboundEvent;
     /// The error type for the actor.

--- a/crates/supervisor/service/src/lib.rs
+++ b/crates/supervisor/service/src/lib.rs
@@ -2,4 +2,8 @@
 //! It integrates the core logic with the RPC server.
 
 mod service;
+
 pub use service::{Config, Service};
+
+mod actors;
+pub use actors::{L1WatcherRpc, L1WatcherRpcError, SupervisorActor};


### PR DESCRIPTION
The PR:
- Creates a `SupervisorActor`
- Which watches async for inbound queries
- Returns the state query depending on the input

This is essentially borrowed from `node/service` and omitted the part that was not required.