### PR TITLE
feat(node): Mark derivation as idle when it yields

### DIFF
--- a/crates/node/service/src/service/validator.rs
+++ b/crates/node/service/src/service/validator.rs
@@ -131,8 +131,8 @@ pub trait ValidatorNodeService {
             engine_l2_safe_rx,
             sync_complete_rx,
             derivation_signal_rx,
-            derived_payload_tx,
             new_head_rx,
+            derived_payload_tx,
             cancellation.clone(),
         );
         let derivation = Some(derivation);


### PR DESCRIPTION
## Overview

When the derivation pipeline yields in order to wait for more data, it should be marked as idle to note that it is not currently expecting an L2 safe head update for the next `step`. This PR implements a flag in the derivation actor to allow for skipping checking if the safe head has updated during event processing while derivation is idle, enabling it to continue progressing once the tip of the safe chain has been reached.