### PR TITLE
fix(node/kurtosis-e2e-test): fixes the versionning for the e2e testing package

### DIFF
--- a/tests/Justfile
+++ b/tests/Justfile
@@ -18,7 +18,6 @@ _build-node COMMIT_TAG="":
 
     cd {{SOURCE}}/.. && just build-node-with-tag $COMMIT_TAG
 
-
 deploy DEVNET_FILE_PATH COMMIT_TAG="" NAME="": (_build-node COMMIT_TAG) setup clone-optimism install-optimism
     #!/usr/bin/env bash
     cd {{SOURCE}}/../optimism/kurtosis-devnet
@@ -33,7 +32,6 @@ deploy DEVNET_FILE_PATH COMMIT_TAG="" NAME="": (_build-node COMMIT_TAG) setup cl
     if [ -z "{{NAME}}" ]; then
         export DEVNET_NAME=`basename $TARGET_NAME .yaml`
     fi
-
 
     export ENCL_NAME="$DEVNET_NAME"-devnet
     

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -2,7 +2,8 @@ module github.com/op-rs/kona
 
 go 1.24.3
 
-require github.com/ethereum-optimism/optimism v1.13.3-0.20250516221950-6fd68b71a61a
+// We're using the "develop" branch of the Optimism repo to include the latest changes to the `devnet-sdk` package.
+require github.com/ethereum-optimism/optimism v1.13.3-0.20250520004549-7962d43f57e6
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
@@ -163,6 +164,9 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum-optimism/optimism/op-node v0.10.14 => github.com/ethereum-optimism/optimism v1.13.2
+replace github.com/ethereum-optimism/optimism/op-node v0.10.14 => github.com/ethereum-optimism/optimism v1.13.3-0.20250520004549-7962d43f57e6
+
+// Patched version of the Optimism repo that includes the latest changes of the `devnet-sdk` package to enable testing for the CL clients.
+replace github.com/ethereum-optimism/optimism v1.13.3-0.20250520004549-7962d43f57e6 => github.com/theochap/optimism v0.0.0-20250520030832-c6ddf76c3505
 
 replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101503.4-rc.1

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -116,8 +116,6 @@ github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
 github.com/ethereum-optimism/op-geth v1.101503.4-rc.1 h1:ddcoFOmABL7bwz6b0pllSE4Org9iFTwMN6r1G6NRy3w=
 github.com/ethereum-optimism/op-geth v1.101503.4-rc.1/go.mod h1:QUo3fn+45vWqJWzJW+rIzRHUV7NmhhHLPdI87mAn1M8=
-github.com/ethereum-optimism/optimism v1.13.3-0.20250516221950-6fd68b71a61a h1:jFJvpJ9DgEw3Hq+TEOLE0nb6uH+7x+gp9XybO6/Nuik=
-github.com/ethereum-optimism/optimism v1.13.3-0.20250516221950-6fd68b71a61a/go.mod h1:WrVFtk3cP45tvHs7MARn9KGQu35XIoXo/IOWU6K/rzk=
 github.com/ethereum/c-kzg-4844 v1.0.0 h1:0X1LBXxaEtYD9xsyj9B9ctQEZIpnvVDeoBx8aHEwTNA=
 github.com/ethereum/c-kzg-4844 v1.0.0/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
 github.com/ethereum/go-verkle v0.2.2 h1:I2W0WjnrFUIzzVPwm8ykY+7pL2d4VhlsePn4j7cnFk8=
@@ -411,6 +409,8 @@ github.com/supranational/blst v0.3.14/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a h1:1ur3QoCqvE5fl+nylMaIr9PVV1w343YRDtsy+Rwu7XI=
 github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
+github.com/theochap/optimism v0.0.0-20250520030832-c6ddf76c3505 h1:RlE5BXELuuK/sgC2Po5nQLsQU1OuJ3pbMWG7fMAJXIc=
+github.com/theochap/optimism v0.0.0-20250520030832-c6ddf76c3505/go.mod h1:WrVFtk3cP45tvHs7MARn9KGQu35XIoXo/IOWU6K/rzk=
 github.com/tklauser/go-sysconf v0.3.14 h1:g5vzr9iPFFz24v2KZXs/pvpvh8/V9Fw6vQK5ZZb78yU=
 github.com/tklauser/go-sysconf v0.3.14/go.mod h1:1ym4lWMLUOhuBOPGtRcJm7tEGX4SCYNEEEtghGG/8uY=
 github.com/tklauser/numcpus v0.8.0 h1:Mx4Wwe/FjZLeQsK/6kt2EOepwwSl7SmJrK5bV/dXYgY=


### PR DESCRIPTION
## Description

This PR fixes the package versions of the go e2e test folder. This fix ensures that the kurtosis CI job fails if the `kona-node` fails to start inside kurtosis. This will help preventing breaking the kurtosis deployment (at least at startup).

Merging this PR means we'll be using the version of the monorepo from my fork `https://github.com/theochap/optimism`. This will be helpful to add features to the `devnet-sdk` without waiting for approval inside the `ethereum-optimism/optimism` repo. Once we stabilize the `devnet-sdk` we can remove the pointer to the forked version of the node.