### PR TITLE
chore(engine): Remove pending/backup unsafe head

### DIFF
--- a/crates/node/engine/src/state/builder.rs
+++ b/crates/node/engine/src/state/builder.rs
@@ -26,10 +26,6 @@ pub struct EngineStateBuilder {
     unsafe_head: Option<L2BlockInfo>,
     /// Cross-verified unsafe head, always equal to the unsafe head pre-interop
     cross_unsafe_head: Option<L2BlockInfo>,
-    /// Pending local safe head
-    /// L2 block processed from the middle of a span batch,
-    /// but not marked as the safe block yet.
-    pending_safe_head: Option<L2BlockInfo>,
     /// Derived from L1, and known to be a completed span-batch,
     /// but not cross-verified yet.
     local_safe_head: Option<L2BlockInfo>,
@@ -48,7 +44,6 @@ impl EngineStateBuilder {
             sync_status: None,
             unsafe_head: None,
             cross_unsafe_head: None,
-            pending_safe_head: None,
             local_safe_head: None,
             safe_head: None,
             finalized_head: None,
@@ -104,17 +99,14 @@ impl EngineStateBuilder {
 
         let local_safe_head = builder.local_safe_head.unwrap_or(safe_head);
         let cross_unsafe_head = builder.cross_unsafe_head.unwrap_or(safe_head);
-        let pending_safe_head = builder.pending_safe_head.unwrap_or(safe_head);
 
         Ok(EngineState {
             sync_status: builder.sync_status.unwrap_or_default(),
             unsafe_head,
             cross_unsafe_head,
-            pending_safe_head,
             local_safe_head,
             safe_head,
             finalized_head,
-            backup_unsafe_head: None,
             forkchoice_update_needed: false,
             need_fcu_call_backup_unsafe_reorg: false,
         })

--- a/crates/node/engine/src/state/core.rs
+++ b/crates/node/engine/src/state/core.rs
@@ -11,10 +11,6 @@ pub struct EngineState {
     pub(crate) unsafe_head: L2BlockInfo,
     /// Cross-verified unsafe head, always equal to the unsafe head pre-interop
     pub(crate) cross_unsafe_head: L2BlockInfo,
-    /// Pending localSafeHead
-    /// L2 block processed from the middle of a span batch,
-    /// but not marked as the safe block yet.
-    pub(crate) pending_safe_head: L2BlockInfo,
     /// Derived from L1, and known to be a completed span-batch,
     /// but not cross-verified yet.
     pub(crate) local_safe_head: L2BlockInfo,
@@ -23,10 +19,6 @@ pub struct EngineState {
     /// Derived from finalized L1 data,
     /// and cross-verified to only have finalized dependencies.
     pub(crate) finalized_head: L2BlockInfo,
-    /// The unsafe head to roll back to,
-    /// after the pending safe head fails to become safe.
-    /// This is changing in the Holocene fork.
-    pub(crate) backup_unsafe_head: Option<L2BlockInfo>,
 
     /// The [`SyncStatus`] of the engine.
     pub sync_status: SyncStatus,
@@ -84,11 +76,6 @@ impl EngineState {
         self.local_safe_head
     }
 
-    /// Returns the current pending safe head.
-    pub const fn pending_safe_head(&self) -> L2BlockInfo {
-        self.pending_safe_head
-    }
-
     /// Returns the current safe head.
     pub const fn safe_head(&self) -> L2BlockInfo {
         self.safe_head
@@ -97,11 +84,6 @@ impl EngineState {
     /// Returns the current finalized head.
     pub const fn finalized_head(&self) -> L2BlockInfo {
         self.finalized_head
-    }
-
-    /// Returns the current backup unsafe head.
-    pub const fn backup_unsafe_head(&self) -> Option<L2BlockInfo> {
-        self.backup_unsafe_head
     }
 
     /// Set the unsafe head.
@@ -118,11 +100,6 @@ impl EngineState {
             Metrics::CROSS_UNSAFE_BLOCK_LABEL,
             cross_unsafe_head.block_info.number,
         );
-    }
-
-    /// Set the pending safe head.
-    pub fn set_pending_safe_head(&mut self, pending_safe_head: L2BlockInfo) {
-        self.pending_safe_head = pending_safe_head;
     }
 
     /// Set the local safe head.
@@ -149,12 +126,6 @@ impl EngineState {
             Metrics::FINALIZED_BLOCK_LABEL,
             finalized_head.block_info.number,
         );
-    }
-
-    /// Set the backup unsafe head.
-    pub fn set_backup_unsafe_head(&mut self, backup_unsafe_head: L2BlockInfo, reorg: bool) {
-        self.backup_unsafe_head = Some(backup_unsafe_head);
-        self.need_fcu_call_backup_unsafe_reorg = reorg;
     }
 
     /// Updates a block label metric, keyed by the label.

--- a/crates/node/rpc/src/rollup.rs
+++ b/crates/node/rpc/src/rollup.rs
@@ -51,7 +51,6 @@ impl RollupRpc {
             local_safe_l2: l2_sync_status.local_safe_head(),
             safe_l2: l2_sync_status.safe_head(),
             finalized_l2: l2_sync_status.finalized_head(),
-            pending_safe_l2: l2_sync_status.pending_safe_head(),
         }
     }
 }

--- a/crates/protocol/protocol/src/sync.rs
+++ b/crates/protocol/protocol/src/sync.rs
@@ -55,11 +55,6 @@ pub struct SyncStatus {
     /// This points to the L2 block that was derived fully from finalized L1 information, thus
     /// irreversible.
     pub finalized_l2: L2BlockInfo,
-    /// The pending safe L2 block ref.
-    ///
-    /// This points to the L2 block processed from the batch, but not consolidated to the safe
-    /// block yet.
-    pub pending_safe_l2: L2BlockInfo,
     /// Cross unsafe L2 block ref.
     ///
     /// This is an unsafe L2 block, that has been verified to match cross-L2 dependencies.


### PR DESCRIPTION
## Overview

Removes the pending and backup unsafe heads from the `EngineState` to simplify. These were necessary pre-Holocene, and since `kona-node` only supports execution layer sync, it will never actually need this functionality in the wild.