### PR TITLE
fix(node/p2p): Disable Topic Scoring

### DIFF
--- a/bin/node/src/flags/p2p.rs
+++ b/bin/node/src/flags/p2p.rs
@@ -166,6 +166,23 @@ pub struct P2PArgs {
     #[arg(long = "p2p.bootnodes", value_delimiter = ',', env = "KONA_NODE_P2P_BOOTNODES")]
     pub bootnodes: Vec<Enr>,
 
+    /// Optionally enable topic scoring.
+    ///
+    /// Topic scoring is a mechanism to score peers based on their behavior in the gossip network.
+    /// Historically, topic scoring was only enabled for the v1 topic on the OP Stack p2p network
+    /// in the `op-node`. This was a silent bug, and topic scoring is actively being
+    /// [phased out of the `op-node`][out].
+    ///
+    /// This flag is only presented for backwards compatibility and debugging purposes.
+    ///
+    /// [out]: https://github.com/ethereum-optimism/optimism/pull/15719
+    #[arg(
+        long = "p2p.topic-scoring",
+        default_value = "false",
+        env = "KONA_NODE_P2P_TOPIC_SCORING"
+    )]
+    pub topic_scoring: bool,
+
     /// An optional unsafe block signer address.
     ///
     /// By default, this is fetched from the chain config in the superchain-registry using the
@@ -214,6 +231,7 @@ impl Default for P2PArgs {
             peer_redial: None,
             unsafe_block_signer: None,
             discovery_randomize: None,
+            topic_scoring: false,
         }
     }
 }
@@ -391,6 +409,7 @@ impl P2PArgs {
             scoring: self.scoring,
             block_time,
             monitor_peers,
+            topic_scoring: self.topic_scoring,
             bootstore: self.bootstore.clone(),
             redial: self.peer_redial,
             // It is ok to clone here since the config only happens at startup

--- a/crates/node/p2p/src/net/builder.rs
+++ b/crates/node/p2p/src/net/builder.rs
@@ -47,6 +47,7 @@ impl From<Config> for NetworkBuilder {
             .with_peer_scoring(config.scoring)
             .with_block_time(config.block_time)
             .with_keypair(config.keypair)
+            .with_topic_scoring(config.topic_scoring)
             .with_peer_redial(config.redial)
     }
 }
@@ -96,6 +97,11 @@ impl NetworkBuilder {
     /// Sets the peer scoring based on the given [`PeerScoreLevel`].
     pub fn with_peer_scoring(self, level: PeerScoreLevel) -> Self {
         Self { gossip: self.gossip.with_peer_scoring(level), ..self }
+    }
+
+    /// Sets topic scoring for the [`crate::GossipDriver`].
+    pub fn with_topic_scoring(self, topic_scoring: bool) -> Self {
+        Self { gossip: self.gossip.with_topic_scoring(topic_scoring), ..self }
     }
 
     /// Sets the peer monitoring for the [`crate::GossipDriver`].

--- a/crates/node/p2p/src/net/config.rs
+++ b/crates/node/p2p/src/net/config.rs
@@ -30,6 +30,8 @@ pub struct Config {
     pub gossip_config: libp2p::gossipsub::Config,
     /// The peer score level.
     pub scoring: PeerScoreLevel,
+    /// Whether to enable topic scoring.
+    pub topic_scoring: bool,
     /// Peer score monitoring config.
     pub monitor_peers: Option<PeerMonitoring>,
     /// The L2 Block Time.

--- a/crates/node/rpc/src/launcher.rs
+++ b/crates/node/rpc/src/launcher.rs
@@ -109,7 +109,7 @@ mod tests {
     #[tokio::test]
     async fn test_launch_with_modules() {
         let mut launcher = RpcLauncher::new();
-        launcher = launcher.set_addr(SocketAddr::from(([127, 0, 0, 1], 8080)));
+        launcher = launcher.set_addr(SocketAddr::from(([127, 0, 0, 1], 8081)));
         launcher = launcher.merge(Some(RpcModule::new(()))).expect("module merge");
         launcher = launcher.merge::<()>(None).expect("module merge");
         launcher = launcher.merge(Some(RpcModule::new(()))).expect("module merge");


### PR DESCRIPTION
### Description

Disables topic scoring for all topics like https://github.com/ethereum-optimism/optimism/pull/15719.

Previously the `kona-node` deviated from `op-node` policy on topic scoring. It scored all topics (v1 - v4). The `op-node` only scored the `v1` topic.