### PR TITLE
feat(node/p2p): implements the `opp2p_peerStats` endpoint

### DIFF
--- a/crates/node/p2p/src/discv5/driver.rs
+++ b/crates/node/p2p/src/discv5/driver.rs
@@ -342,7 +342,7 @@ impl Discv5Driver {
                                             self.disc.ban_node(&enr.node_id(), Some(ban_duration));
                                         }
                                     }
-                                }
+                                },
                             }
                             None => {
                                 trace!(target: "discovery", "Receiver `None` peer enr");

--- a/crates/node/p2p/src/discv5/handler.rs
+++ b/crates/node/p2p/src/discv5/handler.rs
@@ -65,7 +65,7 @@ impl Discv5Handler {
         let sender = self.sender.clone();
         tokio::spawn(async move {
             if let Err(e) = sender.send(HandlerRequest::TableEnrs(tx)).await {
-                warn!("Failed to send table ENRs request: {:?}", e);
+                warn!(target: "discovery", err = ?e, "Failed to send table ENRs request");
             }
         });
         rx
@@ -92,7 +92,7 @@ impl Discv5Handler {
         let sender = self.sender.clone();
         tokio::spawn(async move {
             if let Err(e) = sender.send(HandlerRequest::LocalEnr(tx)).await {
-                warn!("Failed to send local ENR request: {:?}", e);
+                warn!(target: "discovery", err = ?e, "Failed to send local ENR request");
             }
         });
         rx
@@ -123,7 +123,7 @@ impl Discv5Handler {
         let sender = self.sender.clone();
         tokio::spawn(async move {
             if let Err(e) = sender.send(HandlerRequest::Metrics(tx)).await {
-                warn!("Failed to send metrics request: {:?}", e);
+                warn!(target: "discovery", err = ?e, "Failed to send metrics request");
             }
         });
         rx
@@ -137,7 +137,7 @@ impl Discv5Handler {
         let sender = self.sender.clone();
         tokio::spawn(async move {
             if let Err(e) = sender.send(HandlerRequest::PeerCount(tx)).await {
-                warn!("Failed to send peer count request: {:?}", e);
+                warn!(target: "discovery", err = ?e, "Failed to send peer count request");
             }
         });
         rx

--- a/crates/node/p2p/src/rpc/types.rs
+++ b/crates/node/p2p/src/rpc/types.rs
@@ -160,6 +160,9 @@ pub struct PeerStats {
     /// The blocks v3 topic.
     #[serde(rename = "blocksTopicV3")]
     pub blocks_topic_v3: u32,
+    /// The blocks v4 topic.
+    #[serde(rename = "blocksTopicV4")]
+    pub blocks_topic_v4: u32,
     /// The banned count.
     pub banned: u32,
     /// The known count.

--- a/crates/node/rpc/src/jsonrpsee.rs
+++ b/crates/node/rpc/src/jsonrpsee.rs
@@ -63,9 +63,9 @@ pub trait OpP2PApi {
     #[method(name = "peerCount")]
     async fn opp2p_peer_count(&self) -> RpcResult<PeerCount>;
 
-    /// Returns information of peers
+    /// Returns information of peers. If `connected` is true, only returns connected peers.
     #[method(name = "peers")]
-    async fn opp2p_peers(&self) -> RpcResult<PeerDump>;
+    async fn opp2p_peers(&self, connected: bool) -> RpcResult<PeerDump>;
 
     /// Returns statistics of peers
     #[method(name = "peerStats")]


### PR DESCRIPTION
## Description
This PR implements the `opp2p_peerStats` endpoint to expose more internal information from the node through RPC. 

This is progress towards #1634 and completes a good chunk of #1563 (this should close it)