### PR TITLE
fix(kurtosis): fix kurtosis configuration

### DIFF
--- a/.config/kurtosis_network_params.yaml
+++ b/.config/kurtosis_network_params.yaml
@@ -4,11 +4,17 @@
 optimism_package:
   chains:
     - participants:
-      - el_type: op-reth
+      # Note: it seems that op-reth isn't fully compatible with the sequencer mode.
+      # So we use op-geth for now.
+      - el_type: op-geth
         cl_type: op-node
+        el_log_level: "debug"
+        cl_log_level: "debug"
+        count: 1
       - el_type: op-reth
         cl_type: kona-node
-        cl_log_level: "info"
+        el_log_level: "debug"
+        cl_log_level: "debug"
         count: 1
       network_params:
         network: "kurtosis"
@@ -18,10 +24,6 @@ optimism_package:
         fjord_time_offset: 0
         granite_time_offset: 0
         fund_dev_accounts: true
-  op_contract_deployer_params:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.0.12
-    l1_artifacts_locator: https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-fffcbb0ebf7f83311791534a41e65ef90df47797f9ca8f86941452f597f7128c.tar.gz
-    l2_artifacts_locator: https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-fffcbb0ebf7f83311791534a41e65ef90df47797f9ca8f86941452f597f7128c.tar.gz
   global_log_level: "info"
   global_node_selectors: {}
   global_tolerations: []


### PR DESCRIPTION
## Description
Fixes the kurtosis network params to be not fail when running with `just kurtosis-up`. Also ensures that the sequencer is run with `op-geth` as `op-reth` is not yet fully compatible with sequencer mode. Change log levels to debug