### PR TITLE
feat(engine): Engine reset counter metric

### DIFF
--- a/crates/node/engine/src/metrics/mod.rs
+++ b/crates/node/engine/src/metrics/mod.rs
@@ -38,6 +38,9 @@ impl Metrics {
     /// `engine_getPayloadV<N>` label.
     pub const GET_PAYLOAD_METHOD: &str = "engine_getPayload";
 
+    /// Identifier for the counter that tracks the number of times the engine has been reset.
+    pub const ENGINE_RESET_COUNT: &str = "kona_node_engine_reset_count";
+
     /// Initializes metrics for the engine.
     ///
     /// This does two things:
@@ -58,11 +61,18 @@ impl Metrics {
         // Engine task counts
         metrics::describe_counter!(Self::ENGINE_TASK_COUNT, "Engine task counts");
 
-        // FCU time histogram
+        // Engine method request duration histogram
         metrics::describe_histogram!(
             Self::ENGINE_METHOD_REQUEST_DURATION,
             metrics::Unit::Seconds,
             "Engine method request duration"
+        );
+
+        // Engine reset counter
+        metrics::describe_counter!(
+            Self::ENGINE_RESET_COUNT,
+            metrics::Unit::Count,
+            "Engine reset count"
         );
     }
 
@@ -82,5 +92,8 @@ impl Metrics {
         kona_macros::set!(counter, Self::ENGINE_TASK_COUNT, Self::CONSOLIDATE_TASK_LABEL, 0);
         kona_macros::set!(counter, Self::ENGINE_TASK_COUNT, Self::FORKCHOICE_TASK_LABEL, 0);
         kona_macros::set!(counter, Self::ENGINE_TASK_COUNT, Self::BUILD_TASK_LABEL, 0);
+
+        // Engine reset count
+        kona_macros::set!(counter, Self::ENGINE_RESET_COUNT, 0);
     }
 }

--- a/crates/node/engine/src/task_queue/core.rs
+++ b/crates/node/engine/src/task_queue/core.rs
@@ -1,7 +1,7 @@
 //! The [`Engine`] is a task queue that receives and executes [`EngineTask`]s.
 
 use super::{EngineTaskError, EngineTaskExt};
-use crate::{EngineClient, EngineState, EngineTask};
+use crate::{EngineClient, EngineState, EngineTask, Metrics};
 use alloy_provider::Provider;
 use alloy_rpc_types_eth::Transaction;
 use kona_genesis::{RollupConfig, SystemConfig};
@@ -108,6 +108,8 @@ impl Engine {
             .into_consensus()
             .map_transactions(|t| <Transaction<OpTxEnvelope> as Clone>::clone(&t).into_inner());
         let system_config = to_system_config(&l2_safe_block, config)?;
+
+        kona_macros::inc!(counter, Metrics::ENGINE_RESET_COUNT);
 
         Ok((start.safe, l1_origin_info, system_config))
     }

--- a/crates/node/macros/src/metrics.rs
+++ b/crates/node/macros/src/metrics.rs
@@ -19,6 +19,10 @@ macro_rules! set {
         #[cfg(feature = "metrics")]
         metrics::$instrument!($metric, "type" => $value).set($amount);
     };
+    (counter, $metric:path, $value:expr) => {
+        #[cfg(feature = "metrics")]
+        metrics::counter!($metric).absolute($value);
+    };
     ($instrument:ident, $metric:path, $value:expr) => {
         #[cfg(feature = "metrics")]
         metrics::$instrument!($metric).set($value);


### PR DESCRIPTION
## Overview

Adds a metric that tracks the number of times the engine has been reset.

closes https://github.com/op-rs/kona/issues/1627 (the engine reset, by proxy, is a derivation reset.)