### PR TITLE
fix(p2p): Discv5 startup panic

### DIFF
--- a/crates/node/p2p/src/discv5/driver.rs
+++ b/crates/node/p2p/src/discv5/driver.rs
@@ -119,7 +119,6 @@ impl Discv5Driver {
         }
             .retry(ExponentialBuilder::default())
             .context(self)
-            .sleep(sleep)
             .notify(|err: &discv5::Error, dur: Duration| {
                 warn!(target: "discovery", ?err, "Failed to start discovery service [Duration: {:?}]", dur);
             })


### PR DESCRIPTION
## Overview

Fixes the panic in the discv5 driver startup. `backon`'s `RetryableWithContext` has a quirk where it will panic if the `sleep` function is set after `context`. We can just remove it, though, since we've enabled the `tokio-sleep` feature by default.