### PR TITLE
fix(ci): Use stable toolchain for lint job

### DIFF
--- a/.github/workflows/client_host.yaml
+++ b/.github/workflows/client_host.yaml
@@ -30,6 +30,7 @@ jobs:
           cache-on-failure: true
           prefix-key: ${{ matrix.target }}-${{ matrix.name }}
       - name: Log into ghcr
+        if: "!contains(matrix.target, 'native')"
         uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/.github/workflows/rust_ci.yaml
+++ b/.github/workflows/rust_ci.yaml
@@ -36,10 +36,14 @@ jobs:
           submodules: true
       - uses: ./.github/actions/setup
         with:
-          channel: nightly
-          components: rustfmt,clippy
+          channel: stable
+          components: clippy
           prefix-key: ${{ matrix.target }}
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
       - name: Log into ghcr
+        if: ${{ matrix.target != 'native' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -84,6 +88,7 @@ jobs:
           channel: nightly
           prefix-key: ${{ matrix.target }}
       - name: Log into ghcr
+        if: ${{ matrix.target != 'native' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io


### PR DESCRIPTION
## Overview

Fixes the lint job by using the stable toolchain for the `fmt + lint` job. `cargo fmt` still uses nightly, but clippy uses stable.