### PR TITLE
fix(ci): Free disk space on kurtosis e2e tests

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -16,6 +16,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          large-packages: false
       - uses: taiki-e/install-action@just
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -25,4 +29,3 @@ jobs:
           cache: true                  # enable built‑in tool cache
       - name: test with simple-kona devnet
         run: cd tests && just test-e2e simple-kona ${{ github.event.pull_request.head.sha }}
-  


### PR DESCRIPTION
## Overview

Adds an action to free up some disk space prior to the kurtosis run. Seeing this job fail quite a bit due to running out of disk.