### PR TITLE
fix(node-service): Engine sync completion condition

### DIFF
--- a/crates/node/engine/src/sync.rs
+++ b/crates/node/engine/src/sync.rs
@@ -37,12 +37,12 @@ pub enum SyncStatus {
 }
 
 impl SyncStatus {
-    /// Returns if the execution layer sync has started.
+    /// Returns true if the execution layer sync has started.
     pub const fn has_started(&self) -> bool {
         matches!(self, Self::ExecutionLayerStarted)
     }
 
-    /// Returns if syncing is in progress.
+    /// Returns true if syncing is in progress.
     pub const fn is_syncing(&self) -> bool {
         matches!(
             self,
@@ -50,5 +50,10 @@ impl SyncStatus {
                 Self::ExecutionLayerStarted |
                 Self::ExecutionLayerNotFinalized
         )
+    }
+
+    /// Returns true if syncing is finished
+    pub const fn is_finished(&self) -> bool {
+        matches!(self, Self::ExecutionLayerFinished)
     }
 }

--- a/crates/node/engine/src/task_queue/core.rs
+++ b/crates/node/engine/src/task_queue/core.rs
@@ -2,7 +2,6 @@
 
 use super::{EngineTaskError, EngineTaskExt};
 use crate::{EngineState, EngineTask, EngineTaskType};
-use kona_protocol::L2BlockInfo;
 use std::collections::{HashMap, VecDeque};
 use tokio::sync::watch::Sender;
 
@@ -46,9 +45,9 @@ impl Engine {
         self.tasks.entry(task.ty()).or_default().push_back(task);
     }
 
-    /// Returns the L2 Safe Head [`L2BlockInfo`] from the state.
-    pub const fn safe_head(&self) -> L2BlockInfo {
-        self.state.safe_head()
+    /// Returns a reference to the inner [`EngineState`].
+    pub const fn state(&self) -> &EngineState {
+        &self.state
     }
 
     /// Clears the task queue.


### PR DESCRIPTION
## Overview

Updates the condition that the engine actor checks for in order to prompt the beginning of derivation. Previously, it used a call to `eth_syncing`, rather than the engine's own state. This would inadvertently kick off derivation before it EL sync had actually completed.