### PR TITLE
fix(bin/node): Argument Defaults

### DIFF
--- a/bin/node/src/commands/node.rs
+++ b/bin/node/src/commands/node.rs
@@ -150,6 +150,7 @@ impl NodeCommand {
         let jwt_secret = self.validate_jwt(&cfg).await?;
 
         self.p2p_flags.check_ports()?;
+        let disabled = self.p2p_flags.disabled;
         let p2p_config = self.p2p_flags.config(&cfg, args, Some(self.l1_eth_rpc.clone())).await?;
         let rpc_config = self.rpc_flags.into();
 
@@ -164,7 +165,7 @@ impl NodeCommand {
             .with_l2_engine_rpc_url(self.l2_engine_rpc)
             .with_runtime_load_interval(runtime_interval)
             .with_p2p_config(p2p_config)
-            .with_network_disabled(self.p2p_flags.disabled)
+            .with_network_disabled(disabled)
             .with_rpc_config(rpc_config)
             .build()
             .start()

--- a/bin/node/src/flags/metrics.rs
+++ b/bin/node/src/flags/metrics.rs
@@ -4,12 +4,12 @@
 
 use crate::metrics::VersionInfo;
 
-use clap::{Args, arg};
+use clap::{Parser, arg};
 use kona_cli::init_prometheus_server;
 use std::net::IpAddr;
 
 /// The metric configuration available in CLI
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Parser)]
 pub struct MetricsArgs {
     /// Controls whether prometheus metrics are enabled.
     /// Disabled by default.
@@ -36,6 +36,14 @@ pub struct MetricsArgs {
         env = "KONA_NODE_METRICS_ADDR"
     )]
     pub addr: IpAddr,
+}
+
+impl Default for MetricsArgs {
+    fn default() -> Self {
+        // Construct default values using the clap parser.
+        // This works since none of the cli flags are required.
+        Self::parse_from::<[_; 0], &str>([])
+    }
 }
 
 impl MetricsArgs {

--- a/bin/node/src/flags/p2p.rs
+++ b/bin/node/src/flags/p2p.rs
@@ -14,7 +14,7 @@ use kona_p2p::{Config, LocalNode, PeerMonitoring, PeerScoreLevel};
 use kona_sources::RuntimeLoader;
 use libp2p::identity::Keypair;
 use std::{
-    net::{IpAddr, Ipv4Addr, SocketAddr},
+    net::{IpAddr, SocketAddr},
     num::ParseIntError,
     path::PathBuf,
     sync::Arc,
@@ -185,36 +185,9 @@ pub struct P2PArgs {
 
 impl Default for P2PArgs {
     fn default() -> Self {
-        Self {
-            disabled: false,
-            no_discovery: false,
-            priv_path: None,
-            private_key: None,
-            advertise_ip: None,
-            advertise_tcp_port: 0,
-            advertise_udp_port: 0,
-            listen_ip: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-            listen_tcp_port: 9222,
-            listen_udp_port: 9223,
-            peers_lo: 20,
-            peers_hi: 30,
-            peers_grace: Duration::from_secs(30),
-            gossip_mesh_d: kona_p2p::DEFAULT_MESH_D,
-            gossip_mesh_dlo: kona_p2p::DEFAULT_MESH_DLO,
-            gossip_mesh_dhi: kona_p2p::DEFAULT_MESH_DHI,
-            gossip_mesh_dlazy: kona_p2p::DEFAULT_MESH_DLAZY,
-            gossip_flood_publish: false,
-            scoring: PeerScoreLevel::Light,
-            ban_enabled: false,
-            ban_threshold: 0,
-            ban_duration: 30,
-            discovery_interval: 5,
-            bootnodes: Vec::new(),
-            bootstore: None,
-            peer_redial: None,
-            unsafe_block_signer: None,
-            discovery_randomize: None,
-        }
+        // Construct default values using the clap parser.
+        // This works since none of the cli flags are required.
+        Self::parse_from::<[_; 0], &str>([])
     }
 }
 
@@ -319,7 +292,7 @@ impl P2PArgs {
     ///
     /// Errors if the genesis unsafe block signer isn't available for the specified L2 Chain ID.
     pub async fn config(
-        &self,
+        self,
         config: &RollupConfig,
         args: &GlobalArgs,
         l1_rpc: Option<Url>,
@@ -391,12 +364,9 @@ impl P2PArgs {
             scoring: self.scoring,
             block_time,
             monitor_peers,
-            bootstore: self.bootstore.clone(),
+            bootstore: self.bootstore,
             redial: self.peer_redial,
-            // It is ok to clone here since the config only happens at startup
-            // and that we assume the number of bootnodes explicitly specified
-            // through the CLI is small.
-            bootnodes: self.bootnodes.clone(),
+            bootnodes: self.bootnodes,
             rollup_config: config.clone(),
         })
     }

--- a/bin/node/src/flags/rpc.rs
+++ b/bin/node/src/flags/rpc.rs
@@ -4,10 +4,7 @@
 
 use clap::Parser;
 use kona_rpc::RpcConfig;
-use std::{
-    net::{IpAddr, Ipv4Addr},
-    path::PathBuf,
-};
+use std::{net::IpAddr, path::PathBuf};
 
 /// RPC CLI Arguments
 #[derive(Parser, Debug, Clone, PartialEq, Eq)]
@@ -32,13 +29,9 @@ pub struct RpcArgs {
 
 impl Default for RpcArgs {
     fn default() -> Self {
-        Self {
-            rpc_disabled: false,
-            listen_addr: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-            listen_port: 9545,
-            enable_admin: false,
-            admin_persistence: None,
-        }
+        // Construct default values using the clap parser.
+        // This works since none of the cli flags are required.
+        Self::parse_from::<[_; 0], &str>([])
     }
 }
 
@@ -64,6 +57,7 @@ impl From<RpcArgs> for RpcConfig {
 mod tests {
     use super::*;
     use rstest::rstest;
+    use std::net::Ipv4Addr;
 
     #[rstest]
     #[case::disable_rpc(&["--rpc.disabled"], |args: &mut RpcArgs| { args.rpc_disabled = true; })]

--- a/bin/node/src/flags/sequencer.rs
+++ b/bin/node/src/flags/sequencer.rs
@@ -40,6 +40,8 @@ pub struct SequencerArgs {
 
 impl Default for SequencerArgs {
     fn default() -> Self {
-        Self { enabled: false, stopped: false, max_safe_lag: 0, l1_confs: 4, recover: false }
+        // Construct default values using the clap parser.
+        // This works since none of the cli flags are required.
+        Self::parse_from::<[_; 0], &str>([])
     }
 }


### PR DESCRIPTION
### Description

Instead of redefining the argument defaults, use the values defined in the clap fields.