### PR TITLE
chore(node/p2p): Move P2P CLI Utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4112,9 +4112,12 @@ dependencies = [
 name = "kona-cli"
 version = "0.2.0"
 dependencies = [
+ "alloy-primitives",
  "clap",
  "libc",
+ "libp2p",
  "metrics-exporter-prometheus",
+ "thiserror 2.0.12",
  "tracing",
  "tracing-subscriber 0.3.19",
 ]

--- a/bin/node/src/flags/p2p.rs
+++ b/bin/node/src/flags/p2p.rs
@@ -399,14 +399,15 @@ impl P2PArgs {
     pub fn keypair(&self) -> Result<Keypair> {
         // Attempt the parse the private key if specified.
         if let Some(mut private_key) = self.private_key {
-            return kona_p2p::parse_key(&mut private_key.0).map_err(|e| anyhow::anyhow!(e));
+            return kona_cli::SecretKeyLoader::parse(&mut private_key.0)
+                .map_err(|e| anyhow::anyhow!(e));
         }
 
         let Some(ref key_path) = self.priv_path else {
             anyhow::bail!("Neither a raw private key nor a private key file path was provided.");
         };
 
-        kona_p2p::get_keypair(key_path).map_err(|e| anyhow::anyhow!(e))
+        kona_cli::SecretKeyLoader::load(key_path).map_err(|e| anyhow::anyhow!(e))
     }
 }
 

--- a/crates/node/p2p/src/lib.rs
+++ b/crates/node/p2p/src/lib.rs
@@ -44,6 +44,3 @@ mod discv5;
 pub use discv5::{
     Discv5Builder, Discv5BuilderError, Discv5Driver, Discv5Handler, HandlerRequest, LocalNode,
 };
-
-mod utils;
-pub use utils::{KeypairError, ParseKeyError, get_keypair, parse_key};

--- a/crates/node/p2p/src/utils/mod.rs
+++ b/crates/node/p2p/src/utils/mod.rs
@@ -1,4 +1,0 @@
-//! Utility methods for P2P.
-
-mod secret_key;
-pub use secret_key::{KeypairError, ParseKeyError, get_keypair, parse_key};

--- a/crates/utilities/cli/Cargo.toml
+++ b/crates/utilities/cli/Cargo.toml
@@ -12,8 +12,12 @@ publish = false
 workspace = true
 
 [dependencies]
-clap = { workspace = true, features = ["derive", "env"] }
+libp2p.workspace = true
 tracing.workspace = true
+thiserror.workspace = true
+alloy-primitives.workspace = true
+
+clap = { workspace = true, features = ["derive", "env"] }
 tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
 metrics-exporter-prometheus = { workspace = true, features = ["http-listener"] }
 

--- a/crates/utilities/cli/src/lib.rs
+++ b/crates/utilities/cli/src/lib.rs
@@ -8,6 +8,9 @@
 mod clap;
 pub use clap::cli_styles;
 
+mod secrets;
+pub use secrets::{KeypairError, ParseKeyError, SecretKeyLoader};
+
 pub mod backtrace;
 
 mod tracing;


### PR DESCRIPTION
### Description

Moves the `kona-p2p` cli utilities into the `kona-cli` crate for easier accessibility.