### PR TITLE
feat(node-service): Handle derivation reset events

### DIFF
--- a/crates/node/service/src/actors/derivation.rs
+++ b/crates/node/service/src/actors/derivation.rs
@@ -5,14 +5,14 @@ use async_trait::async_trait;
 use kona_derive::{
     errors::{PipelineError, PipelineErrorKind, ResetError},
     traits::{Pipeline, SignalReceiver},
-    types::{ActivationSignal, ResetSignal, Signal, StepResult},
+    types::{ActivationSignal, Signal, StepResult},
 };
 use kona_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent};
 use thiserror::Error;
 use tokio::{
     select,
     sync::{
-        mpsc::{UnboundedReceiver, UnboundedSender, error::SendError},
+        mpsc::{UnboundedReceiver, UnboundedSender},
         watch::Receiver as WatchReceiver,
     },
 };
@@ -30,6 +30,7 @@ where
 {
     /// The derivation pipeline.
     pipeline: P,
+
     /// The l2 safe head from the engine.
     engine_l2_safe_head: WatchReceiver<L2BlockInfo>,
     /// A receiver that tells derivation to begin.
@@ -53,16 +54,23 @@ where
     ///
     /// Specs: <https://specs.optimism.io/protocol/derivation.html#l1-sync-payload-attributes-processing>
     derivation_signal_rx: UnboundedReceiver<Signal>,
+
     /// The receiver for L1 head update notifications.
     l1_head_updates: UnboundedReceiver<BlockInfo>,
-    /// The sender for derived [OpAttributesWithParent]s produced by the actor.
+    /// The sender for derived [`OpAttributesWithParent`]s produced by the actor.
     attributes_out: UnboundedSender<OpAttributesWithParent>,
+    /// The reset request sender, used to handle [`PipelineErrorKind::Reset`] events and forward
+    /// them to the engine.
+    reset_request_tx: UnboundedSender<()>,
 
     /// A flag indicating whether the derivation pipeline is ready to start.
     engine_ready: bool,
     /// A flag indicating whether or not derivation is idle. Derivation is considered idle when it
     /// has yielded to wait for more data on the DAL.
     derivation_idle: bool,
+    /// A flag indicating whether or not derivation is waiting for a signal. When waiting for a
+    /// signal, derivation cannot process any incoming events.
+    waiting_for_signal: bool,
 
     /// The cancellation token, shared between all tasks.
     cancellation: CancellationToken,
@@ -81,6 +89,7 @@ where
         derivation_signal_rx: UnboundedReceiver<Signal>,
         l1_head_updates: UnboundedReceiver<BlockInfo>,
         attributes_out: UnboundedSender<OpAttributesWithParent>,
+        reset_request_tx: UnboundedSender<()>,
         cancellation: CancellationToken,
     ) -> Self {
         Self {
@@ -90,8 +99,10 @@ where
             derivation_signal_rx,
             l1_head_updates,
             attributes_out,
+            reset_request_tx,
             engine_ready: false,
             derivation_idle: true,
+            waiting_for_signal: false,
             cancellation,
         }
     }
@@ -169,22 +180,12 @@ where
                                     );
                                 }
 
-                                // Reset the pipeline to the initial L2 safe head and L1 origin,
-                                // and try again.
-                                let l1_origin = self
-                                    .pipeline
-                                    .origin()
-                                    .ok_or(PipelineError::MissingOrigin.crit())?;
-                                self.pipeline
-                                    .signal(
-                                        ResetSignal {
-                                            l2_safe_head,
-                                            l1_origin,
-                                            system_config: Some(system_config),
-                                        }
-                                        .signal(),
-                                    )
-                                    .await?;
+                                self.reset_request_tx.send(()).map_err(|e| {
+                                    error!(target: "derivation", ?e, "Failed to send reset request");
+                                    DerivationError::Sender(Box::new(e))
+                                })?;
+                                self.waiting_for_signal = true;
+                                return Err(DerivationError::Yield);
                             }
                         }
                         PipelineErrorKind::Critical(_) => {
@@ -234,6 +235,7 @@ where
                     };
 
                     self.signal(signal).await;
+                    self.waiting_for_signal = false;
                 }
                 msg = self.l1_head_updates.recv() => {
                     if msg.is_none() {
@@ -279,7 +281,10 @@ where
     async fn process(&mut self, msg: Self::InboundEvent) -> Result<(), Self::Error> {
         // Only attempt derivation once the engine finishes syncing.
         if !self.engine_ready {
-            trace!(target: "derivation", "Engine not ready, skipping derivation.");
+            trace!(target: "derivation", "Engine not ready, skipping derivation");
+            return Ok(());
+        } else if self.waiting_for_signal {
+            trace!(target: "derivation", "Waiting to receive a signal, skipping derivation");
             return Ok(());
         }
 
@@ -328,7 +333,9 @@ where
         self.engine_l2_safe_head.borrow_and_update();
 
         // Send payload attributes out for processing.
-        self.attributes_out.send(payload_attrs).map_err(Box::new)?;
+        self.attributes_out
+            .send(payload_attrs)
+            .map_err(|e| DerivationError::Sender(Box::new(e)))?;
 
         Ok(())
     }
@@ -354,8 +361,8 @@ pub enum DerivationError {
     #[error("Waiting for more data to be available")]
     Yield,
     /// An error originating from the broadcast sender.
-    #[error("Failed to send event to broadcast sender")]
-    Sender(#[from] Box<SendError<OpAttributesWithParent>>),
+    #[error("Failed to send event to broadcast sender: {0}")]
+    Sender(Box<dyn std::error::Error>),
     /// An error from the signal receiver.
     #[error("Failed to receive signal")]
     SignalReceiveFailed,

--- a/crates/node/service/src/service/validator.rs
+++ b/crates/node/service/src/service/validator.rs
@@ -108,6 +108,7 @@ pub trait ValidatorNodeService {
         let (sync_complete_tx, sync_complete_rx) = mpsc::unbounded_channel();
         let (runtime_config_tx, runtime_config_rx) = mpsc::unbounded_channel();
         let (derivation_signal_tx, derivation_signal_rx) = mpsc::unbounded_channel();
+        let (reset_request_tx, reset_request_rx) = mpsc::unbounded_channel();
 
         let (block_signer_tx, block_signer_rx) = mpsc::unbounded_channel();
         let (l1_watcher_queries_sender, l1_watcher_queries_recv) = tokio::sync::mpsc::channel(1024);
@@ -128,6 +129,7 @@ pub trait ValidatorNodeService {
             derivation_signal_rx,
             new_head_rx,
             derived_payload_tx,
+            reset_request_tx,
             cancellation.clone(),
         );
         let derivation = Some(derivation);
@@ -158,6 +160,7 @@ pub trait ValidatorNodeService {
             runtime_config_rx,
             derived_payload_rx,
             unsafe_block_rx,
+            reset_request_rx,
             Some(engine_query_recv),
             cancellation.clone(),
         );


### PR DESCRIPTION
## Overview

Forwards derivation reset events to the engine. In the case of the `HoloceneActivation` reset, the reset can be handled internal to the pipeline without informing the engine.

Additionally, adds functionality to block the derivation actor while it is waiting for a signal to be sent back. This will prevent it from attempting to advance while the engine is resetting.