### PR TITLE
feat(node): Retry engine capability handshake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,6 +1411,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "backon"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0b50b1b78dbadd44ab18b3c794e496f3a139abb9fbc27d9c94c4eebbb96496"
+dependencies = [
+ "fastrand",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4656,6 +4666,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "alloy-transport",
  "anyhow",
+ "backon",
  "clap",
  "color-eyre",
  "crossterm 0.29.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,6 +179,7 @@ buddy_system_allocator = "0.11.0"
 
 rand = { version = "0.9.1", default-features = false }
 tabled = { version = "0.19", default-features = false }
+backon = { version = "1.5.0", default-features = false, features = ["std", "tokio", "tokio-sleep"] }
 anyhow = { version = "1.0.98", default-features = false }
 thiserror = { version = "2.0.12", default-features = false }
 derive_more = { version = "2.0.1", default-features = false }

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -45,6 +45,7 @@ crossterm = { workspace = true, features = ["event-stream"] }
 # general
 dirs.workspace = true
 url.workspace = true
+backon.workspace = true
 tokio-stream.workspace = true
 tracing-appender.workspace = true
 discv5.workspace = true


### PR DESCRIPTION
## Overview

Adds a retrying future with an exponential backoff for the initial engine capabilities handshake to validate the JWT secret.

closes #1738 