### PR TITLE
feat(node): Version info metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,6 +1707,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.26",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2311,6 +2343,37 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
  "syn 2.0.101",
 ]
 
@@ -3041,6 +3104,19 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "git2"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
+dependencies = [
+ "bitflags 2.9.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
 
 [[package]]
 name = "glob"
@@ -4539,6 +4615,7 @@ dependencies = [
  "kona-rpc",
  "kona-sources",
  "libp2p",
+ "metrics",
  "op-alloy-provider",
  "rstest",
  "serde_json",
@@ -4548,6 +4625,8 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.19",
  "url",
+ "vergen",
+ "vergen-git2",
 ]
 
 [[package]]
@@ -4945,6 +5024,18 @@ name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.18.1+1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1dcb20f84ffcdd825c7a311ae347cce604a6f084a767dec4a4929829645290e"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -5406,6 +5497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
 dependencies = [
  "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -5939,6 +6031,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -7734,6 +7835,9 @@ name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "semver-parser"
@@ -8351,7 +8455,9 @@ checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -8838,6 +8944,47 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "9.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b2bf58be11fc9414104c6d3a2e464163db5ef74b12296bda593cac37b6e4777"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "derive_builder",
+ "regex",
+ "rustversion",
+ "time",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-git2"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f6ee511ec45098eabade8a0750e76eec671e7fb2d9360c563911336bea9cac1"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "git2",
+ "rustversion",
+ "time",
+ "vergen",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,7 @@ crossterm = "0.29.0"
 color-eyre = "0.6.3"
 jsonrpsee = "0.25.1"
 tokio-util = "0.7.15"
+vergen-git2 = "1.0.0"
 parking_lot = "0.12.3"
 async-trait = "0.1.88"
 tokio-stream = "0.1.17"
@@ -181,6 +182,7 @@ rand = { version = "0.9.1", default-features = false }
 tabled = { version = "0.19", default-features = false }
 backon = { version = "1.5.0", default-features = false, features = ["std", "tokio", "tokio-sleep"] }
 anyhow = { version = "1.0.98", default-features = false }
+vergen = { version = "9.0.0", features = ["build", "cargo", "emit_and_set"] }
 thiserror = { version = "2.0.12", default-features = false }
 derive_more = { version = "2.0.1", default-features = false }
 lazy_static = { version = "1.5.0", default-features = false }

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -48,6 +48,7 @@ discv5.workspace = true
 tabled.workspace = true
 libp2p.workspace = true
 anyhow.workspace = true
+metrics.workspace = true
 tracing.workspace = true
 serde_json = { workspace = true, features = ["std"] }
 jsonrpsee = { workspace = true, features = ["server"] }
@@ -57,3 +58,7 @@ tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
 
 [dev-dependencies]
 rstest.workspace = true
+
+[build-dependencies]
+vergen.workspace = true
+vergen-git2.workspace = true

--- a/bin/node/build.rs
+++ b/bin/node/build.rs
@@ -1,0 +1,92 @@
+//! Derived from [`reth-node-core`][reth-build-script]
+//!
+//! [reth-build-script]: https://github.com/paradigmxyz/reth/blob/805fb1012cd1601c3b4fe9e8ca2d97c96f61355b/crates/node/core/build.rs
+
+#![allow(missing_docs)]
+
+use std::{env, error::Error};
+use vergen::{BuildBuilder, CargoBuilder, Emitter};
+use vergen_git2::Git2Builder;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut emitter = Emitter::default();
+
+    let build_builder = BuildBuilder::default().build_timestamp(true).build()?;
+
+    // Add build timestamp information.
+    emitter.add_instructions(&build_builder)?;
+
+    let cargo_builder = CargoBuilder::default().features(true).target_triple(true).build()?;
+
+    // Add cargo features and target information.
+    emitter.add_instructions(&cargo_builder)?;
+
+    let git_builder =
+        Git2Builder::default().describe(false, true, None).dirty(true).sha(false).build()?;
+
+    // Add commit information.
+    emitter.add_instructions(&git_builder)?;
+
+    emitter.emit_and_set()?;
+    let sha = env::var("VERGEN_GIT_SHA")?;
+    let sha_short = &sha[0..7];
+
+    let is_dirty = env::var("VERGEN_GIT_DIRTY")? == "true";
+    // > git describe --always --tags
+    // if not on a tag: v0.2.0-beta.3-82-g1939939b
+    // if on a tag: v0.2.0-beta.3
+    let not_on_tag = env::var("VERGEN_GIT_DESCRIBE")?.ends_with(&format!("-g{sha_short}"));
+    let version_suffix = if is_dirty || not_on_tag { "-dev" } else { "" };
+    println!("cargo:rustc-env=KONA_NODE_VERSION_SUFFIX={version_suffix}");
+
+    // Set short SHA
+    println!("cargo:rustc-env=VERGEN_GIT_SHA_SHORT={}", &sha[..8]);
+
+    // Set the build profile
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let profile = out_dir.rsplit(std::path::MAIN_SEPARATOR).nth(3).unwrap();
+    println!("cargo:rustc-env=KONA_NODE_BUILD_PROFILE={profile}");
+
+    // Set formatted version strings
+    let pkg_version = env!("CARGO_PKG_VERSION");
+
+    // The short version information for kona-node.
+    // - The latest version from Cargo.toml
+    // - The short SHA of the latest commit.
+    // Example: 0.1.0 (defa64b2)
+    println!("cargo:rustc-env=KONA_NODE_SHORT_VERSION={pkg_version}{version_suffix} ({sha_short})");
+
+    let features = env::var("VERGEN_CARGO_FEATURES")?;
+
+    // LONG_VERSION
+    // The long version information for kona-node.
+    //
+    // - The latest version from Cargo.toml + version suffix (if any)
+    // - The full SHA of the latest commit
+    // - The build datetime
+    // - The build features
+    // - The build profile
+    //
+    // Example:
+    //
+    // ```text
+    // Version: 0.1.0
+    // Commit SHA: defa64b2
+    // Build Timestamp: 2023-05-19T01:47:19.815651705Z
+    // Build Features: jemalloc
+    // Build Profile: maxperf
+    // ```
+    println!("cargo:rustc-env=KONA_NODE_LONG_VERSION_0=Version: {pkg_version}{version_suffix}");
+    println!("cargo:rustc-env=KONA_NODE_LONG_VERSION_1=Commit SHA: {sha}");
+    println!(
+        "cargo:rustc-env=KONA_NODE_LONG_VERSION_2=Build Timestamp: {}",
+        env::var("VERGEN_BUILD_TIMESTAMP")?
+    );
+    println!(
+        "cargo:rustc-env=KONA_NODE_LONG_VERSION_3=Build Features: {}",
+        if features.is_empty() { "no features enabled".to_string() } else { features }
+    );
+    println!("cargo:rustc-env=KONA_NODE_LONG_VERSION_4=Build Profile: {profile}");
+
+    Ok(())
+}

--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -3,6 +3,7 @@
 use crate::{
     commands::{BootstoreCommand, InfoCommand, NetCommand, NodeCommand, RegistryCommand},
     flags::{GlobalArgs, MetricsArgs},
+    version,
 };
 use anyhow::Result;
 use clap::{Parser, Subcommand};
@@ -30,7 +31,14 @@ pub enum Commands {
 
 /// The node CLI.
 #[derive(Parser, Clone, Debug)]
-#[command(author, version, about, styles = cli_styles(), long_about = None)]
+#[command(
+    author,
+    version = version::SHORT_VERSION,
+    long_version = version::LONG_VERSION,
+    about,
+    styles = cli_styles(),
+    long_about = None
+)]
 pub struct Cli {
     /// The subcommand to run.
     #[command(subcommand)]

--- a/bin/node/src/flags/metrics.rs
+++ b/bin/node/src/flags/metrics.rs
@@ -2,10 +2,11 @@
 //!
 //! Specifies the available flags for prometheus metric configuration inside CLI
 
-use std::net::IpAddr;
+use crate::metrics::VersionInfo;
 
 use clap::{Args, arg};
 use kona_cli::init_prometheus_server;
+use std::net::IpAddr;
 
 /// The metric configuration available in CLI
 #[derive(Debug, Clone, Args)]
@@ -46,6 +47,7 @@ impl MetricsArgs {
             init_prometheus_server(self.addr, self.port)?;
             kona_p2p::Metrics::init();
             kona_engine::Metrics::init();
+            VersionInfo::from_build().register_version_metrics();
         }
 
         Ok(())

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -9,6 +9,9 @@
 pub mod cli;
 pub mod commands;
 pub mod flags;
+pub mod metrics;
+
+pub(crate) mod version;
 
 fn main() {
     use clap::Parser;

--- a/bin/node/src/metrics/mod.rs
+++ b/bin/node/src/metrics/mod.rs
@@ -1,0 +1,4 @@
+//! Global metrics for `kona-node`
+
+mod version;
+pub use version::VersionInfo;

--- a/bin/node/src/metrics/version.rs
+++ b/bin/node/src/metrics/version.rs
@@ -1,0 +1,55 @@
+//! [`VersionInfo`] metrics
+//!
+//! Derived from [`reth-node-core`'s type][reth-version-info]
+//!
+//! [reth-version-info]: https://github.com/paradigmxyz/reth/blob/805fb1012cd1601c3b4fe9e8ca2d97c96f61355b/crates/node/metrics/src/version.rs#L6
+
+use metrics::gauge;
+
+/// Contains version information for the application and allows for exposing the contained
+/// information as a prometheus metric.
+#[derive(Debug, Clone)]
+pub struct VersionInfo {
+    /// The version of the application.
+    pub version: &'static str,
+    /// The build timestamp of the application.
+    pub build_timestamp: &'static str,
+    /// The cargo features enabled for the build.
+    pub cargo_features: &'static str,
+    /// The Git SHA of the build.
+    pub git_sha: &'static str,
+    /// The target triple for the build.
+    pub target_triple: &'static str,
+    /// The build profile (e.g., debug or release).
+    pub build_profile: &'static str,
+}
+
+impl VersionInfo {
+    /// Creates a new instance of [`VersionInfo`] from the constants defined in [`crate::version`]
+    /// at compile time.
+    pub const fn from_build() -> Self {
+        Self {
+            version: crate::version::CARGO_PKG_VERSION,
+            build_timestamp: crate::version::VERGEN_BUILD_TIMESTAMP,
+            cargo_features: crate::version::VERGEN_CARGO_FEATURES,
+            git_sha: crate::version::VERGEN_GIT_SHA,
+            target_triple: crate::version::VERGEN_CARGO_TARGET_TRIPLE,
+            build_profile: crate::version::BUILD_PROFILE_NAME,
+        }
+    }
+
+    /// Exposes kona-node's version information over prometheus.
+    pub fn register_version_metrics(&self) {
+        let labels: [(&str, &str); 6] = [
+            ("version", self.version),
+            ("build_timestamp", self.build_timestamp),
+            ("cargo_features", self.cargo_features),
+            ("git_sha", self.git_sha),
+            ("target_triple", self.target_triple),
+            ("build_profile", self.build_profile),
+        ];
+
+        let gauge = gauge!("kona_node_info", &labels);
+        gauge.set(1);
+    }
+}

--- a/bin/node/src/version.rs
+++ b/bin/node/src/version.rs
@@ -1,0 +1,35 @@
+//! Version information for kona-node.
+
+/// The latest version from Cargo.toml.
+pub(crate) const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// The 8 character short SHA of the latest commit.
+pub(crate) const VERGEN_GIT_SHA: &str = env!("VERGEN_GIT_SHA_SHORT");
+
+/// The build timestamp.
+pub(crate) const VERGEN_BUILD_TIMESTAMP: &str = env!("VERGEN_BUILD_TIMESTAMP");
+
+/// The target triple.
+pub(crate) const VERGEN_CARGO_TARGET_TRIPLE: &str = env!("VERGEN_CARGO_TARGET_TRIPLE");
+
+/// The build features.
+pub(crate) const VERGEN_CARGO_FEATURES: &str = env!("VERGEN_CARGO_FEATURES");
+
+/// The short version information for kona-node.
+pub(crate) const SHORT_VERSION: &str = env!("KONA_NODE_SHORT_VERSION");
+
+/// The long version information for kona-node.
+pub(crate) const LONG_VERSION: &str = concat!(
+    env!("KONA_NODE_LONG_VERSION_0"),
+    "\n",
+    env!("KONA_NODE_LONG_VERSION_1"),
+    "\n",
+    env!("KONA_NODE_LONG_VERSION_2"),
+    "\n",
+    env!("KONA_NODE_LONG_VERSION_3"),
+    "\n",
+    env!("KONA_NODE_LONG_VERSION_4")
+);
+
+/// The build profile name.
+pub(crate) const BUILD_PROFILE_NAME: &str = env!("KONA_NODE_BUILD_PROFILE");


### PR DESCRIPTION
## Overview

Adds metrics for the version information of the node, including:
1. The binary version
2. The build timestamp
3. Any bin features enabled
4. The commit sha of the build
5. The target triple of the binary
6. The build profile

Also uses this rich version information for the `clap` version.