### PR TITLE
chore(node/p2p): Remove Stale Docs

### DIFF
--- a/crates/node/p2p/src/discv5/driver.rs
+++ b/crates/node/p2p/src/discv5/driver.rs
@@ -29,36 +29,6 @@ use crate::{
 /// If an `Arc<Mutex<>>` were used, a lock held across the operation's future
 /// would be needed since some asynchronous operations require a mutable
 /// reference to the [`Discv5`] service.
-///
-/// ## Example
-///
-/// ```no_run
-/// use discv5::enr::CombinedKey;
-/// use kona_p2p::{Discv5Driver, LocalNode};
-/// use std::net::{IpAddr, Ipv4Addr};
-///
-/// #[tokio::main]
-/// async fn main() {
-///     let CombinedKey::Secp256k1(k256_key) = CombinedKey::generate_secp256k1() else {
-///         unreachable!()
-///     };
-///
-///     let advertise_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
-///     let addr = LocalNode::new(k256_key, advertise_ip, 9099, 9098);
-///     let mut disc = Discv5Driver::builder()
-///         .with_local_node(addr)
-///         .with_chain_id(10) // OP Mainnet chain id
-///         .build()
-///         .expect("Failed to build discovery service");
-///     let (_, mut enr_receiver) = disc.start();
-///
-///     loop {
-///         if let Some(enr) = enr_receiver.recv().await {
-///             println!("Received peer enr: {:?}", enr);
-///         }
-///     }
-/// }
-/// ```
 #[derive(Debug)]
 pub struct Discv5Driver {
     /// The [`Discv5`] discovery service.


### PR DESCRIPTION
### Description

Small PR to remove the stale docs marked `no_run` in `kona-p2p`.