### PR TITLE
fix(node-p2p): Discovery event metric labels

### DIFF
--- a/crates/node/p2p/src/discv5/driver.rs
+++ b/crates/node/p2p/src/discv5/driver.rs
@@ -366,7 +366,7 @@ impl Discv5Driver {
                             discv5::Event::Discovered(enr) => {
                                 if EnrValidation::validate(&enr, chain_id).is_valid() {
                                     debug!(target: "discovery", "Valid ENR discovered, forwarding to swarm: {:?}", enr);
-                                    kona_macros::inc!(gauge, crate::Metrics::DISCOVERY_EVENT, "discovered", "discovered");
+                                    kona_macros::inc!(gauge, crate::Metrics::DISCOVERY_EVENT, "type", "discovered");
                                     self.store.add_enr(enr.clone());
                                     let sender = enr_sender.clone();
                                     tokio::spawn(async move {
@@ -379,7 +379,7 @@ impl Discv5Driver {
                             discv5::Event::SessionEstablished(enr, addr) => {
                                 if EnrValidation::validate(&enr, chain_id).is_valid() {
                                     debug!(target: "discovery", "Session established with valid ENR, forwarding to swarm. Address: {:?}, ENR: {:?}", addr, enr);
-                                    kona_macros::inc!(gauge, crate::Metrics::DISCOVERY_EVENT, "session_established", "session_established");
+                                    kona_macros::inc!(gauge, crate::Metrics::DISCOVERY_EVENT, "type", "session_established");
                                     self.store.add_enr(enr.clone());
                                     let sender = enr_sender.clone();
                                     tokio::spawn(async move {
@@ -392,7 +392,7 @@ impl Discv5Driver {
                             discv5::Event::UnverifiableEnr { enr, .. } => {
                                 if EnrValidation::validate(&enr, chain_id).is_valid() {
                                     debug!(target: "discovery", "Valid ENR discovered, forwarding to swarm: {:?}", enr);
-                                    kona_macros::inc!(gauge, crate::Metrics::DISCOVERY_EVENT, "unverifiable_enr", "unverifiable_enr");
+                                    kona_macros::inc!(gauge, crate::Metrics::DISCOVERY_EVENT, "type", "unverifiable_enr");
                                     self.store.add_enr(enr.clone());
                                     let sender = enr_sender.clone();
                                     tokio::spawn(async move {

--- a/crates/node/p2p/src/metrics/mod.rs
+++ b/crates/node/p2p/src/metrics/mod.rs
@@ -113,15 +113,9 @@ impl Metrics {
         kona_macros::set!(gauge, Self::UNSAFE_BLOCK_PUBLISHED, 0);
 
         // Discovery Event
-        kona_macros::set!(gauge, Self::DISCOVERY_EVENT, "discovered", "discovered", 0);
-        kona_macros::set!(
-            gauge,
-            Self::DISCOVERY_EVENT,
-            "session_established",
-            "session_established",
-            0
-        );
-        kona_macros::set!(gauge, Self::DISCOVERY_EVENT, "unverifiable_enr", "unverifiable_enr", 0);
+        kona_macros::set!(gauge, Self::DISCOVERY_EVENT, "type", "discovered", 0);
+        kona_macros::set!(gauge, Self::DISCOVERY_EVENT, "type", "session_established", 0);
+        kona_macros::set!(gauge, Self::DISCOVERY_EVENT, "type", "unverifiable_enr", 0);
 
         // Peer Counts
         kona_macros::set!(gauge, Self::GOSSIP_PEER_COUNT, 0);


### PR DESCRIPTION
## Overview

Fixes discovery event metric labels to be keyed under `type`, rather than under several different keys.