### PR TITLE
fix(node): Zero `safe` + `finalized` hashes while EL syncs

### DIFF
--- a/crates/node/engine/src/attributes.rs
+++ b/crates/node/engine/src/attributes.rs
@@ -120,7 +120,7 @@ impl AttributesMatch {
         // Note that it is safe to zip both iterators because we checked their length
         // beforehand.
         for (attr_tx_bytes, block_tx) in attributes_txs.iter().zip(block_txs) {
-            debug!(
+            trace!(
                 target: "engine",
                 ?attr_tx_bytes,
                 block_tx_hash = %block_tx.tx_hash(),
@@ -157,7 +157,7 @@ impl AttributesMatch {
             }
 
             if &attr_tx != block_tx {
-                debug!(target: "engine", ?attr_tx, ?block_tx, "Transaction mismatch");
+                warn!(target: "engine", ?attr_tx, ?block_tx, "Transaction mismatch in derived attributes");
                 return AttributesMismatch::TransactionContent(attr_tx.tx_hash(), block_tx.tx_hash())
                     .into()
             }


### PR DESCRIPTION
## Overview

Sets the `safe` and `finalized` hashes to `B256::ZERO` while the EL syncs, and also only finalizes the unsafe ref if the client is undergoing its _initial_ sync.

Also moves the priority of the `sync_complete_rx.recv()` future in the biased select within the derivation actor. Since the futures are polled in-order, that future always resolves once the channel has been closed - it must be placed last.