### PR TITLE
fix(node): Set `local-safe` and `cross-unsafe` labels

### DIFF
--- a/crates/node/engine/src/attributes.rs
+++ b/crates/node/engine/src/attributes.rs
@@ -120,7 +120,7 @@ impl AttributesMatch {
         // Note that it is safe to zip both iterators because we checked their length
         // beforehand.
         for (attr_tx_bytes, block_tx) in attributes_txs.iter().zip(block_txs) {
-            debug!(
+            trace!(
                 target: "engine",
                 ?attr_tx_bytes,
                 block_tx_hash = %block_tx.tx_hash(),
@@ -157,7 +157,7 @@ impl AttributesMatch {
             }
 
             if &attr_tx != block_tx {
-                debug!(target: "engine", ?attr_tx, ?block_tx, "Transaction mismatch");
+                warn!(target: "engine", ?attr_tx, ?block_tx, "Transaction mismatch in derived attributes");
                 return AttributesMismatch::TransactionContent(attr_tx.tx_hash(), block_tx.tx_hash())
                     .into()
             }

--- a/crates/node/engine/src/task_queue/tasks/build/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/build/task.rs
@@ -232,7 +232,9 @@ impl BuildTask {
                     L2BlockInfo::from_payload_and_genesis(&payload, &cfg.genesis).unwrap();
 
                 state.set_unsafe_head(imported_info);
+                state.set_cross_unsafe_head(imported_info);
                 if self.is_attributes_derived {
+                    state.set_local_safe_head(imported_info);
                     state.set_safe_head(imported_info);
                 }
 

--- a/crates/node/engine/src/task_queue/tasks/consolidate/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/consolidate/task.rs
@@ -87,6 +87,7 @@ impl ConsolidateTask {
             match L2BlockInfo::from_block_and_genesis(&block.into_consensus(), &self.cfg.genesis) {
                 Ok(block_info) => {
                     debug!(target: "engine", ?block_info, "Promoted safe head");
+                    state.set_local_safe_head(block_info);
                     state.set_safe_head(block_info);
                     match self.execute_forkchoice_task(state).await {
                         Ok(()) => {

--- a/crates/node/engine/src/task_queue/tasks/insert/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/insert/task.rs
@@ -190,6 +190,7 @@ impl EngineTaskExt for InsertUnsafeTask {
         }
 
         // Update the local engine state.
+        state.set_cross_unsafe_head(new_unsafe_ref);
         state.set_unsafe_head(new_unsafe_ref);
         state.forkchoice_update_needed = false;
 


### PR DESCRIPTION
## Overview

Sets the `cross-unsafe` and `local-safe` labels along with the `unsafe` and `safe` labels. Pre-interop, these labels exactly track each other. When we get around to adding interop support, we'll need to add conditionals for cross-unsafety and reach out to the supervisor for `cross-safe` (`safe` label) promotion