### PR TITLE
feat(node/p2p): enable support for the peers RPC endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "398be19900ac9fe2ad7214ac7bd6462fd9ae2e0366a3b5d532213e8353713b7d"
+checksum = "de0210f2d5854895b376f7fbbf78f3e33eb4f0e59abc503502cc0ed8d295a837"
 dependencies = [
  "alloy-consensus 1.0.1",
  "alloy-eips 1.0.1",
@@ -429,7 +429,7 @@ checksum = "e7a290b11f3a3e0a34d09c5ef55afe7ec91890824b8daf73b1a99c152f6ad94c"
 dependencies = [
  "alloy-consensus 1.0.1",
  "alloy-eips 1.0.1",
- "alloy-evm 0.8.0",
+ "alloy-evm 0.8.1",
  "alloy-op-hardforks",
  "alloy-primitives",
  "auto_impl",
@@ -1872,9 +1872,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.15"
+version = "1.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
+checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
 dependencies = [
  "jobserver",
  "libc",
@@ -3183,16 +3183,15 @@ checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
 name = "generator"
-version = "0.8.5"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d18470a76cb7f8ff746cf1f7470914f900252ec36bbc40b569d74b1258446827"
+checksum = "cc6bd114ceda131d3b1d665eba35788690ad37f5916457286b32ab6fd3c438dd"
 dependencies = [
- "cc",
  "cfg-if",
  "libc",
  "log",
  "rustversion",
- "windows 0.61.1",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -4271,7 +4270,7 @@ version = "1.0.1"
 dependencies = [
  "alloy-consensus 1.0.1",
  "alloy-eips 1.0.1",
- "alloy-evm 0.8.0",
+ "alloy-evm 0.8.1",
  "alloy-op-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -4368,7 +4367,7 @@ name = "kona-driver"
 version = "0.3.0"
 dependencies = [
  "alloy-consensus 1.0.1",
- "alloy-evm 0.8.0",
+ "alloy-evm 0.8.1",
  "alloy-primitives",
  "alloy-rlp",
  "async-trait",
@@ -4432,7 +4431,7 @@ version = "0.3.0"
 dependencies = [
  "alloy-consensus 1.0.1",
  "alloy-eips 1.0.1",
- "alloy-evm 0.8.0",
+ "alloy-evm 0.8.1",
  "alloy-op-evm",
  "alloy-op-hardforks",
  "alloy-primitives",
@@ -4732,7 +4731,7 @@ version = "0.3.0"
 dependencies = [
  "alloy-consensus 1.0.1",
  "alloy-eips 1.0.1",
- "alloy-evm 0.8.0",
+ "alloy-evm 0.8.1",
  "alloy-op-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -4771,7 +4770,7 @@ version = "0.2.0"
 dependencies = [
  "alloy-consensus 1.0.1",
  "alloy-eips 1.0.1",
- "alloy-evm 0.8.0",
+ "alloy-evm 0.8.1",
  "alloy-op-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -5459,7 +5458,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tracing",
  "yamux 0.12.1",
- "yamux 0.13.5",
+ "yamux 0.13.4",
 ]
 
 [[package]]
@@ -9783,24 +9782,12 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.61.1"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
- "windows-collections",
- "windows-core 0.61.0",
- "windows-future",
- "windows-link",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core 0.61.0",
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -9815,25 +9802,39 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.0",
+ "windows-interface 0.59.1",
  "windows-link",
  "windows-result 0.3.2",
  "windows-strings 0.4.0",
 ]
 
 [[package]]
-name = "windows-future"
-version = "0.2.0"
+name = "windows-implement"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1d6bbefcb7b60acd19828e1bc965da6fcf18a7e39490c5f8be71e54a19ba32"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
- "windows-core 0.61.0",
- "windows-link",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9841,6 +9842,17 @@ name = "windows-implement"
 version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9865,16 +9877,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.0",
- "windows-link",
-]
-
-[[package]]
 name = "windows-registry"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9896,11 +9898,30 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -10322,16 +10343,16 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.13.5"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da1acad1c2dc53f0dde419115a38bd8221d8c3e47ae9aeceaf453266d29307e"
+checksum = "17610762a1207ee816c6fadc29220904753648aba0a9ed61c7b8336e80a559c4"
 dependencies = [
  "futures",
  "log",
  "nohash-hasher",
  "parking_lot",
  "pin-project",
- "rand 0.9.1",
+ "rand 0.8.5",
  "static_assertions",
  "web-time",
 ]

--- a/crates/node/p2p/src/discv5/driver.rs
+++ b/crates/node/p2p/src/discv5/driver.rs
@@ -312,13 +312,22 @@ impl Discv5Driver {
                                 HandlerRequest::AddEnr(enr) => {
                                     let _ = self.disc.add_enr(enr);
                                 }
-                                HandlerRequest::RequestEnr(enode) => {
-                                    let _ = self.disc.request_enr(enode).await;
+                                HandlerRequest::RequestEnr{out, addr} => {
+                                    let enr = self.disc.request_enr(addr).await;
+                                    if let Err(e) = out.send(enr) {
+                                        warn!(target: "discovery", "Failed to send request enr: {:?}", e);
+                                    }
                                 }
                                 HandlerRequest::TableEnrs(tx) => {
                                     let enrs = self.disc.table_entries_enr();
                                     if let Err(e) = tx.send(enrs) {
                                         warn!(target: "discovery", "Failed to send table enrs: {:?}", e);
+                                    }
+                                },
+                                HandlerRequest::TableInfos(tx) => {
+                                    let infos = self.disc.table_entries();
+                                    if let Err(e) = tx.send(infos) {
+                                        warn!(target: "discovery", "Failed to send table infos: {:?}", e);
                                     }
                                 },
                                 HandlerRequest::BanAddrs{addrs_to_ban, ban_duration} => {

--- a/crates/node/p2p/src/rpc/request.rs
+++ b/crates/node/p2p/src/rpc/request.rs
@@ -1,10 +1,20 @@
 //! Contains the p2p RPC request type.
 
+use std::collections::HashMap;
+
 use crate::{Discv5Handler, GossipDriver};
-use discv5::multiaddr::Protocol;
+use alloy_primitives::map::foldhash::fast::RandomState;
+use discv5::{
+    enr::{NodeId, k256::ecdsa},
+    multiaddr::Protocol,
+};
+use libp2p::PeerId;
 use tokio::sync::oneshot::Sender;
 
-use super::types::{Connectedness, Direction, PeerInfo, PeerScores};
+use super::{
+    PeerDump,
+    types::{Connectedness, Direction, PeerInfo, PeerScores},
+};
 
 /// A p2p RPC Request.
 #[derive(Debug)]
@@ -17,6 +27,14 @@ pub enum P2pRpcRequest {
     /// - Discovery Service ([`crate::Discv5Driver`])
     /// - Gossip Service ([`crate::GossipDriver`])
     PeerCount(Sender<(Option<usize>, usize)>),
+    /// Returns a [`PeerDump`] containing detailed information about connected peers.
+    /// If `connected` is true, only returns connected peers.
+    Peers {
+        /// The output channel to send the [`PeerDump`] to.
+        out: Sender<PeerDump>,
+        /// Whether to only return connected peers.
+        connected: bool,
+    },
 }
 
 impl P2pRpcRequest {
@@ -26,6 +44,7 @@ impl P2pRpcRequest {
             Self::PeerCount(s) => Self::handle_peer_count(s, gossip, disc),
             Self::DiscoveryTable(s) => Self::handle_discovery_table(s, disc),
             Self::PeerInfo(s) => Self::handle_peer_info(s, gossip, disc),
+            Self::Peers { out, connected } => Self::handle_peers(out, connected, gossip, disc),
         }
     }
 
@@ -43,6 +62,129 @@ impl P2pRpcRequest {
 
             if let Err(e) = sender.send(dt) {
                 warn!("Failed to send peer count through response channel: {:?}", e);
+            }
+        });
+    }
+
+    fn handle_peers(
+        sender: Sender<PeerDump>,
+        connected: bool,
+        gossip: &GossipDriver,
+        disc: &Discv5Handler,
+    ) {
+        let Ok(total_connected) = gossip.swarm.network_info().num_peers().try_into() else {
+            error!(target: "p2p::rpc", "Failed to get total connected peers. The number of connected peers is too large and overflows u32.");
+            return;
+        };
+
+        let peer_ids: Vec<PeerId> = if connected {
+            gossip.swarm.connected_peers().cloned().collect()
+        } else {
+            gossip.peerstore.keys().cloned().collect()
+        };
+
+        // Build a map of peer ids to their supported protocols.
+        let mut protocols: HashMap<PeerId, Vec<String>> =
+            gossip.swarm.behaviour().gossipsub.peer_protocol().fold(
+                HashMap::new(),
+                |mut protocols, (id, protocol)| {
+                    protocols.entry(*id).or_default().push(protocol.to_string());
+                    protocols
+                },
+            );
+
+        // Build a map of peer ids to their known addresses.
+        let mut addresses: HashMap<PeerId, Vec<String>> =
+        peer_ids.iter().filter_map(|id| {
+            gossip.peerstore.get(id).or_else(|| {
+                warn!(target: "p2p::rpc", "Failed to get peer address. The peerstore is not in sync with the gossip swarm.");
+                None
+            }).map(|addr| (*id, vec![addr.to_string()]))
+        }).collect();
+
+        let disc_table_infos = disc.table_infos();
+
+        tokio::spawn(async move {
+            let Ok(table_infos) = disc_table_infos.await else {
+                error!(target: "p2p::rpc", "Failed to get table infos. The connection to the gossip driver is closed.");
+                return;
+            };
+
+            let node_to_peer_id: HashMap<NodeId, PeerId> = peer_ids.into_iter().filter_map(|id|
+            {
+                let Ok(pubkey) = libp2p_identity::PublicKey::try_decode_protobuf(&id.to_bytes()[2..]) else {
+                    error!(target: "p2p::rpc", peer_id = ?id, "Failed to decode public key from peer id. This is a bug as all the peer ids should be decodable (because they come from secp256k1 public keys).");
+                    return None;
+                };
+
+                let key =
+                match pubkey.try_into_secp256k1().map_err(|err| err.to_string()).and_then(
+                    |key| ecdsa::VerifyingKey::from_sec1_bytes(key.to_bytes().as_slice()).map_err(|err| err.to_string())
+                )    {                     Ok(key) => key,
+                        Err(err) => {
+                            error!(target: "p2p::rpc", peer_id = ?id, err = ?err, "Failed to convert public key to secp256k1 public key. This is a bug.");
+                            return None;
+                        }};
+                let node_id = NodeId::from(key);
+                Some((node_id, id))
+            }
+            ).collect();
+
+            let infos: HashMap<String, PeerInfo, RandomState> = table_infos
+                .iter()
+                .filter_map(|(id, enr, status)| {
+                    // TODO(@theochap, `<https://github.com/op-rs/kona/issues/1562>`): improve the connectedness information to include the other
+                    // variants.
+                    let connectedness = if status.is_connected() {
+                        Connectedness::Connected
+                    } else {
+                        Connectedness::NotConnected
+                    };
+
+                    let direction =
+                        if status.is_incoming() { Direction::Inbound } else { Direction::Outbound };
+
+                    node_to_peer_id.get(id).map(|peer_id| {
+                        (
+                            peer_id.to_string(),
+                            PeerInfo {
+                                peer_id: peer_id.to_string(),
+                                node_id: enr.node_id().to_string(),
+                                // TODO(@theochap, `<https://github.com/op-rs/kona/issues/1562>`): support these fields
+                                user_agent: String::new(),
+                                // TODO(@theochap): support these fields
+                                protocol_version: String::new(),
+                                enr: enr.to_string(),
+                                addresses: addresses.remove(peer_id).unwrap_or_default(),
+                                protocols: protocols.remove(peer_id),
+                                connectedness,
+                                direction,
+                                // TODO(@theochap, `<https://github.com/op-rs/kona/issues/1562>`): support these fields
+                                protected: false,
+                                // TODO(@theochap, `<https://github.com/op-rs/kona/issues/1562>`): support these fields
+                                chain_id: 0,
+                                // TODO(@theochap, `<https://github.com/op-rs/kona/issues/1562>`): support these fields
+                                latency: 0,
+                                // TODO(@theochap, `<https://github.com/op-rs/kona/issues/1562>`): support these fields
+                                gossip_blocks: false,
+                                // TODO(@theochap, `<https://github.com/op-rs/kona/issues/1562>`): support these fields
+                                peer_scores: PeerScores::default(),
+                            },
+                        )
+                    })
+                })
+                .collect();
+
+            if let Err(e) = sender.send(PeerDump {
+                total_connected,
+                peers: infos,
+
+                // TODO(@theochap): support these fields
+                banned_peers: vec![],
+                banned_ips: vec![],
+                banned_subnets: vec![],
+            }) {
+                warn!(target: "p2p::rpc", "Failed to send peer info through response channel: {:?}", e);
             }
         });
     }


### PR DESCRIPTION
## Description

To be able to properly test the `kona-node` synchronization primitives we need to add RPC methods that would allow to interact with the node's internal state.

This PR starts the implementation of the `opp2p_peers` endpoint. A series of follow-up PRs will complete the implementation

Progress towards #1562