### PR TITLE
fix(engine): Reset with inconsistent chain state

### DIFF
--- a/crates/node/engine/src/task_queue/tasks/consolidate/error.rs
+++ b/crates/node/engine/src/task_queue/tasks/consolidate/error.rs
@@ -17,7 +17,7 @@ pub enum ConsolidateTaskError {
 impl From<ConsolidateTaskError> for EngineTaskError {
     fn from(value: ConsolidateTaskError) -> Self {
         match value {
-            ConsolidateTaskError::MissingUnsafeL2Block(_) => Self::Temporary(Box::new(value)),
+            ConsolidateTaskError::MissingUnsafeL2Block(_) => Self::Reset(Box::new(value)),
             ConsolidateTaskError::FailedToFetchUnsafeL2Block => Self::Temporary(Box::new(value)),
         }
     }

--- a/crates/node/engine/src/task_queue/tasks/consolidate/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/consolidate/task.rs
@@ -37,7 +37,7 @@ impl ConsolidateTask {
     }
 
     /// Executes the [`ForkchoiceTask`] if the attributes match the block.
-    pub async fn execute_forkchoice_task(
+    async fn execute_forkchoice_task(
         &self,
         state: &mut EngineState,
     ) -> Result<(), EngineTaskError> {
@@ -47,7 +47,7 @@ impl ConsolidateTask {
 
     /// Executes a new [`BuildTask`].
     /// This is used when the [`ConsolidateTask`] fails to consolidate the engine state.
-    pub async fn execute_build_task(&self, state: &mut EngineState) -> Result<(), EngineTaskError> {
+    async fn execute_build_task(&self, state: &mut EngineState) -> Result<(), EngineTaskError> {
         let build_task = BuildTask::new(
             self.client.clone(),
             self.cfg.clone(),


### PR DESCRIPTION
## Overview

Changes the `MissingUnsafeL2Block` error to be a `Reset`. In the case where attributes are being compared with the unsafe block they're associated to, and the `needs_consolidation` check returns `true`, we've encountered an inconsistent engine state.