### PR TITLE
chore(deps): Bump alloy deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,31 +118,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c3f3bc4f2a6b725970cd354e78e9738ea1e8961a91898f57bf6317970b1915"
-dependencies = [
- "alloy-eips 0.15.11",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.15.11",
- "alloy-trie",
- "arbitrary",
- "auto_impl",
- "c-kzg",
- "derive_more",
- "either",
- "k256",
- "once_cell",
- "rand 0.8.5",
- "secp256k1 0.30.0",
- "serde",
- "serde_with",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "alloy-consensus"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5af9455152b18b9efc329120c85006705862a21786449e425eb714d0c04bbfda"
@@ -168,25 +143,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda014fb5591b8d8d24cab30f52690117d238e52254c6fb40658e91ea2ccd6c3"
-dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-eips 0.15.11",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.15.11",
- "serde",
-]
-
-[[package]]
-name = "alloy-consensus-any"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9256691696deb28fd71ca6b698d958e80abe5dd0ed95f8e96ac55076b4a70e95"
 dependencies = [
- "alloy-consensus 1.0.1",
+ "alloy-consensus",
  "alloy-eips 1.0.1",
  "alloy-primitives",
  "alloy-rlp",
@@ -260,27 +221,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7b2f7010581f29bcace81776cf2f0e022008d05a7d326884763f16f3044620"
-dependencies = [
- "alloy-eip2124",
- "alloy-eip2930",
- "alloy-eip7702",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.15.11",
- "arbitrary",
- "auto_impl",
- "c-kzg",
- "derive_more",
- "either",
- "serde",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "alloy-eips"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a3ecb56e34e1c3dca4aa06b653c96f0f381a67e0d353271949c683fba5ecbd4"
@@ -304,18 +244,18 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7263f5a79a16743b33237017097886d7bd62d4d32eebe64f22e0a7c7ba70f4"
+checksum = "398be19900ac9fe2ad7214ac7bd6462fd9ae2e0366a3b5d532213e8353713b7d"
 dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-eips 0.15.11",
+ "alloy-consensus",
+ "alloy-eips 1.0.1",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
- "op-alloy-consensus 0.15.7",
+ "op-alloy-consensus",
  "op-revm",
  "revm",
  "thiserror 2.0.12",
@@ -348,20 +288,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca1e31b50f4ed9a83689ae97263d366b15b935a67c4acb5dd46d5b1c3b27e8e6"
-dependencies = [
- "alloy-primitives",
- "alloy-sol-types",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
- "tracing",
-]
-
-[[package]]
-name = "alloy-json-rpc"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b22b5e5872d5ece9df2411a65637af3bfc5ce868ddf392cb91ce9a0c7cb1b30"
@@ -376,46 +302,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879afc0f4a528908c8fe6935b2ab0bc07f77221a989186f71583f7592831689e"
-dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-consensus-any 0.15.11",
- "alloy-eips 0.15.11",
- "alloy-json-rpc 0.15.11",
- "alloy-network-primitives 0.15.11",
- "alloy-primitives",
- "alloy-rpc-types-any 0.15.11",
- "alloy-rpc-types-eth 0.15.11",
- "alloy-serde 0.15.11",
- "alloy-signer 0.15.11",
- "alloy-sol-types",
- "async-trait",
- "auto_impl",
- "derive_more",
- "futures-utils-wasm",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "alloy-network"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8a707ccae2aaca8fb64cec54904c1fdce6be5c5d5be24a7ae04e6a393cb62e"
 dependencies = [
- "alloy-consensus 1.0.1",
- "alloy-consensus-any 1.0.1",
+ "alloy-consensus",
+ "alloy-consensus-any",
  "alloy-eips 1.0.1",
- "alloy-json-rpc 1.0.1",
- "alloy-network-primitives 1.0.1",
+ "alloy-json-rpc",
+ "alloy-network-primitives",
  "alloy-primitives",
- "alloy-rpc-types-any 1.0.1",
- "alloy-rpc-types-eth 1.0.1",
+ "alloy-rpc-types-any",
+ "alloy-rpc-types-eth",
  "alloy-serde 1.0.1",
- "alloy-signer 1.0.1",
+ "alloy-signer",
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
@@ -424,19 +324,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.12",
-]
-
-[[package]]
-name = "alloy-network-primitives"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec185bac9d32df79c1132558a450d48f6db0bfb5adef417dbb1a0258153f879b"
-dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-eips 0.15.11",
- "alloy-primitives",
- "alloy-serde 0.15.11",
- "serde",
 ]
 
 [[package]]
@@ -445,7 +332,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d27be7a0d29a77b2568c105e5418736da5555026a4b054ea2e3b549a0a9645b"
 dependencies = [
- "alloy-consensus 1.0.1",
+ "alloy-consensus",
  "alloy-eips 1.0.1",
  "alloy-primitives",
  "alloy-serde 1.0.1",
@@ -454,17 +341,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-op-evm"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2379a87a3018a563a0524002caed789ac832a8ae8ff0270189559dccf8e49ae9"
+checksum = "e7a290b11f3a3e0a34d09c5ef55afe7ec91890824b8daf73b1a99c152f6ad94c"
 dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-eips 0.15.11",
+ "alloy-consensus",
+ "alloy-eips 1.0.1",
  "alloy-evm",
  "alloy-op-hardforks",
  "alloy-primitives",
  "auto_impl",
- "op-alloy-consensus 0.15.7",
+ "op-alloy-consensus",
  "op-revm",
  "revm",
 ]
@@ -512,24 +399,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.15.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2d918534afe9cc050eabd8309c107dafd161aa77357782eca4f218bef08a660"
+checksum = "064d72578caba01fc1d04e8119dbfac36f7cc3b0b9c65804f2282482d55c4904"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 0.15.11",
- "alloy-eips 0.15.11",
- "alloy-json-rpc 0.15.11",
- "alloy-network 0.15.11",
- "alloy-network-primitives 0.15.11",
+ "alloy-consensus",
+ "alloy-eips 1.0.1",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-network-primitives",
  "alloy-primitives",
  "alloy-pubsub",
- "alloy-rpc-client 0.15.11",
- "alloy-rpc-types-engine 0.15.11",
- "alloy-rpc-types-eth 0.15.11",
- "alloy-signer 0.15.11",
+ "alloy-rpc-client",
+ "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
  "alloy-sol-types",
- "alloy-transport 0.15.11",
+ "alloy-transport",
  "alloy-transport-http",
  "alloy-transport-ipc",
  "alloy-transport-ws",
@@ -554,50 +441,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-provider"
+name = "alloy-pubsub"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064d72578caba01fc1d04e8119dbfac36f7cc3b0b9c65804f2282482d55c4904"
+checksum = "071721a7fbe5fa0b7e0391c4ff8b5919a9f9866944cd8608dcb893d846e7087d"
 dependencies = [
- "alloy-chains",
- "alloy-consensus 1.0.1",
- "alloy-eips 1.0.1",
- "alloy-json-rpc 1.0.1",
- "alloy-network 1.0.1",
- "alloy-network-primitives 1.0.1",
+ "alloy-json-rpc",
  "alloy-primitives",
- "alloy-rpc-client 1.0.1",
- "alloy-rpc-types-eth 1.0.1",
- "alloy-signer 1.0.1",
- "alloy-sol-types",
- "alloy-transport 1.0.1",
- "async-stream",
- "async-trait",
- "auto_impl",
- "dashmap",
- "either",
- "futures",
- "futures-utils-wasm",
- "lru 0.13.0",
- "parking_lot",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
- "tokio",
- "tracing",
- "wasmtimer",
-]
-
-[[package]]
-name = "alloy-pubsub"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d77a92001c6267261a5e493d33db794b2206ebebf7c2dfbbe3825ebaec6a96d"
-dependencies = [
- "alloy-json-rpc 0.15.11",
- "alloy-primitives",
- "alloy-transport 0.15.11",
+ "alloy-transport",
  "bimap",
  "futures",
  "parking_lot",
@@ -634,14 +485,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.15.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15e30dcada47c04820b64f63de2423506c5c74f9ab59b115277ef5ad595a6fc"
+checksum = "8cb00c4260ca83980422fc4a44658aafe50ad7b7ad43fb21523bd53453cfd202"
 dependencies = [
- "alloy-json-rpc 0.15.11",
+ "alloy-json-rpc",
  "alloy-primitives",
  "alloy-pubsub",
- "alloy-transport 0.15.11",
+ "alloy-transport",
  "alloy-transport-http",
  "alloy-transport-ipc",
  "alloy-transport-ws",
@@ -661,49 +512,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-rpc-client"
+name = "alloy-rpc-types"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb00c4260ca83980422fc4a44658aafe50ad7b7ad43fb21523bd53453cfd202"
-dependencies = [
- "alloy-json-rpc 1.0.1",
- "alloy-primitives",
- "alloy-transport 1.0.1",
- "async-stream",
- "futures",
- "pin-project",
- "serde",
- "serde_json",
- "tokio",
- "tokio-stream",
- "tower",
- "tracing",
- "tracing-futures",
- "wasmtimer",
-]
-
-[[package]]
-name = "alloy-rpc-types"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa10e26554ad7f79a539a6a8851573aedec5289f1f03244aad0bdbc324bfe5c"
+checksum = "eac9e3abe5083df822304ac63664873c988e427a27215b2ce328ee5a2a51bfbd"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-debug",
- "alloy-rpc-types-eth 0.15.11",
- "alloy-serde 0.15.11",
+ "alloy-rpc-types-eth",
+ "alloy-serde 1.0.1",
  "serde",
-]
-
-[[package]]
-name = "alloy-rpc-types-any"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5a8f1efd77116915dad61092f9ef9295accd0b0b251062390d9c4e81599344"
-dependencies = [
- "alloy-consensus-any 0.15.11",
- "alloy-rpc-types-eth 0.15.11",
- "alloy-serde 0.15.11",
 ]
 
 [[package]]
@@ -712,20 +530,20 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8740d1e374cf177f5e94ee694cbbca5d0435c3e8a6d4e908841e9cfc5247e2"
 dependencies = [
- "alloy-consensus-any 1.0.1",
- "alloy-rpc-types-eth 1.0.1",
+ "alloy-consensus-any",
+ "alloy-rpc-types-eth",
  "alloy-serde 1.0.1",
 ]
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "0.15.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7b4a021b4daff504208b3b43a25270d0a5a27490d6535655052f32c419ba0a"
+checksum = "d0540c6ac1169f687a6d04be56ac3afd49c945b7f275375ff93e2999a9f5073c"
 dependencies = [
- "alloy-eips 0.15.11",
+ "alloy-eips 1.0.1",
  "alloy-primitives",
- "alloy-rpc-types-engine 0.15.11",
+ "alloy-rpc-types-engine",
  "serde",
  "serde_with",
  "thiserror 2.0.12",
@@ -733,30 +551,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "0.15.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c142af843da7422e5e979726dcfeb78064949fdc6cb651457cc95034806a52"
+checksum = "5db15952f375ba2295124c52bcf893c72fd87091198a781b2bf10c4dd8c79249"
 dependencies = [
  "alloy-primitives",
  "serde",
-]
-
-[[package]]
-name = "alloy-rpc-types-engine"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246c225f878dbcb8ad405949a30c403b3bb43bdf974f7f0331b276f835790a5e"
-dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-eips 0.15.11",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.15.11",
- "derive_more",
- "jsonwebtoken",
- "rand 0.8.5",
- "serde",
- "strum",
 ]
 
 [[package]]
@@ -765,7 +565,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "738a62884dcf024b244411cf124cb514a06cdd41d27c9ae898c45ca01a161e0e"
 dependencies = [
- "alloy-consensus 1.0.1",
+ "alloy-consensus",
  "alloy-eips 1.0.1",
  "alloy-primitives",
  "alloy-rlp",
@@ -773,29 +573,10 @@ dependencies = [
  "derive_more",
  "ethereum_ssz",
  "ethereum_ssz_derive",
+ "jsonwebtoken",
  "rand 0.8.5",
  "serde",
  "strum",
-]
-
-[[package]]
-name = "alloy-rpc-types-eth"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc1323310d87f9d950fb3ff58d943fdf832f5e10e6f902f405c0eaa954ffbaf1"
-dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-consensus-any 0.15.11",
- "alloy-eips 0.15.11",
- "alloy-network-primitives 0.15.11",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.15.11",
- "alloy-sol-types",
- "itertools 0.14.0",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -804,10 +585,10 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc2bbc0385aac988551f747c050d5bd1b2b9dd59eabaebf063edbb6a41b2ccb"
 dependencies = [
- "alloy-consensus 1.0.1",
- "alloy-consensus-any 1.0.1",
+ "alloy-consensus",
+ "alloy-consensus-any",
  "alloy-eips 1.0.1",
- "alloy-network-primitives 1.0.1",
+ "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde 1.0.1",
@@ -832,18 +613,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05ace2ef3da874544c3ffacfd73261cdb1405d8631765deb991436a53ec6069"
-dependencies = [
- "alloy-primitives",
- "arbitrary",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "alloy-serde"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071c74effe6ad192dde40cbd4da49784c946561dec6679f73665337c6cf72316"
@@ -852,21 +621,6 @@ dependencies = [
  "arbitrary",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "alloy-signer"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fdabad99ad3c71384867374c60bcd311fc1bb90ea87f5f9c779fd8c7ec36aa"
-dependencies = [
- "alloy-primitives",
- "async-trait",
- "auto_impl",
- "either",
- "elliptic-curve",
- "k256",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -957,34 +711,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6964d85cd986cfc015b96887b89beed9e06d0d015b75ee2b7bfbd64341aab874"
-dependencies = [
- "alloy-json-rpc 0.15.11",
- "alloy-primitives",
- "base64",
- "derive_more",
- "futures",
- "futures-utils-wasm",
- "parking_lot",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
- "tokio",
- "tower",
- "tracing",
- "url",
- "wasmtimer",
-]
-
-[[package]]
-name = "alloy-transport"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f5564661f166792da89d9a6785ff815e44853436637842c59ab48393c4c2fad"
 dependencies = [
- "alloy-json-rpc 1.0.1",
+ "alloy-json-rpc",
  "alloy-primitives",
  "base64",
  "derive_more",
@@ -1003,13 +734,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.15.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef7c5ea7bda4497abe4ea92dcb8c76e9f052c178f3c82aa6976bcb264675f73c"
+checksum = "14c2bba49856a38b54b9134f1fc218fc67d1b1313c16a310514f3b10110559fc"
 dependencies = [
- "alloy-json-rpc 0.15.11",
- "alloy-rpc-types-engine 0.15.11",
- "alloy-transport 0.15.11",
+ "alloy-json-rpc",
+ "alloy-rpc-types-engine",
+ "alloy-transport",
  "http-body-util",
  "hyper",
  "hyper-tls",
@@ -1024,13 +755,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "0.15.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c506a002d77e522ccab7b7068089a16e24694ea04cb89c0bfecf3cc3603fccf"
+checksum = "e9d919bfc40fd92a628561a2053aa68a8e6a994cae65207a086d2672b4f13276"
 dependencies = [
- "alloy-json-rpc 0.15.11",
+ "alloy-json-rpc",
  "alloy-pubsub",
- "alloy-transport 0.15.11",
+ "alloy-transport",
  "bytes",
  "futures",
  "interprocess",
@@ -1044,12 +775,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "0.15.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ff1bb1182601fa5e7b0f8bac03dcd496441ed23859387731462b17511c6680"
+checksum = "802de53990270861acf00044837794ea2450ccc3d9795e824a5d865633241a23"
 dependencies = [
  "alloy-pubsub",
- "alloy-transport 0.15.11",
+ "alloy-transport",
  "futures",
  "http 1.3.1",
  "rustls",
@@ -3309,15 +3040,16 @@ checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
 name = "generator"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bd114ceda131d3b1d665eba35788690ad37f5916457286b32ab6fd3c438dd"
+checksum = "d18470a76cb7f8ff746cf1f7470914f900252ec36bbc40b569d74b1258446827"
 dependencies = [
+ "cc",
  "cfg-if",
  "libc",
  "log",
  "rustversion",
- "windows 0.58.0",
+ "windows 0.61.1",
 ]
 
 [[package]]
@@ -4391,13 +4123,13 @@ dependencies = [
 name = "kona-client"
 version = "1.0.1"
 dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-eips 0.15.11",
+ "alloy-consensus",
+ "alloy-eips 1.0.1",
  "alloy-evm",
  "alloy-op-evm",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-engine 0.15.11",
+ "alloy-rpc-types-engine",
  "async-trait",
  "cfg-if",
  "kona-derive",
@@ -4414,7 +4146,7 @@ dependencies = [
  "kona-std-fpvm",
  "kona-std-fpvm-proc",
  "lru 0.14.0",
- "op-alloy-consensus 0.16.0",
+ "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
  "op-revm",
  "revm",
@@ -4432,12 +4164,12 @@ name = "kona-comp"
 version = "0.3.0"
 dependencies = [
  "alloc-no-stdlib",
- "alloy-consensus 0.15.11",
- "alloy-eips 0.15.11",
+ "alloy-consensus",
+ "alloy-eips 1.0.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-engine 0.15.11",
- "alloy-serde 0.15.11",
+ "alloy-rpc-types-engine",
+ "alloy-serde 1.0.1",
  "alloy-sol-types",
  "arbitrary",
  "async-trait",
@@ -4446,7 +4178,7 @@ dependencies = [
  "kona-genesis",
  "kona-protocol",
  "miniz_oxide",
- "op-alloy-consensus 0.16.0",
+ "op-alloy-consensus",
  "proptest",
  "rand 0.9.1",
  "serde",
@@ -4462,18 +4194,18 @@ dependencies = [
 name = "kona-derive"
 version = "0.3.0"
 dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-eips 0.15.11",
+ "alloy-consensus",
+ "alloy-eips 1.0.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-engine 0.15.11",
+ "alloy-rpc-types-engine",
  "async-trait",
  "kona-derive",
  "kona-genesis",
  "kona-hardforks",
  "kona-protocol",
  "kona-registry",
- "op-alloy-consensus 0.16.0",
+ "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
  "proptest",
  "serde",
@@ -4489,7 +4221,7 @@ dependencies = [
 name = "kona-driver"
 version = "0.3.0"
 dependencies = [
- "alloy-consensus 0.15.11",
+ "alloy-consensus",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -4498,7 +4230,7 @@ dependencies = [
  "kona-executor",
  "kona-genesis",
  "kona-protocol",
- "op-alloy-consensus 0.16.0",
+ "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
  "spin 0.10.0",
  "thiserror 2.0.12",
@@ -4509,16 +4241,16 @@ dependencies = [
 name = "kona-engine"
 version = "0.1.0"
 dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-eips 0.15.11",
- "alloy-network 0.15.11",
- "alloy-network-primitives 0.15.11",
+ "alloy-consensus",
+ "alloy-eips 1.0.1",
+ "alloy-network",
+ "alloy-network-primitives",
  "alloy-primitives",
- "alloy-provider 0.15.11",
- "alloy-rpc-client 0.15.11",
- "alloy-rpc-types-engine 0.15.11",
- "alloy-rpc-types-eth 0.15.11",
- "alloy-transport 0.15.11",
+ "alloy-provider",
+ "alloy-rpc-client",
+ "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
+ "alloy-transport",
  "alloy-transport-http",
  "arbitrary",
  "async-trait",
@@ -4530,7 +4262,7 @@ dependencies = [
  "kona-registry",
  "metrics",
  "metrics-exporter-prometheus",
- "op-alloy-consensus 0.16.0",
+ "op-alloy-consensus",
  "op-alloy-network",
  "op-alloy-provider",
  "op-alloy-rpc-types",
@@ -4551,17 +4283,17 @@ dependencies = [
 name = "kona-executor"
 version = "0.3.0"
 dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-eips 0.15.11",
+ "alloy-consensus",
+ "alloy-eips 1.0.1",
  "alloy-evm",
  "alloy-op-evm",
  "alloy-op-hardforks",
  "alloy-primitives",
- "alloy-provider 0.15.11",
+ "alloy-provider",
  "alloy-rlp",
- "alloy-rpc-client 0.15.11",
- "alloy-rpc-types-engine 0.15.11",
- "alloy-transport 0.15.11",
+ "alloy-rpc-client",
+ "alloy-rpc-types-engine",
+ "alloy-transport",
  "alloy-transport-http",
  "alloy-trie",
  "kona-executor",
@@ -4569,7 +4301,7 @@ dependencies = [
  "kona-mpt",
  "kona-protocol",
  "kona-registry",
- "op-alloy-consensus 0.16.0",
+ "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
  "op-revm",
  "rand 0.9.1",
@@ -4588,8 +4320,8 @@ dependencies = [
 name = "kona-genesis"
 version = "0.3.0"
 dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-eips 0.15.11",
+ "alloy-consensus",
+ "alloy-eips 1.0.1",
  "alloy-hardforks",
  "alloy-op-hardforks",
  "alloy-primitives",
@@ -4610,10 +4342,10 @@ dependencies = [
 name = "kona-hardforks"
 version = "0.3.0"
 dependencies = [
- "alloy-eips 0.15.11",
+ "alloy-eips 1.0.1",
  "alloy-primitives",
  "kona-protocol",
- "op-alloy-consensus 0.16.0",
+ "op-alloy-consensus",
  "op-revm",
  "revm",
 ]
@@ -4622,17 +4354,17 @@ dependencies = [
 name = "kona-host"
 version = "1.0.1"
 dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-eips 0.15.11",
+ "alloy-consensus",
+ "alloy-eips 1.0.1",
  "alloy-op-evm",
  "alloy-primitives",
- "alloy-provider 0.15.11",
+ "alloy-provider",
  "alloy-rlp",
- "alloy-rpc-client 0.15.11",
+ "alloy-rpc-client",
  "alloy-rpc-types",
  "alloy-rpc-types-beacon",
- "alloy-serde 0.15.11",
- "alloy-transport 0.15.11",
+ "alloy-serde 1.0.1",
+ "alloy-transport",
  "alloy-transport-http",
  "anyhow",
  "ark-ff 0.5.0",
@@ -4670,8 +4402,8 @@ dependencies = [
 name = "kona-interop"
 version = "0.3.0"
 dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-eips 0.15.11",
+ "alloy-consensus",
+ "alloy-eips 1.0.1",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-sol-types",
@@ -4681,7 +4413,7 @@ dependencies = [
  "kona-genesis",
  "kona-protocol",
  "kona-registry",
- "op-alloy-consensus 0.16.0",
+ "op-alloy-consensus",
  "rand 0.9.1",
  "serde",
  "serde_json",
@@ -4698,9 +4430,9 @@ version = "0.1.0"
 name = "kona-mpt"
 version = "0.2.0"
 dependencies = [
- "alloy-consensus 0.15.11",
+ "alloy-consensus",
  "alloy-primitives",
- "alloy-provider 0.15.11",
+ "alloy-provider",
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-transport-http",
@@ -4721,9 +4453,9 @@ name = "kona-node"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
- "alloy-provider 0.15.11",
- "alloy-rpc-types-engine 0.15.11",
- "alloy-transport 0.15.11",
+ "alloy-provider",
+ "alloy-rpc-types-engine",
+ "alloy-transport",
  "anyhow",
  "backon",
  "clap",
@@ -4760,13 +4492,13 @@ dependencies = [
 name = "kona-node-service"
 version = "0.1.0"
 dependencies = [
- "alloy-eips 0.15.11",
+ "alloy-eips 1.0.1",
  "alloy-primitives",
- "alloy-provider 0.15.11",
- "alloy-rpc-client 0.15.11",
- "alloy-rpc-types-engine 0.15.11",
- "alloy-rpc-types-eth 0.15.11",
- "alloy-transport 0.15.11",
+ "alloy-provider",
+ "alloy-rpc-client",
+ "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
+ "alloy-transport",
  "alloy-transport-http",
  "async-trait",
  "derive_more",
@@ -4797,11 +4529,11 @@ dependencies = [
 name = "kona-p2p"
 version = "0.1.0"
 dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-eips 0.15.11",
+ "alloy-consensus",
+ "alloy-eips 1.0.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-engine 0.15.11",
+ "alloy-rpc-types-engine",
  "arbitrary",
  "arbtest",
  "derive_more",
@@ -4816,7 +4548,7 @@ dependencies = [
  "libp2p-identity",
  "metrics",
  "multihash",
- "op-alloy-consensus 0.16.0",
+ "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
  "openssl",
  "rand 0.9.1",
@@ -4850,8 +4582,8 @@ dependencies = [
 name = "kona-proof"
 version = "0.3.0"
 dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-eips 0.15.11",
+ "alloy-consensus",
+ "alloy-eips 1.0.1",
  "alloy-evm",
  "alloy-op-evm",
  "alloy-primitives",
@@ -4871,7 +4603,7 @@ dependencies = [
  "kona-registry",
  "lazy_static",
  "lru 0.14.0",
- "op-alloy-consensus 0.16.0",
+ "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
  "op-revm",
  "rand 0.9.1",
@@ -4889,13 +4621,13 @@ dependencies = [
 name = "kona-proof-interop"
 version = "0.2.0"
 dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-eips 0.15.11",
+ "alloy-consensus",
+ "alloy-eips 1.0.1",
  "alloy-evm",
  "alloy-op-evm",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-engine 0.15.11",
+ "alloy-rpc-types-engine",
  "arbitrary",
  "async-trait",
  "kona-executor",
@@ -4906,7 +4638,7 @@ dependencies = [
  "kona-proof",
  "kona-protocol",
  "kona-registry",
- "op-alloy-consensus 0.16.0",
+ "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
  "op-revm",
  "rand 0.9.1",
@@ -4923,13 +4655,13 @@ name = "kona-protocol"
 version = "0.3.0"
 dependencies = [
  "alloc-no-stdlib",
- "alloy-consensus 0.15.11",
- "alloy-eips 0.15.11",
+ "alloy-consensus",
+ "alloy-eips 1.0.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-engine 0.15.11",
- "alloy-rpc-types-eth 0.15.11",
- "alloy-serde 0.15.11",
+ "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
+ "alloy-serde 1.0.1",
  "alloy-sol-types",
  "arbitrary",
  "async-trait",
@@ -4938,7 +4670,7 @@ dependencies = [
  "kona-genesis",
  "kona-protocol",
  "miniz_oxide",
- "op-alloy-consensus 0.16.0",
+ "op-alloy-consensus",
  "op-alloy-rpc-types",
  "op-alloy-rpc-types-engine",
  "proptest",
@@ -4958,15 +4690,15 @@ dependencies = [
 name = "kona-providers-alloy"
 version = "0.2.0"
 dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-eips 0.15.11",
+ "alloy-consensus",
+ "alloy-eips 1.0.1",
  "alloy-primitives",
- "alloy-provider 0.15.11",
- "alloy-rpc-client 0.15.11",
+ "alloy-provider",
+ "alloy-rpc-client",
  "alloy-rpc-types-beacon",
- "alloy-rpc-types-engine 0.15.11",
- "alloy-serde 0.15.11",
- "alloy-transport 0.15.11",
+ "alloy-rpc-types-engine",
+ "alloy-serde 1.0.1",
+ "alloy-transport",
  "alloy-transport-http",
  "async-trait",
  "http-body-util",
@@ -4974,7 +4706,7 @@ dependencies = [
  "kona-genesis",
  "kona-protocol",
  "lru 0.14.0",
- "op-alloy-consensus 0.16.0",
+ "op-alloy-consensus",
  "op-alloy-network",
  "reqwest",
  "serde",
@@ -4988,7 +4720,7 @@ name = "kona-registry"
 version = "0.3.0"
 dependencies = [
  "alloy-chains",
- "alloy-eips 0.15.11",
+ "alloy-eips 1.0.1",
  "alloy-primitives",
  "kona-genesis",
  "lazy_static",
@@ -5002,9 +4734,9 @@ dependencies = [
 name = "kona-rpc"
 version = "0.2.0"
 dependencies = [
- "alloy-eips 0.15.11",
+ "alloy-eips 1.0.1",
  "alloy-primitives",
- "alloy-rpc-client 0.15.11",
+ "alloy-rpc-client",
  "async-trait",
  "derive_more",
  "getrandom 0.3.3",
@@ -5016,7 +4748,7 @@ dependencies = [
  "kona-p2p",
  "kona-protocol",
  "metrics",
- "op-alloy-consensus 0.16.0",
+ "op-alloy-consensus",
  "op-alloy-rpc-jsonrpsee",
  "op-alloy-rpc-types-engine",
  "serde",
@@ -5039,10 +4771,10 @@ dependencies = [
 name = "kona-sources"
 version = "0.1.0"
 dependencies = [
- "alloy-eips 0.15.11",
+ "alloy-eips 1.0.1",
  "alloy-primitives",
- "alloy-provider 0.15.11",
- "alloy-transport 0.15.11",
+ "alloy-provider",
+ "alloy-transport",
  "kona-cli",
  "kona-derive",
  "kona-genesis",
@@ -5099,7 +4831,7 @@ dependencies = [
 name = "kona-supervisor-core"
 version = "0.1.0"
 dependencies = [
- "alloy-eips 0.15.11",
+ "alloy-eips 1.0.1",
  "alloy-primitives",
  "async-trait",
  "jsonrpsee",
@@ -5114,7 +4846,7 @@ dependencies = [
 name = "kona-supervisor-rpc"
 version = "0.1.0"
 dependencies = [
- "alloy-eips 0.15.11",
+ "alloy-eips 1.0.1",
  "alloy-primitives",
  "jsonrpsee",
  "kona-interop",
@@ -5124,10 +4856,10 @@ dependencies = [
 name = "kona-supervisor-service"
 version = "0.1.0"
 dependencies = [
- "alloy-eips 0.15.11",
+ "alloy-eips 1.0.1",
  "alloy-primitives",
- "alloy-provider 0.15.11",
- "alloy-rpc-client 0.15.11",
+ "alloy-provider",
+ "alloy-rpc-client",
  "anyhow",
  "async-trait",
  "futures",
@@ -5557,7 +5289,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tracing",
  "yamux 0.12.1",
- "yamux 0.13.4",
+ "yamux 0.13.5",
 ]
 
 [[package]]
@@ -6227,25 +5959,11 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.15.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33ec121a10f7348ee360b8af71caf4623d7e61942c046cdbe4360e4b640316a"
-dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-eips 0.15.11",
- "alloy-primitives",
- "alloy-rlp",
- "derive_more",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "op-alloy-consensus"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f318b09e24148f07392c5e011bae047a0043851f9041145df5f3b01e4fedd1e"
 dependencies = [
- "alloy-consensus 1.0.1",
+ "alloy-consensus",
  "alloy-eips 1.0.1",
  "alloy-primitives",
  "alloy-rlp",
@@ -6262,12 +5980,12 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a567640236a672a1a0007959c437dbe846dd3e8e9b1d5656dba9c8b4879f67a"
 dependencies = [
- "alloy-consensus 1.0.1",
- "alloy-network 1.0.1",
+ "alloy-consensus",
+ "alloy-network",
  "alloy-primitives",
- "alloy-rpc-types-eth 1.0.1",
- "alloy-signer 1.0.1",
- "op-alloy-consensus 0.16.0",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
+ "op-alloy-consensus",
  "op-alloy-rpc-types",
 ]
 
@@ -6277,11 +5995,11 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc41caf39aec39b65a61bfccff32ca892c0c5152ec830ab3a9b3aa630b18b2a"
 dependencies = [
- "alloy-network 1.0.1",
+ "alloy-network",
  "alloy-primitives",
- "alloy-provider 1.0.1",
- "alloy-rpc-types-engine 1.0.1",
- "alloy-transport 1.0.1",
+ "alloy-provider",
+ "alloy-rpc-types-engine",
+ "alloy-transport",
  "async-trait",
  "op-alloy-rpc-types-engine",
 ]
@@ -6302,15 +6020,15 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15ede8322c10c21249de4fced204e2af4978972e715afee34b6fe684d73880cf"
 dependencies = [
- "alloy-consensus 1.0.1",
+ "alloy-consensus",
  "alloy-eips 1.0.1",
- "alloy-network-primitives 1.0.1",
+ "alloy-network-primitives",
  "alloy-primitives",
- "alloy-rpc-types-eth 1.0.1",
+ "alloy-rpc-types-eth",
  "alloy-serde 1.0.1",
  "arbitrary",
  "derive_more",
- "op-alloy-consensus 0.16.0",
+ "op-alloy-consensus",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -6322,15 +6040,15 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f6cb2e937e88faa8f3d38d38377398d17e44cecd5b019e6d7e1fbde0f5af2a"
 dependencies = [
- "alloy-consensus 1.0.1",
+ "alloy-consensus",
  "alloy-eips 1.0.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-engine 1.0.1",
+ "alloy-rpc-types-engine",
  "alloy-serde 1.0.1",
  "derive_more",
  "ethereum_ssz",
- "op-alloy-consensus 0.16.0",
+ "op-alloy-consensus",
  "serde",
  "snap",
  "thiserror 2.0.12",
@@ -9364,12 +9082,24 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.58.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
 dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
+ "windows-collections",
+ "windows-core 0.61.0",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.0",
 ]
 
 [[package]]
@@ -9384,39 +9114,25 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
- "windows-implement 0.60.0",
- "windows-interface 0.59.1",
+ "windows-implement",
+ "windows-interface",
  "windows-link",
  "windows-result 0.3.2",
  "windows-strings 0.4.0",
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.58.0"
+name = "windows-future"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+checksum = "7a1d6bbefcb7b60acd19828e1bc965da6fcf18a7e39490c5f8be71e54a19ba32"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "windows-core 0.61.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -9424,17 +9140,6 @@ name = "windows-implement"
 version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9459,6 +9164,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.0",
+ "windows-link",
+]
+
+[[package]]
 name = "windows-registry"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9480,30 +9195,11 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -9925,16 +9621,16 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17610762a1207ee816c6fadc29220904753648aba0a9ed61c7b8336e80a559c4"
+checksum = "3da1acad1c2dc53f0dde419115a38bd8221d8c3e47ae9aeceaf453266d29307e"
 dependencies = [
  "futures",
  "log",
  "nohash-hasher",
  "parking_lot",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.9.1",
  "static_assertions",
  "web-time",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,16 +142,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-consensus"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5af9455152b18b9efc329120c85006705862a21786449e425eb714d0c04bbfda"
+dependencies = [
+ "alloy-eips 1.0.1",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 1.0.1",
+ "alloy-trie",
+ "arbitrary",
+ "auto_impl",
+ "c-kzg",
+ "derive_more",
+ "either",
+ "k256",
+ "once_cell",
+ "rand 0.8.5",
+ "secp256k1 0.30.0",
+ "serde",
+ "serde_with",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "alloy-consensus-any"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dda014fb5591b8d8d24cab30f52690117d238e52254c6fb40658e91ea2ccd6c3"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.11",
  "alloy-eips 0.15.11",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde 0.15.11",
+ "serde",
+]
+
+[[package]]
+name = "alloy-consensus-any"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9256691696deb28fd71ca6b698d958e80abe5dd0ed95f8e96ac55076b4a70e95"
+dependencies = [
+ "alloy-consensus 1.0.1",
+ "alloy-eips 1.0.1",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 1.0.1",
  "arbitrary",
  "serde",
 ]
@@ -236,6 +275,27 @@ dependencies = [
  "c-kzg",
  "derive_more",
  "either",
+ "serde",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3ecb56e34e1c3dca4aa06b653c96f0f381a67e0d353271949c683fba5ecbd4"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 1.0.1",
+ "arbitrary",
+ "auto_impl",
+ "c-kzg",
+ "derive_more",
+ "either",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "serde",
@@ -248,14 +308,14 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7263f5a79a16743b33237017097886d7bd62d4d32eebe64f22e0a7c7ba70f4"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.11",
  "alloy-eips 0.15.11",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.15.7",
  "op-revm",
  "revm",
  "thiserror 2.0.12",
@@ -301,21 +361,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-json-rpc"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b22b5e5872d5ece9df2411a65637af3bfc5ce868ddf392cb91ce9a0c7cb1b30"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
 name = "alloy-network"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879afc0f4a528908c8fe6935b2ab0bc07f77221a989186f71583f7592831689e"
 dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
+ "alloy-consensus 0.15.11",
+ "alloy-consensus-any 0.15.11",
  "alloy-eips 0.15.11",
- "alloy-json-rpc",
- "alloy-network-primitives",
+ "alloy-json-rpc 0.15.11",
+ "alloy-network-primitives 0.15.11",
  "alloy-primitives",
- "alloy-rpc-types-any",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-any 0.15.11",
+ "alloy-rpc-types-eth 0.15.11",
  "alloy-serde 0.15.11",
- "alloy-signer",
+ "alloy-signer 0.15.11",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "derive_more",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-network"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8a707ccae2aaca8fb64cec54904c1fdce6be5c5d5be24a7ae04e6a393cb62e"
+dependencies = [
+ "alloy-consensus 1.0.1",
+ "alloy-consensus-any 1.0.1",
+ "alloy-eips 1.0.1",
+ "alloy-json-rpc 1.0.1",
+ "alloy-network-primitives 1.0.1",
+ "alloy-primitives",
+ "alloy-rpc-types-any 1.0.1",
+ "alloy-rpc-types-eth 1.0.1",
+ "alloy-serde 1.0.1",
+ "alloy-signer 1.0.1",
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
@@ -332,10 +432,23 @@ version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec185bac9d32df79c1132558a450d48f6db0bfb5adef417dbb1a0258153f879b"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.11",
  "alloy-eips 0.15.11",
  "alloy-primitives",
  "alloy-serde 0.15.11",
+ "serde",
+]
+
+[[package]]
+name = "alloy-network-primitives"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d27be7a0d29a77b2568c105e5418736da5555026a4b054ea2e3b549a0a9645b"
+dependencies = [
+ "alloy-consensus 1.0.1",
+ "alloy-eips 1.0.1",
+ "alloy-primitives",
+ "alloy-serde 1.0.1",
  "serde",
 ]
 
@@ -345,13 +458,13 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2379a87a3018a563a0524002caed789ac832a8ae8ff0270189559dccf8e49ae9"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.11",
  "alloy-eips 0.15.11",
  "alloy-evm",
  "alloy-op-hardforks",
  "alloy-primitives",
  "auto_impl",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.15.7",
  "op-revm",
  "revm",
 ]
@@ -404,19 +517,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2d918534afe9cc050eabd8309c107dafd161aa77357782eca4f218bef08a660"
 dependencies = [
  "alloy-chains",
- "alloy-consensus",
+ "alloy-consensus 0.15.11",
  "alloy-eips 0.15.11",
- "alloy-json-rpc",
- "alloy-network",
- "alloy-network-primitives",
+ "alloy-json-rpc 0.15.11",
+ "alloy-network 0.15.11",
+ "alloy-network-primitives 0.15.11",
  "alloy-primitives",
  "alloy-pubsub",
- "alloy-rpc-client",
- "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
- "alloy-signer",
+ "alloy-rpc-client 0.15.11",
+ "alloy-rpc-types-engine 0.15.11",
+ "alloy-rpc-types-eth 0.15.11",
+ "alloy-signer 0.15.11",
  "alloy-sol-types",
- "alloy-transport",
+ "alloy-transport 0.15.11",
  "alloy-transport-http",
  "alloy-transport-ipc",
  "alloy-transport-ws",
@@ -441,14 +554,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-provider"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "064d72578caba01fc1d04e8119dbfac36f7cc3b0b9c65804f2282482d55c4904"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus 1.0.1",
+ "alloy-eips 1.0.1",
+ "alloy-json-rpc 1.0.1",
+ "alloy-network 1.0.1",
+ "alloy-network-primitives 1.0.1",
+ "alloy-primitives",
+ "alloy-rpc-client 1.0.1",
+ "alloy-rpc-types-eth 1.0.1",
+ "alloy-signer 1.0.1",
+ "alloy-sol-types",
+ "alloy-transport 1.0.1",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap",
+ "either",
+ "futures",
+ "futures-utils-wasm",
+ "lru 0.13.0",
+ "parking_lot",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "wasmtimer",
+]
+
+[[package]]
 name = "alloy-pubsub"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d77a92001c6267261a5e493d33db794b2206ebebf7c2dfbbe3825ebaec6a96d"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 0.15.11",
  "alloy-primitives",
- "alloy-transport",
+ "alloy-transport 0.15.11",
  "bimap",
  "futures",
  "parking_lot",
@@ -456,7 +605,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower 0.5.2",
+ "tower",
  "tracing",
  "wasmtimer",
 ]
@@ -489,10 +638,10 @@ version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a15e30dcada47c04820b64f63de2423506c5c74f9ab59b115277ef5ad595a6fc"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 0.15.11",
  "alloy-primitives",
  "alloy-pubsub",
- "alloy-transport",
+ "alloy-transport 0.15.11",
  "alloy-transport-http",
  "alloy-transport-ipc",
  "alloy-transport-ws",
@@ -504,10 +653,32 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower 0.5.2",
+ "tower",
  "tracing",
  "tracing-futures",
  "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb00c4260ca83980422fc4a44658aafe50ad7b7ad43fb21523bd53453cfd202"
+dependencies = [
+ "alloy-json-rpc 1.0.1",
+ "alloy-primitives",
+ "alloy-transport 1.0.1",
+ "async-stream",
+ "futures",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
+ "tracing-futures",
  "wasmtimer",
 ]
 
@@ -519,7 +690,7 @@ checksum = "4aa10e26554ad7f79a539a6a8851573aedec5289f1f03244aad0bdbc324bfe5c"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-debug",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 0.15.11",
  "alloy-serde 0.15.11",
  "serde",
 ]
@@ -530,9 +701,20 @@ version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a8f1efd77116915dad61092f9ef9295accd0b0b251062390d9c4e81599344"
 dependencies = [
- "alloy-consensus-any",
- "alloy-rpc-types-eth",
+ "alloy-consensus-any 0.15.11",
+ "alloy-rpc-types-eth 0.15.11",
  "alloy-serde 0.15.11",
+]
+
+[[package]]
+name = "alloy-rpc-types-any"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8740d1e374cf177f5e94ee694cbbca5d0435c3e8a6d4e908841e9cfc5247e2"
+dependencies = [
+ "alloy-consensus-any 1.0.1",
+ "alloy-rpc-types-eth 1.0.1",
+ "alloy-serde 1.0.1",
 ]
 
 [[package]]
@@ -543,7 +725,7 @@ checksum = "df7b4a021b4daff504208b3b43a25270d0a5a27490d6535655052f32c419ba0a"
 dependencies = [
  "alloy-eips 0.15.11",
  "alloy-primitives",
- "alloy-rpc-types-engine",
+ "alloy-rpc-types-engine 0.15.11",
  "serde",
  "serde_with",
  "thiserror 2.0.12",
@@ -565,15 +747,32 @@ version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246c225f878dbcb8ad405949a30c403b3bb43bdf974f7f0331b276f835790a5e"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.11",
  "alloy-eips 0.15.11",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde 0.15.11",
  "derive_more",
+ "jsonwebtoken",
+ "rand 0.8.5",
+ "serde",
+ "strum",
+]
+
+[[package]]
+name = "alloy-rpc-types-engine"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "738a62884dcf024b244411cf124cb514a06cdd41d27c9ae898c45ca01a161e0e"
+dependencies = [
+ "alloy-consensus 1.0.1",
+ "alloy-eips 1.0.1",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 1.0.1",
+ "derive_more",
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "jsonwebtoken",
  "rand 0.8.5",
  "serde",
  "strum",
@@ -585,13 +784,33 @@ version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc1323310d87f9d950fb3ff58d943fdf832f5e10e6f902f405c0eaa954ffbaf1"
 dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
+ "alloy-consensus 0.15.11",
+ "alloy-consensus-any 0.15.11",
  "alloy-eips 0.15.11",
- "alloy-network-primitives",
+ "alloy-network-primitives 0.15.11",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde 0.15.11",
+ "alloy-sol-types",
+ "itertools 0.14.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-rpc-types-eth"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc2bbc0385aac988551f747c050d5bd1b2b9dd59eabaebf063edbb6a41b2ccb"
+dependencies = [
+ "alloy-consensus 1.0.1",
+ "alloy-consensus-any 1.0.1",
+ "alloy-eips 1.0.1",
+ "alloy-network-primitives 1.0.1",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 1.0.1",
  "alloy-sol-types",
  "arbitrary",
  "itertools 0.14.0",
@@ -624,10 +843,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-serde"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071c74effe6ad192dde40cbd4da49784c946561dec6679f73665337c6cf72316"
+dependencies = [
+ "alloy-primitives",
+ "arbitrary",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "alloy-signer"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67fdabad99ad3c71384867374c60bcd311fc1bb90ea87f5f9c779fd8c7ec36aa"
+dependencies = [
+ "alloy-primitives",
+ "async-trait",
+ "auto_impl",
+ "either",
+ "elliptic-curve",
+ "k256",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-signer"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e920bcbaf28af4c3edf6dac128a5d04185582bf496b031add01de909b4cb153"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -715,7 +961,7 @@ version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6964d85cd986cfc015b96887b89beed9e06d0d015b75ee2b7bfbd64341aab874"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 0.15.11",
  "alloy-primitives",
  "base64",
  "derive_more",
@@ -726,7 +972,30 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
- "tower 0.5.2",
+ "tower",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f5564661f166792da89d9a6785ff815e44853436637842c59ab48393c4c2fad"
+dependencies = [
+ "alloy-json-rpc 1.0.1",
+ "alloy-primitives",
+ "base64",
+ "derive_more",
+ "futures",
+ "futures-utils-wasm",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tower",
  "tracing",
  "url",
  "wasmtimer",
@@ -738,9 +1007,9 @@ version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef7c5ea7bda4497abe4ea92dcb8c76e9f052c178f3c82aa6976bcb264675f73c"
 dependencies = [
- "alloy-json-rpc",
- "alloy-rpc-types-engine",
- "alloy-transport",
+ "alloy-json-rpc 0.15.11",
+ "alloy-rpc-types-engine 0.15.11",
+ "alloy-transport 0.15.11",
  "http-body-util",
  "hyper",
  "hyper-tls",
@@ -748,7 +1017,7 @@ dependencies = [
  "jsonwebtoken",
  "reqwest",
  "serde_json",
- "tower 0.5.2",
+ "tower",
  "tracing",
  "url",
 ]
@@ -759,9 +1028,9 @@ version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c506a002d77e522ccab7b7068089a16e24694ea04cb89c0bfecf3cc3603fccf"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 0.15.11",
  "alloy-pubsub",
- "alloy-transport",
+ "alloy-transport 0.15.11",
  "bytes",
  "futures",
  "interprocess",
@@ -780,7 +1049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ff1bb1182601fa5e7b0f8bac03dcd496441ed23859387731462b17511c6680"
 dependencies = [
  "alloy-pubsub",
- "alloy-transport",
+ "alloy-transport 0.15.11",
  "futures",
  "http 1.3.1",
  "rustls",
@@ -3888,61 +4157,20 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b26c20e2178756451cfeb0661fb74c47dd5988cb7e3939de7e9241fd604d42"
-dependencies = [
- "jsonrpsee-client-transport 0.24.9",
- "jsonrpsee-core 0.24.9",
- "jsonrpsee-http-client 0.24.9",
- "jsonrpsee-proc-macros 0.24.9",
- "jsonrpsee-types 0.24.9",
- "jsonrpsee-wasm-client 0.24.9",
- "jsonrpsee-ws-client 0.24.9",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fba77a59c4c644fd48732367624d1bcf6f409f9c9a286fbc71d2f1fc0b2ea16"
 dependencies = [
- "jsonrpsee-client-transport 0.25.1",
- "jsonrpsee-core 0.25.1",
- "jsonrpsee-http-client 0.25.1",
- "jsonrpsee-proc-macros 0.25.1",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-http-client",
+ "jsonrpsee-proc-macros",
  "jsonrpsee-server",
- "jsonrpsee-types 0.25.1",
- "jsonrpsee-wasm-client 0.25.1",
- "jsonrpsee-ws-client 0.25.1",
+ "jsonrpsee-types",
+ "jsonrpsee-wasm-client",
+ "jsonrpsee-ws-client",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-client-transport"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bacb85abf4117092455e1573625e21b8f8ef4dec8aff13361140b2dc266cdff2"
-dependencies = [
- "base64",
- "futures-channel",
- "futures-util",
- "gloo-net",
- "http 1.3.1",
- "jsonrpsee-core 0.24.9",
- "pin-project",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "soketto",
- "thiserror 1.0.69",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "tracing",
- "url",
 ]
 
 [[package]]
@@ -3956,7 +4184,7 @@ dependencies = [
  "futures-util",
  "gloo-net",
  "http 1.3.1",
- "jsonrpsee-core 0.25.1",
+ "jsonrpsee-core",
  "pin-project",
  "rustls",
  "rustls-pki-types",
@@ -3968,33 +4196,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "jsonrpsee-core"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456196007ca3a14db478346f58c7238028d55ee15c1df15115596e411ff27925"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-timer",
- "futures-util",
- "http 1.3.1",
- "http-body",
- "http-body-util",
- "jsonrpsee-types 0.24.9",
- "parking_lot",
- "pin-project",
- "rand 0.8.5",
- "rustc-hash 2.1.1",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tracing",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -4010,7 +4211,7 @@ dependencies = [
  "http 1.3.1",
  "http-body",
  "http-body-util",
- "jsonrpsee-types 0.25.1",
+ "jsonrpsee-types",
  "parking_lot",
  "pin-project",
  "rand 0.9.1",
@@ -4020,34 +4221,9 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
- "tower 0.5.2",
+ "tower",
  "tracing",
  "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "jsonrpsee-http-client"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c872b6c9961a4ccc543e321bb5b89f6b2d2c7fe8b61906918273a3333c95400c"
-dependencies = [
- "async-trait",
- "base64",
- "http-body",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "jsonrpsee-core 0.24.9",
- "jsonrpsee-types 0.24.9",
- "rustls",
- "rustls-platform-verifier",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tower 0.4.13",
- "tracing",
- "url",
 ]
 
 [[package]]
@@ -4061,29 +4237,16 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
- "jsonrpsee-core 0.25.1",
- "jsonrpsee-types 0.25.1",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "rustls",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
- "tower 0.5.2",
+ "tower",
  "url",
-]
-
-[[package]]
-name = "jsonrpsee-proc-macros"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e65763c942dfc9358146571911b0cd1c361c2d63e2d2305622d40d36376ca80"
-dependencies = [
- "heck",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
 ]
 
 [[package]]
@@ -4111,8 +4274,8 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "jsonrpsee-core 0.25.1",
- "jsonrpsee-types 0.25.1",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "pin-project",
  "route-recognizer",
  "serde",
@@ -4122,20 +4285,8 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower 0.5.2",
+ "tower",
  "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-types"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a8e70baf945b6b5752fc8eb38c918a48f1234daf11355e07106d963f860089"
-dependencies = [
- "http 1.3.1",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4152,38 +4303,14 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6558a9586cad43019dafd0b6311d0938f46efc116b34b28c74778bc11a2edf6"
-dependencies = [
- "jsonrpsee-client-transport 0.24.9",
- "jsonrpsee-core 0.24.9",
- "jsonrpsee-types 0.24.9",
-]
-
-[[package]]
-name = "jsonrpsee-wasm-client"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b67695cbcf4653f39f8f8738925547e0e23fd9fe315bccf951097b9f6a38781"
 dependencies = [
- "jsonrpsee-client-transport 0.25.1",
- "jsonrpsee-core 0.25.1",
- "jsonrpsee-types 0.25.1",
- "tower 0.5.2",
-]
-
-[[package]]
-name = "jsonrpsee-ws-client"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b3323d890aa384f12148e8d2a1fd18eb66e9e7e825f9de4fa53bcc19b93eef"
-dependencies = [
- "http 1.3.1",
- "jsonrpsee-client-transport 0.24.9",
- "jsonrpsee-core 0.24.9",
- "jsonrpsee-types 0.24.9",
- "url",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "tower",
 ]
 
 [[package]]
@@ -4193,10 +4320,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da2694c9ff271a9d3ebfe520f6b36820e85133a51be77a3cb549fd615095261"
 dependencies = [
  "http 1.3.1",
- "jsonrpsee-client-transport 0.25.1",
- "jsonrpsee-core 0.25.1",
- "jsonrpsee-types 0.25.1",
- "tower 0.5.2",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "tower",
  "url",
 ]
 
@@ -4264,13 +4391,13 @@ dependencies = [
 name = "kona-client"
 version = "1.0.1"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.11",
  "alloy-eips 0.15.11",
  "alloy-evm",
  "alloy-op-evm",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-engine",
+ "alloy-rpc-types-engine 0.15.11",
  "async-trait",
  "cfg-if",
  "kona-derive",
@@ -4287,7 +4414,7 @@ dependencies = [
  "kona-std-fpvm",
  "kona-std-fpvm-proc",
  "lru 0.14.0",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.16.0",
  "op-alloy-rpc-types-engine",
  "op-revm",
  "revm",
@@ -4305,11 +4432,11 @@ name = "kona-comp"
 version = "0.3.0"
 dependencies = [
  "alloc-no-stdlib",
- "alloy-consensus",
+ "alloy-consensus 0.15.11",
  "alloy-eips 0.15.11",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-engine",
+ "alloy-rpc-types-engine 0.15.11",
  "alloy-serde 0.15.11",
  "alloy-sol-types",
  "arbitrary",
@@ -4319,7 +4446,7 @@ dependencies = [
  "kona-genesis",
  "kona-protocol",
  "miniz_oxide",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.16.0",
  "proptest",
  "rand 0.9.1",
  "serde",
@@ -4335,18 +4462,18 @@ dependencies = [
 name = "kona-derive"
 version = "0.3.0"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.11",
  "alloy-eips 0.15.11",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-engine",
+ "alloy-rpc-types-engine 0.15.11",
  "async-trait",
  "kona-derive",
  "kona-genesis",
  "kona-hardforks",
  "kona-protocol",
  "kona-registry",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.16.0",
  "op-alloy-rpc-types-engine",
  "proptest",
  "serde",
@@ -4362,7 +4489,7 @@ dependencies = [
 name = "kona-driver"
 version = "0.3.0"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.11",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -4371,7 +4498,7 @@ dependencies = [
  "kona-executor",
  "kona-genesis",
  "kona-protocol",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.16.0",
  "op-alloy-rpc-types-engine",
  "spin 0.10.0",
  "thiserror 2.0.12",
@@ -4382,16 +4509,16 @@ dependencies = [
 name = "kona-engine"
 version = "0.1.0"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.11",
  "alloy-eips 0.15.11",
- "alloy-network",
- "alloy-network-primitives",
+ "alloy-network 0.15.11",
+ "alloy-network-primitives 0.15.11",
  "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-client",
- "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
- "alloy-transport",
+ "alloy-provider 0.15.11",
+ "alloy-rpc-client 0.15.11",
+ "alloy-rpc-types-engine 0.15.11",
+ "alloy-rpc-types-eth 0.15.11",
+ "alloy-transport 0.15.11",
  "alloy-transport-http",
  "arbitrary",
  "async-trait",
@@ -4403,7 +4530,7 @@ dependencies = [
  "kona-registry",
  "metrics",
  "metrics-exporter-prometheus",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.16.0",
  "op-alloy-network",
  "op-alloy-provider",
  "op-alloy-rpc-types",
@@ -4415,7 +4542,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
- "tower 0.5.2",
+ "tower",
  "tracing",
  "url",
 ]
@@ -4424,17 +4551,17 @@ dependencies = [
 name = "kona-executor"
 version = "0.3.0"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.11",
  "alloy-eips 0.15.11",
  "alloy-evm",
  "alloy-op-evm",
  "alloy-op-hardforks",
  "alloy-primitives",
- "alloy-provider",
+ "alloy-provider 0.15.11",
  "alloy-rlp",
- "alloy-rpc-client",
- "alloy-rpc-types-engine",
- "alloy-transport",
+ "alloy-rpc-client 0.15.11",
+ "alloy-rpc-types-engine 0.15.11",
+ "alloy-transport 0.15.11",
  "alloy-transport-http",
  "alloy-trie",
  "kona-executor",
@@ -4442,7 +4569,7 @@ dependencies = [
  "kona-mpt",
  "kona-protocol",
  "kona-registry",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.16.0",
  "op-alloy-rpc-types-engine",
  "op-revm",
  "rand 0.9.1",
@@ -4461,7 +4588,7 @@ dependencies = [
 name = "kona-genesis"
 version = "0.3.0"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.11",
  "alloy-eips 0.15.11",
  "alloy-hardforks",
  "alloy-op-hardforks",
@@ -4486,7 +4613,7 @@ dependencies = [
  "alloy-eips 0.15.11",
  "alloy-primitives",
  "kona-protocol",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.16.0",
  "op-revm",
  "revm",
 ]
@@ -4495,17 +4622,17 @@ dependencies = [
 name = "kona-host"
 version = "1.0.1"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.11",
  "alloy-eips 0.15.11",
  "alloy-op-evm",
  "alloy-primitives",
- "alloy-provider",
+ "alloy-provider 0.15.11",
  "alloy-rlp",
- "alloy-rpc-client",
+ "alloy-rpc-client 0.15.11",
  "alloy-rpc-types",
  "alloy-rpc-types-beacon",
  "alloy-serde 0.15.11",
- "alloy-transport",
+ "alloy-transport 0.15.11",
  "alloy-transport-http",
  "anyhow",
  "ark-ff 0.5.0",
@@ -4543,7 +4670,7 @@ dependencies = [
 name = "kona-interop"
 version = "0.3.0"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.11",
  "alloy-eips 0.15.11",
  "alloy-primitives",
  "alloy-rlp",
@@ -4554,7 +4681,7 @@ dependencies = [
  "kona-genesis",
  "kona-protocol",
  "kona-registry",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.16.0",
  "rand 0.9.1",
  "serde",
  "serde_json",
@@ -4571,9 +4698,9 @@ version = "0.1.0"
 name = "kona-mpt"
 version = "0.2.0"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.11",
  "alloy-primitives",
- "alloy-provider",
+ "alloy-provider 0.15.11",
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-transport-http",
@@ -4594,16 +4721,16 @@ name = "kona-node"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types-engine",
- "alloy-transport",
+ "alloy-provider 0.15.11",
+ "alloy-rpc-types-engine 0.15.11",
+ "alloy-transport 0.15.11",
  "anyhow",
  "backon",
  "clap",
  "dirs",
  "discv5",
  "futures",
- "jsonrpsee 0.25.1",
+ "jsonrpsee",
  "kona-cli",
  "kona-derive",
  "kona-engine",
@@ -4635,17 +4762,17 @@ version = "0.1.0"
 dependencies = [
  "alloy-eips 0.15.11",
  "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-client",
- "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
- "alloy-transport",
+ "alloy-provider 0.15.11",
+ "alloy-rpc-client 0.15.11",
+ "alloy-rpc-types-engine 0.15.11",
+ "alloy-rpc-types-eth 0.15.11",
+ "alloy-transport 0.15.11",
  "alloy-transport-http",
  "async-trait",
  "derive_more",
  "futures",
  "http-body-util",
- "jsonrpsee 0.25.1",
+ "jsonrpsee",
  "kona-derive",
  "kona-engine",
  "kona-genesis",
@@ -4661,7 +4788,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
- "tower 0.5.2",
+ "tower",
  "tracing",
  "url",
 ]
@@ -4670,11 +4797,11 @@ dependencies = [
 name = "kona-p2p"
 version = "0.1.0"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.11",
  "alloy-eips 0.15.11",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-engine",
+ "alloy-rpc-types-engine 0.15.11",
  "arbitrary",
  "arbtest",
  "derive_more",
@@ -4689,7 +4816,7 @@ dependencies = [
  "libp2p-identity",
  "metrics",
  "multihash",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.16.0",
  "op-alloy-rpc-types-engine",
  "openssl",
  "rand 0.9.1",
@@ -4723,7 +4850,7 @@ dependencies = [
 name = "kona-proof"
 version = "0.3.0"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.11",
  "alloy-eips 0.15.11",
  "alloy-evm",
  "alloy-op-evm",
@@ -4744,7 +4871,7 @@ dependencies = [
  "kona-registry",
  "lazy_static",
  "lru 0.14.0",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.16.0",
  "op-alloy-rpc-types-engine",
  "op-revm",
  "rand 0.9.1",
@@ -4762,13 +4889,13 @@ dependencies = [
 name = "kona-proof-interop"
 version = "0.2.0"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.11",
  "alloy-eips 0.15.11",
  "alloy-evm",
  "alloy-op-evm",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-engine",
+ "alloy-rpc-types-engine 0.15.11",
  "arbitrary",
  "async-trait",
  "kona-executor",
@@ -4779,7 +4906,7 @@ dependencies = [
  "kona-proof",
  "kona-protocol",
  "kona-registry",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.16.0",
  "op-alloy-rpc-types-engine",
  "op-revm",
  "rand 0.9.1",
@@ -4796,12 +4923,12 @@ name = "kona-protocol"
 version = "0.3.0"
 dependencies = [
  "alloc-no-stdlib",
- "alloy-consensus",
+ "alloy-consensus 0.15.11",
  "alloy-eips 0.15.11",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-engine 0.15.11",
+ "alloy-rpc-types-eth 0.15.11",
  "alloy-serde 0.15.11",
  "alloy-sol-types",
  "arbitrary",
@@ -4811,7 +4938,7 @@ dependencies = [
  "kona-genesis",
  "kona-protocol",
  "miniz_oxide",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.16.0",
  "op-alloy-rpc-types",
  "op-alloy-rpc-types-engine",
  "proptest",
@@ -4831,15 +4958,15 @@ dependencies = [
 name = "kona-providers-alloy"
 version = "0.2.0"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.11",
  "alloy-eips 0.15.11",
  "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-client",
+ "alloy-provider 0.15.11",
+ "alloy-rpc-client 0.15.11",
  "alloy-rpc-types-beacon",
- "alloy-rpc-types-engine",
+ "alloy-rpc-types-engine 0.15.11",
  "alloy-serde 0.15.11",
- "alloy-transport",
+ "alloy-transport 0.15.11",
  "alloy-transport-http",
  "async-trait",
  "http-body-util",
@@ -4847,13 +4974,13 @@ dependencies = [
  "kona-genesis",
  "kona-protocol",
  "lru 0.14.0",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.16.0",
  "op-alloy-network",
  "reqwest",
  "serde",
  "thiserror 2.0.12",
  "tokio",
- "tower 0.5.2",
+ "tower",
 ]
 
 [[package]]
@@ -4877,11 +5004,11 @@ version = "0.2.0"
 dependencies = [
  "alloy-eips 0.15.11",
  "alloy-primitives",
- "alloy-rpc-client",
+ "alloy-rpc-client 0.15.11",
  "async-trait",
  "derive_more",
  "getrandom 0.3.3",
- "jsonrpsee 0.25.1",
+ "jsonrpsee",
  "kona-engine",
  "kona-genesis",
  "kona-interop",
@@ -4889,7 +5016,7 @@ dependencies = [
  "kona-p2p",
  "kona-protocol",
  "metrics",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.16.0",
  "op-alloy-rpc-jsonrpsee",
  "op-alloy-rpc-types-engine",
  "serde",
@@ -4914,8 +5041,8 @@ version = "0.1.0"
 dependencies = [
  "alloy-eips 0.15.11",
  "alloy-primitives",
- "alloy-provider",
- "alloy-transport",
+ "alloy-provider 0.15.11",
+ "alloy-transport 0.15.11",
  "kona-cli",
  "kona-derive",
  "kona-genesis",
@@ -4975,7 +5102,7 @@ dependencies = [
  "alloy-eips 0.15.11",
  "alloy-primitives",
  "async-trait",
- "jsonrpsee 0.25.1",
+ "jsonrpsee",
  "kona-interop",
  "kona-supervisor-rpc",
  "metrics",
@@ -4989,7 +5116,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-eips 0.15.11",
  "alloy-primitives",
- "jsonrpsee 0.25.1",
+ "jsonrpsee",
  "kona-interop",
 ]
 
@@ -4999,12 +5126,12 @@ version = "0.1.0"
 dependencies = [
  "alloy-eips 0.15.11",
  "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-client",
+ "alloy-provider 0.15.11",
+ "alloy-rpc-client 0.15.11",
  "anyhow",
  "async-trait",
  "futures",
- "jsonrpsee 0.25.1",
+ "jsonrpsee",
  "kona-genesis",
  "kona-protocol",
  "kona-rpc",
@@ -6104,11 +6231,25 @@ version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33ec121a10f7348ee360b8af71caf4623d7e61942c046cdbe4360e4b640316a"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.15.11",
  "alloy-eips 0.15.11",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.15.11",
+ "derive_more",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "op-alloy-consensus"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f318b09e24148f07392c5e011bae047a0043851f9041145df5f3b01e4fedd1e"
+dependencies = [
+ "alloy-consensus 1.0.1",
+ "alloy-eips 1.0.1",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 1.0.1",
  "arbitrary",
  "derive_more",
  "serde",
@@ -6117,78 +6258,79 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-network"
-version = "0.15.7"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1402f67836bb833948037ca6128e0bc7a5261f47d50c4a4b38470c2ecabf6362"
+checksum = "3a567640236a672a1a0007959c437dbe846dd3e8e9b1d5656dba9c8b4879f67a"
 dependencies = [
- "alloy-consensus",
- "alloy-network",
+ "alloy-consensus 1.0.1",
+ "alloy-network 1.0.1",
  "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-signer",
- "op-alloy-consensus",
+ "alloy-rpc-types-eth 1.0.1",
+ "alloy-signer 1.0.1",
+ "op-alloy-consensus 0.16.0",
  "op-alloy-rpc-types",
 ]
 
 [[package]]
 name = "op-alloy-provider"
-version = "0.15.7"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5750a993e607c26901ed139b5e6fa14289257c9d1d9f367dda50c8f8df1872"
+checksum = "0cc41caf39aec39b65a61bfccff32ca892c0c5152ec830ab3a9b3aa630b18b2a"
 dependencies = [
- "alloy-network",
+ "alloy-network 1.0.1",
  "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types-engine",
- "alloy-transport",
+ "alloy-provider 1.0.1",
+ "alloy-rpc-types-engine 1.0.1",
+ "alloy-transport 1.0.1",
  "async-trait",
  "op-alloy-rpc-types-engine",
 ]
 
 [[package]]
 name = "op-alloy-rpc-jsonrpsee"
-version = "0.15.7"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb33c378cf40decbd166f49d9df37e315889308ebdc14a7f66cd1765491a6c6"
+checksum = "0d817bec4d9475405cb69f3c990946763b26ba6c70cfa03674d21c77c671864c"
 dependencies = [
  "alloy-primitives",
- "jsonrpsee 0.24.9",
+ "jsonrpsee",
 ]
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.15.7"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084a0a5dc3d5af1e161ca5a602b9efac872c7d416120be24d7f33e299973a204"
+checksum = "15ede8322c10c21249de4fced204e2af4978972e715afee34b6fe684d73880cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips 0.15.11",
- "alloy-network-primitives",
+ "alloy-consensus 1.0.1",
+ "alloy-eips 1.0.1",
+ "alloy-network-primitives 1.0.1",
  "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde 0.15.11",
+ "alloy-rpc-types-eth 1.0.1",
+ "alloy-serde 1.0.1",
  "arbitrary",
  "derive_more",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.16.0",
  "serde",
  "serde_json",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.15.7"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d840947bd5ce24a8db8a29eb7b0eaf8c2280a56eefe968c44a5aa79afe6af51"
+checksum = "f6f6cb2e937e88faa8f3d38d38377398d17e44cecd5b019e6d7e1fbde0f5af2a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips 0.15.11",
+ "alloy-consensus 1.0.1",
+ "alloy-eips 1.0.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-engine",
- "alloy-serde 0.15.11",
+ "alloy-rpc-types-engine 1.0.1",
+ "alloy-serde 1.0.1",
  "derive_more",
  "ethereum_ssz",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.16.0",
  "serde",
  "snap",
  "thiserror 2.0.12",
@@ -7124,7 +7266,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tower 0.5.2",
+ "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -8660,21 +8802,6 @@ dependencies = [
  "serde_spanned",
  "toml_datetime",
  "winnow",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,22 +114,22 @@ kona-serde = { path = "crates/utilities/serde", version = "0.2.0", default-featu
 alloy-rlp = { version = "0.3.11", default-features = false }
 alloy-trie = { version = "0.8.1", default-features = false }
 alloy-chains = { version = "0.2", default-features = false }
-alloy-eips = { version = "0.15.11", default-features = false }
-alloy-serde = { version = "0.15.11", default-features = false }
-alloy-network = { version = "0.15.11", default-features = false }
-alloy-provider = { version = "0.15.11", default-features = false }
+alloy-eips = { version = "1.0.0", default-features = false }
+alloy-serde = { version = "1.0.0", default-features = false }
+alloy-network = { version = "1.0.0", default-features = false }
+alloy-provider = { version = "1.0.0", default-features = false }
 alloy-sol-types = { version = "1.1.0", default-features = false }
-alloy-consensus = { version = "0.15.11", default-features = false }
-alloy-transport = { version = "0.15.11", default-features = false }
-alloy-rpc-types = { version = "0.15.11", default-features = false }
-alloy-rpc-client = { version = "0.15.11", default-features = false }
+alloy-consensus = { version = "1.0.0", default-features = false }
+alloy-transport = { version = "1.0.0", default-features = false }
+alloy-rpc-types = { version = "1.0.0", default-features = false }
+alloy-rpc-client = { version = "1.0.0", default-features = false }
 alloy-primitives = { version = "1.1.0", default-features = false }
-alloy-node-bindings = { version = "0.15.11", default-features = false }
-alloy-rpc-types-eth = { version = "0.15.11", default-features = false }
-alloy-transport-http = { version = "0.15.11", default-features = false }
-alloy-rpc-types-engine = { version = "0.15.11", default-features = false }
-alloy-rpc-types-beacon = { version = "0.15.11", default-features = false }
-alloy-network-primitives = { version = "0.15.11", default-features = false }
+alloy-node-bindings = { version = "1.0.0", default-features = false }
+alloy-rpc-types-eth = { version = "1.0.0", default-features = false }
+alloy-transport-http = { version = "1.0.0", default-features = false }
+alloy-rpc-types-engine = { version = "1.0.0", default-features = false }
+alloy-rpc-types-beacon = { version = "1.0.0", default-features = false }
+alloy-network-primitives = { version = "1.0.0", default-features = false }
 alloy-hardforks = { version = "0.2.0", default-features = false }
 
 # OP Alloy
@@ -144,8 +144,8 @@ alloy-op-hardforks = { version = "0.2.0", default-features = false }
 # Execution
 revm = { version = "23.1.0", default-features = false }
 op-revm = { version = "4.0.2", default-features = false }
-alloy-evm = { version = "0.7.2", default-features = false, features = ["op"] }
-alloy-op-evm = { version = "0.7.2", default-features = false }
+alloy-evm = { version = "0.8.0", default-features = false, features = ["op"] }
+alloy-op-evm = { version = "0.8.0", default-features = false }
 
 # General
 url = "2.5.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,12 +133,12 @@ alloy-network-primitives = { version = "0.15.11", default-features = false }
 alloy-hardforks = { version = "0.2.0", default-features = false }
 
 # OP Alloy
-op-alloy-network = { version = "0.15.7", default-features = false }
-op-alloy-provider = { version = "0.15.7", default-features = false }
-op-alloy-consensus = { version = "0.15.7", default-features = false }
-op-alloy-rpc-types = { version = "0.15.7", default-features = false }
-op-alloy-rpc-jsonrpsee = { version = "0.15.7", default-features = false }
-op-alloy-rpc-types-engine = { version = "0.15.7", default-features = false }
+op-alloy-network = { version = "0.16.0", default-features = false }
+op-alloy-provider = { version = "0.16.0", default-features = false }
+op-alloy-consensus = { version = "0.16.0", default-features = false }
+op-alloy-rpc-types = { version = "0.16.0", default-features = false }
+op-alloy-rpc-jsonrpsee = { version = "0.16.0", default-features = false }
+op-alloy-rpc-types-engine = { version = "0.16.0", default-features = false }
 alloy-op-hardforks = { version = "0.2.0", default-features = false }
 
 # Execution

--- a/crates/proof/executor/src/builder/core.rs
+++ b/crates/proof/executor/src/builder/core.rs
@@ -2,13 +2,12 @@
 
 use crate::{ExecutorError, ExecutorResult, TrieDB, TrieDBError, TrieDBProvider};
 use alloc::{string::ToString, vec::Vec};
-use alloy_consensus::{Header, Sealed};
+use alloy_consensus::{Header, Sealed, crypto::RecoveryError};
 use alloy_evm::{
     EvmFactory, FromRecoveredTx, FromTxWithEncoded,
     block::{BlockExecutionResult, BlockExecutor, BlockExecutorFactory},
 };
 use alloy_op_evm::{OpBlockExecutionCtx, OpBlockExecutorFactory, block::OpAlloyReceiptBuilder};
-use alloy_primitives::SignatureError;
 use kona_genesis::RollupConfig;
 use kona_mpt::TrieHinter;
 use op_alloy_consensus::{OpReceiptEnvelope, OpTxEnvelope};
@@ -111,8 +110,8 @@ where
         // Step 3. Execute the block containing the transactions within the payload attributes.
         let transactions = attrs
             .recovered_transactions_with_encoded()
-            .collect::<Result<Vec<_>, SignatureError>>()
-            .map_err(ExecutorError::SignatureError)?;
+            .collect::<Result<Vec<_>, RecoveryError>>()
+            .map_err(ExecutorError::Recovery)?;
         let ex_result = executor.execute_block(transactions.iter())?;
 
         info!(

--- a/crates/proof/executor/src/errors.rs
+++ b/crates/proof/executor/src/errors.rs
@@ -38,9 +38,9 @@ pub enum ExecutorError {
     /// Execution error.
     #[error("Execution error: {0}")]
     ExecutionError(#[from] BlockExecutionError),
-    /// Signature error.
-    #[error("Signature error: {0}")]
-    SignatureError(alloy_primitives::SignatureError),
+    /// Opaque error type for sender recovery from signature and sender pub key.
+    #[error("sender recovery error: {0}")]
+    Recovery(#[from] alloy_consensus::crypto::RecoveryError),
     /// RLP error.
     #[error("RLP error: {0}")]
     RLPError(alloy_eips::eip2718::Eip2718Error),


### PR DESCRIPTION
- Bumps `op-alloy` to latest version
- Bumps `alloy`, `alloy-evm` and `alloy-op-evm` to the required versions in order to bump `op-alloy`