### PR TITLE
feat(node/e2e-test): add peer count test in Kurtosis

### DIFF
--- a/crates/node/p2p/src/rpc/request.rs
+++ b/crates/node/p2p/src/rpc/request.rs
@@ -1,6 +1,9 @@
 //! Contains the p2p RPC request type.
 
-use std::collections::HashMap;
+use std::{
+    collections::{HashMap, HashSet},
+    num::TryFromIntError,
+};
 
 use crate::{Discv5Handler, GossipDriver};
 use alloy_primitives::map::foldhash::fast::RandomState;
@@ -10,8 +13,6 @@ use discv5::{
 };
 use libp2p::PeerId;
 use tokio::sync::oneshot::Sender;
-
-use std::{collections::HashSet, num::TryFromIntError};
 
 use libp2p::gossipsub::TopicHash;
 

--- a/tests/node/mod.go
+++ b/tests/node/mod.go
@@ -1,0 +1,83 @@
+package node
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+)
+
+// --- Generic RPC request/response types -------------------------------------
+
+type rpcRequest struct {
+	JSONRPC string      `json:"jsonrpc"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params"`
+	ID      uint64      `json:"id"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      uint64          `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// ---------------------------------------------------------------------------
+
+const (
+	DEFAULT_TIMEOUT = 10 * time.Second
+)
+
+func (s *rpcRequest) SendRPCRequest(addr string) (rpcResponse, error) {
+	// 1. Marshal the request.
+	payload, err := json.Marshal(s)
+	if err != nil {
+		return (rpcResponse{}), err
+	}
+
+	// 2. Configure an HTTP client with sensible timeouts.
+	client := &http.Client{
+		Timeout: DEFAULT_TIMEOUT,
+	}
+
+	// 3. Create a context (optional, lets you cancel).
+	ctx, cancel := context.WithTimeout(context.Background(), DEFAULT_TIMEOUT)
+	defer cancel()
+
+	// 4. Build the HTTP request.
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		addr, bytes.NewReader(payload))
+	if err != nil {
+		return (rpcResponse{}), err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// 5. Send the request.
+	resp, err := client.Do(req)
+	if err != nil {
+		return (rpcResponse{}), err
+	}
+	defer resp.Body.Close()
+
+	// 6. Read and decode the response.
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return (rpcResponse{}), err
+	}
+
+	var rpcResp rpcResponse
+	if err := json.Unmarshal(respBytes, &rpcResp); err != nil {
+		return (rpcResponse{}), err
+	}
+
+	return rpcResp, nil
+
+}

--- a/tests/node/mod.go
+++ b/tests/node/mod.go
@@ -36,7 +36,15 @@ const (
 	DEFAULT_TIMEOUT = 10 * time.Second
 )
 
