### PR TITLE
chore(workspace): Use `alloy-eips`' `EMPTY_REQUESTS_HASH` constant

### DIFF
--- a/crates/node/p2p/Cargo.toml
+++ b/crates/node/p2p/Cargo.toml
@@ -25,6 +25,7 @@ alloy-rlp.workspace = true
 alloy-primitives = { workspace = true, features = ["k256", "getrandom"] }
 alloy-rpc-types-engine.workspace = true
 alloy-consensus.workspace = true
+alloy-eips.workspace = true
 
 # Op Alloy
 op-alloy-consensus = { workspace = true, features = ["k256"] }

--- a/crates/node/p2p/src/gossip/block_validity.rs
+++ b/crates/node/p2p/src/gossip/block_validity.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashSet, time::SystemTime};
 
 use alloy_consensus::Block;
+use alloy_eips::eip7685::EMPTY_REQUESTS_HASH;
 use alloy_primitives::{Address, B256};
 use alloy_rpc_types_engine::{ExecutionPayloadV3, PayloadError};
 use libp2p::gossipsub::MessageAcceptance;
@@ -132,9 +133,7 @@ impl BlockHandler {
         block.header.parent_beacon_block_root = envelope.parent_beacon_block_root;
         // If isthmus is active, set the requests hash to the empty hash.
         if self.rollup_config.is_isthmus_active(envelope.payload.timestamp()) {
-            block.header.requests_hash = Some(alloy_primitives::b256!(
-                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-            ));
+            block.header.requests_hash = Some(EMPTY_REQUESTS_HASH);
         }
         let received = block.header.hash_slow();
         if received != expected {

--- a/crates/proof/executor/src/builder/assemble.rs
+++ b/crates/proof/executor/src/builder/assemble.rs
@@ -2,12 +2,12 @@
 
 use super::StatelessL2Builder;
 use crate::{
-    ExecutorError, ExecutorResult, TrieDBError, TrieDBProvider, constants::SHA256_EMPTY,
+    ExecutorError, ExecutorResult, TrieDBError, TrieDBProvider,
     util::encode_holocene_eip_1559_params,
 };
 use alloc::vec::Vec;
 use alloy_consensus::{EMPTY_OMMER_ROOT_HASH, Header, Sealed};
-use alloy_eips::Encodable2718;
+use alloy_eips::{Encodable2718, eip7685::EMPTY_REQUESTS_HASH};
 use alloy_evm::{EvmFactory, block::BlockExecutionResult};
 use alloy_primitives::{B256, Sealable, U256, logs_bloom};
 use alloy_trie::EMPTY_ROOT_HASH;
@@ -78,7 +78,7 @@ where
             .unwrap_or_default();
 
         // The requests hash on the OP Stack, if Isthmus is active, is always the empty SHA256 hash.
-        let requests_hash = self.config.is_isthmus_active(timestamp).then_some(SHA256_EMPTY);
+        let requests_hash = self.config.is_isthmus_active(timestamp).then_some(EMPTY_REQUESTS_HASH);
 
         // Construct the new header.
         let header = Header {

--- a/crates/proof/executor/src/constants.rs
+++ b/crates/proof/executor/src/constants.rs
@@ -1,10 +1,4 @@
 //! Protocol constants for the executor.
 
-use alloy_primitives::{B256, b256};
-
 /// The version byte for the Holocene extra data.
 pub(crate) const HOLOCENE_EXTRA_DATA_VERSION: u8 = 0x00;
-
-/// Empty SHA-256 hash.
-pub(crate) const SHA256_EMPTY: B256 =
-    b256!("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");


### PR DESCRIPTION
## Overview

Uses `alloy-eips`' `EMPTY_REQUESTS_HASH` constant, rather than defining constants of our own for the empty sha256 hash.