### PR TITLE
fix(node/p2p): fix node id serialization and connectedness display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4702,6 +4702,7 @@ dependencies = [
  "secp256k1 0.31.0",
  "serde",
  "serde_json",
+ "serde_repr",
  "snap",
  "tempfile",
  "thiserror 2.0.12",

--- a/crates/node/p2p/Cargo.toml
+++ b/crates/node/p2p/Cargo.toml
@@ -45,6 +45,7 @@ secp256k1.workspace = true
 # Misc
 url.workspace = true
 dirs.workspace = true
+serde_repr.workspace = true
 serde.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/node/p2p/src/rpc/request.rs
+++ b/crates/node/p2p/src/rpc/request.rs
@@ -219,11 +219,14 @@ impl P2pRpcRequest {
             let enr = match local_enr.await {
                 Ok(enr) => enr,
                 Err(e) => {
-                    warn!("Failed to receive local ENR: {:?}", e);
+                    warn!(target: "p2p::rpc", "Failed to receive local ENR: {:?}", e);
                     return;
                 }
             };
-            let node_id = enr.node_id().to_string();
+
+            // Note: we need to use `Debug` impl here because the `Display` impl of
+            // `NodeId` strips some part of the hex string and replaces it with "...".
+            let node_id = format!("{:?}", &enr.node_id());
 
             // We need to add the local multiaddr to the list of known addresses.
             let peer_info = PeerInfo {

--- a/crates/node/p2p/src/rpc/types.rs
+++ b/crates/node/p2p/src/rpc/types.rs
@@ -171,7 +171,17 @@ pub struct PeerStats {
 
 /// Represents the connectivity state of a peer in a network, indicating the reachability and
 /// interaction status of a node with its peers.
-#[derive(Clone, Debug, Display, PartialEq, Copy, Default, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    Display,
+    PartialEq,
+    Copy,
+    Default,
+    // We need to use `serde_repr` to serialize the enum as an integer to match the `op-node` API.
+    serde_repr::Serialize_repr,
+    serde_repr::Deserialize_repr,
+)]
 #[repr(u8)]
 pub enum Connectedness {
     /// No current connection to the peer, and no recent history of a successful connection.
@@ -264,15 +274,6 @@ mod tests {
         assert_eq!(Connectedness::from(3), Connectedness::CannotConnect);
         assert_eq!(Connectedness::from(4), Connectedness::Limited);
         assert_eq!(Connectedness::from(5), Connectedness::NotConnected);
-    }
-
-    #[test]
-    fn test_connectedness_display() {
-        assert_eq!(Connectedness::NotConnected.to_string(), "Not Connected");
-        assert_eq!(Connectedness::Connected.to_string(), "Connected");
-        assert_eq!(Connectedness::CanConnect.to_string(), "Can Connect");
-        assert_eq!(Connectedness::CannotConnect.to_string(), "Cannot Connect");
-        assert_eq!(Connectedness::Limited.to_string(), "Limited");
     }
 
     #[test]


### PR DESCRIPTION
## Description

Small PR that fixes the `NodeId` serialization inside `opp2p_self`. Using the default `Display` impl strips the middle of the address for readability. We want to be able to return the full address in RPC

Also removes the special display for `Connectedness` which was causing the RPC responses for `opp2p_self` returned by `kona-node` to differ from ones from the `op-node` (only return a `u8`)