-func (s *rpcRequest) SendRPCRequest(addr string) (rpcResponse, error) {
+func SendRPCRequest(addr string, method string, params []any) (rpcResponse, error) {
+	// 1. Build the payload.
+	s := rpcRequest{
+		JSONRPC: "2.0",
+		Method:  method,
+		Params:  params,
+		ID:      1,
+	}
+
 	// 1. Marshal the request.
 	payload, err := json.Marshal(s)
 	if err != nil {

--- a/tests/node/node_test.go
+++ b/tests/node/node_test.go
@@ -1,57 +1,13 @@
 package node
 
 import (
-	"encoding/json"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/devnet-sdk/system"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/systest"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/testlib/validators"
-	"github.com/ethereum-optimism/optimism/op-service/apis"
 )
 
-// Really simple system test that just checks that each node has at least 1 peer that is connected to its topics.
-func peerCount() systest.SystemTestFunc {
-	return func(t systest.T, sys system.System) {
-		l2s := sys.L2s()
-
-		for _, l2 := range l2s {
-			for _, node := range l2.Nodes() {
-				clRPC := node.CLRPC()
-				clName := node.CLName()
-
-				// 1. Build the payload.
-				reqBody := rpcRequest{
-					JSONRPC: "2.0",
-					Method:  "opp2p_peerStats", // example: Ethereum JSON‑RPC
-					Params:  []any{},
-					ID:      1,
-				}
-
-				rpcResp, err := reqBody.SendRPCRequest(clRPC)
-
-				if err != nil {
-					t.Errorf("failed to send RPC request to node %s: %s", clName, err)
-				} else if rpcResp.Error != nil {
-					t.Errorf("received RPC error from node %s: %s", clName, rpcResp.Error)
-				}
-
-				peerStats := apis.PeerStats{}
-
-				err = json.Unmarshal(rpcResp.Result, &peerStats)
-
-				if err != nil {
-					t.Errorf("failed to unmarshal result: %s", err)
-				}
-
-				if peerStats.Connected < 1 {
-					t.Errorf("node %s has no peers", clName)
-				}
-			}
-		}
-	}
-}
-
+// Contains general system tests for the node.
 func TestSystemKonaTest(t *testing.T) {
 	// Get the L2 chain we want to test with
 	chainIdx := uint64(0) // First L2 chain

--- a/tests/node/node_test.go
+++ b/tests/node/node_test.go
@@ -1,24 +1,53 @@
 package node
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/system"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/systest"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/testlib/validators"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
 )
 
-func nodeUpScenario() systest.SystemTestFunc {
+// Really simple system test that just checks that each node has at least 1 peer that is connected to its topics.
+func peerCount() systest.SystemTestFunc {
 	return func(t systest.T, sys system.System) {
 		l2s := sys.L2s()
 
 		for _, l2 := range l2s {
-			config, err := l2.Config()
-			if err != nil {
-				t.Log(err)
-			}
+			for _, node := range l2.Nodes() {
+				clRPC := node.CLRPC()
+				clName := node.CLName()
 
-			t.Log(l2.ID(), l2.Nodes(), config)
+				// 1. Build the payload.
+				reqBody := rpcRequest{
+					JSONRPC: "2.0",
+					Method:  "opp2p_peerStats", // example: Ethereum JSON‑RPC
+					Params:  []any{},
+					ID:      1,
+				}
+
+				rpcResp, err := reqBody.SendRPCRequest(clRPC)
+
+				if err != nil {
+					t.Errorf("failed to send RPC request to node %s: %s", clName, err)
+				} else if rpcResp.Error != nil {
+					t.Errorf("received RPC error from node %s: %s", clName, rpcResp.Error)
+				}
+
+				peerStats := apis.PeerStats{}
+
+				err = json.Unmarshal(rpcResp.Result, &peerStats)
+
+				if err != nil {
+					t.Errorf("failed to unmarshal result: %s", err)
+				}
+
+				if peerStats.Connected < 1 {
+					t.Errorf("node %s has no peers", clName)
+				}
+			}
 		}
 	}
 }
@@ -27,10 +56,10 @@ func TestSystemKonaTest(t *testing.T) {
 	// Get the L2 chain we want to test with
 	chainIdx := uint64(0) // First L2 chain
 
-	nodeValidator := validators.HasSufficientL2Nodes(chainIdx, 1)
+	nodeValidator := validators.HasSufficientL2Nodes(chainIdx, 2)
 
 	systest.SystemTest(t,
-		nodeUpScenario(),
+		peerCount(),
 		nodeValidator,
 	)
 }

--- a/tests/node/opp2p_rpc.go
+++ b/tests/node/opp2p_rpc.go
@@ -1,0 +1,1 @@
+package node

--- a/tests/node/opp2p_rpc.go
+++ b/tests/node/opp2p_rpc.go
@@ -1,1 +1,0 @@
-package node

--- a/tests/node/peer_count.go
+++ b/tests/node/peer_count.go
@@ -1,0 +1,67 @@
+package node
+
+import (
+	"encoding/json"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/systest"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+)
+
+// Really simple system test that just checks that each node has at least 1 peer that is connected to its topics.
+func peerCount() systest.SystemTestFunc {
+	return func(t systest.T, sys system.System) {
+		l2s := sys.L2s()
+
+		for _, l2 := range l2s {
+			for _, node := range l2.Nodes() {
+				clRPC := node.CLRPC()
+				clName := node.CLName()
+
+				rpcResp, err := SendRPCRequest(clRPC, "opp2p_peerStats", nil)
+
+				if err != nil {
+					t.Errorf("failed to send RPC request to node %s: %s", clName, err)
+				} else if rpcResp.Error != nil {
+					t.Errorf("received RPC error from node %s: %s", clName, rpcResp.Error)
+				}
+
+				peerStats := apis.PeerStats{}
+
+				err = json.Unmarshal(rpcResp.Result, &peerStats)
+
+				if err != nil {
+					t.Errorf("failed to unmarshal result: %s", err)
+				}
+
+				if peerStats.Known == 0 {
+					t.Errorf("node %s has no known peers", clName)
+				}
+
+				if peerStats.Table == 0 {
+					t.Errorf("node %s has no peers in the discovery table", clName)
+				}
+
+				if peerStats.Connected == 0 {
+					t.Errorf("node %s has no peers", clName)
+				}
+
+				if peerStats.BlocksTopicV4 == 0 {
+					t.Errorf("node %s has no blocks topic v4 peers", clName)
+				}
+
+				if peerStats.BlocksTopicV3 == 0 {
+					t.Errorf("node %s has no blocks topic v3 peers", clName)
+				}
+
+				if peerStats.BlocksTopicV2 == 0 {
+					t.Errorf("node %s has no blocks topic v2 peers", clName)
+				}
+
+				if peerStats.BlocksTopic == 0 {
+					t.Errorf("node %s has no blocks topic peers", clName)
+				}
+			}
+		}
+	}
+}

--- a/tests/simple-kona.yaml
+++ b/tests/simple-kona.yaml
@@ -1,0 +1,76 @@
+# A simple network configuration for kurtosis (https://github.com/ethpandaops/optimism-package)
+# Spins up a 2 EL/CL networks. One with op-geth/op-node and one with op-reth/kona-node.
+
+optimism_package:
+  chains:
+    - participants:
+      # Note: it seems that op-reth isn't fully compatible with the sequencer mode.
+      # So we use op-geth for now.
+      - el_type: op-geth
+        cl_type: op-node
+        el_log_level: "debug"
+        cl_log_level: "debug"
+        count: 1
+      - el_type: op-reth
+        cl_type: kona-node
+        el_log_level: "debug"
+        cl_log_level: "debug"
+        # Note: we use the local image for now. This allows us to run the tests in CI pipelines without publishing new docker images every time.
+        cl_image: "kona-node:local"
+        count: 1
+      network_params:
+        network: "kurtosis"
+        network_id: "2151908"
+        seconds_per_slot: 2
+        name: "op-kurtosis"
+        fjord_time_offset: 0
+        granite_time_offset: 0
+        holocene_time_offset: 0
+        fund_dev_accounts: true
+      batcher_params:
+        image: {{ localDockerImage "op-batcher" }}
+        extra_params: []
+      proposer_params:
+        image: {{ localDockerImage "op-proposer" }}
+        extra_params: []
+        game_type: 1
+        proposal_interval: 10m
+      mev_params:
+        rollup_boost_image: ""
+        builder_host: ""
+        builder_port: ""
+      additional_services: []
+  challengers:
+    challenger:
+      enabled: true
+      image: {{ localDockerImage "op-challenger" }}
+      participants: "*"
+      cannon_prestates_url: {{ localPrestate.URL }}
+      cannon_trace_types: ["cannon", "permissioned"]
+  op_contract_deployer_params:
+    image: {{ localDockerImage "op-deployer" }}
+    l1_artifacts_locator: {{ localContractArtifacts "l1" }}
+    l2_artifacts_locator: {{ localContractArtifacts "l2" }}
+    overrides:
+      faultGameAbsolutePrestate: {{ localPrestate.Hashes.prestate_mt64 }}
+  global_log_level: "info"
+  global_node_selectors: {}
+  global_tolerations: []
+  persistent: false
+ethereum_package:
+  participants:
+  - el_type: geth
+    cl_type: nimbus
+  network_params:
+    preset: minimal
+    genesis_delay: 5
+    additional_preloaded_contracts: '
+      {
+        "0x4e59b44847b379578588920cA78FbF26c0B4956C": {
+          "balance": "0ETH",
+          "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3",
+          "storage": {},
+          "nonce": "1"
+        }
+      }
+    '


### PR DESCRIPTION
## Description

This PR adds a very simple test for the node to ensure that nodes in Kurtosis can at least connect to one peer.

This test gives a basic structure to:

- Instantiate a basic e2e test for the `kona-node`
- Query the nodes through RPC for one of their publicly exposed methods
- Retrieve the associated data and perform assertions.

Note: depends on #1812 