### PR TITLE
chore(ci): Normalize foundry version

### DIFF
--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -56,7 +56,17 @@ jobs:
       - name: Extract monorepo forge version
         id: collect-versions
         run: |
-          echo "forge-version=$(yq '.tools.forge' monorepo/mise.toml | tr -d '\n')" >> $GITHUB_OUTPUT
+          append_v() {
+            local input="$1"
+
+            if [[ "$input" == v* ]] || [[ "$input" == nightly* ]]; then
+              echo "$input"
+            else
+              echo "v$input"
+            fi
+          }
+          forge_version=$(append_v "$(yq '.tools.forge' monorepo/mise.toml | tr -d '\n')")
+          echo "forge-version=$forge_version" >> $GITHUB_OUTPUT
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:


### PR DESCRIPTION
## Overview

Normalizes the forge version from the monorepo in the action tests job. `foundry-toolchain` requires appending a `v` to numbered versions since it directly downloads from the tagged release artifacts, and the monorepo's `mise.toml` doesn't do this.

This workaround can be removed once `foundry-toolchain` has implemented https://github.com/foundry-rs/foundry-toolchain/issues/73