### PR TITLE
feat(node/p2p): streaming engine state through websockets

### DIFF
--- a/crates/node/rpc/src/lib.rs
+++ b/crates/node/rpc/src/lib.rs
@@ -24,9 +24,9 @@ mod output;
 pub use output::OutputResponse;
 
 mod jsonrpsee;
-#[cfg(feature = "client")]
-pub use jsonrpsee::{MinerApiExtClient, OpAdminApiClient, OpP2PApiClient, RollupNodeApiClient};
-pub use jsonrpsee::{MinerApiExtServer, OpAdminApiServer, OpP2PApiServer, RollupNodeApiServer};
+pub use jsonrpsee::{
+    MinerApiExtServer, OpAdminApiServer, OpP2PApiServer, RollupNodeApiServer, WsServer,
+};
 
 #[cfg(feature = "reqwest")]
 pub mod reqwest;
@@ -46,3 +46,6 @@ pub use rollup::RollupRpc;
 
 mod l1_watcher;
 pub use l1_watcher::{L1State, L1WatcherQueries, L1WatcherQuerySender};
+
+mod ws;
+pub use ws::WsRPC;

--- a/crates/node/rpc/src/ws.rs
+++ b/crates/node/rpc/src/ws.rs
@@ -1,0 +1,127 @@
+//! Custom RPC subscription endpoints to for the kona node to stream internal state/data.
+
+use jsonrpsee::{
+    PendingSubscriptionSink, SubscriptionSink, core::SubscriptionResult, tracing::warn,
+};
+use kona_engine::{EngineQueries, EngineQuerySender, EngineState};
+use kona_protocol::L2BlockInfo;
+
+use jsonrpsee::core::to_json_raw_value;
+
+use crate::jsonrpsee::WsServer;
+
+/// An RPC server that handles subscriptions to the node's state.
+#[derive(Debug)]
+pub struct WsRPC {
+    /// The engine query sender.
+    engine_query_sender: EngineQuerySender,
+}
+
+impl WsRPC {
+    /// Constructs a new [`WsRPC`] instance.
+    pub const fn new(engine_query_sender: EngineQuerySender) -> Self {
+        Self { engine_query_sender }
+    }
+
+    async fn engine_state_watcher(
+        &self,
+    ) -> Result<tokio::sync::watch::Receiver<EngineState>, jsonrpsee::core::SubscriptionError> {
+        let (query_tx, query_rx) = tokio::sync::oneshot::channel();
+
+        if let Err(e) = self.engine_query_sender.send(EngineQueries::StateReceiver(query_tx)).await
+        {
+            warn!(target: "rpc::ws", ?e, "Failed to send engine state receiver query. The engine query handler is likely closed.");
+            return Err(jsonrpsee::core::SubscriptionError::from(
+                "Internal error. Failed to send engine state receiver query. The engine query handler is likely closed.",
+            ));
+        }
+
+        query_rx.await.map_err(|_| jsonrpsee::core::SubscriptionError::from("Internal error. Failed to receive engine state receiver query. The engine query handler is likely closed."))
+    }
+
+    async fn send_state_update(
+        sink: &SubscriptionSink,
+        state: L2BlockInfo,
+    ) -> Result<(), jsonrpsee::core::SubscriptionError> {
+        sink.send(to_json_raw_value(&state).map_err(|_| {
+            jsonrpsee::core::SubscriptionError::from(
+                "Internal error. Impossible to convert l2 block info to json",
+            )
+        })?)
+        .await
+        .map_err(|_| {
+            jsonrpsee::core::SubscriptionError::from(
+                "Failed to send head update. Subscription likely dropped.",
+            )
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl WsServer for WsRPC {
+    async fn ws_safe_head_updates(&self, sink: PendingSubscriptionSink) -> SubscriptionResult {
+        let sink = sink.accept().await?;
+
+        let mut subscription = self.engine_state_watcher().await?;
+
+        let mut current_safe_head = subscription.borrow().safe_head();
+
+        Self::send_state_update(&sink, current_safe_head).await?;
+
+        while let Ok(new_state) = subscription
+            .wait_for(|state| state.safe_head() != current_safe_head)
+            .await
+            .map(|state| *state)
+        {
+            current_safe_head = new_state.safe_head();
+            Self::send_state_update(&sink, current_safe_head).await?;
+        }
+
+        warn!(target: "rpc::ws", "Subscription to safe head updates has been closed.");
+        Ok(())
+    }
+
+    async fn ws_finalized_head_updates(&self, sink: PendingSubscriptionSink) -> SubscriptionResult {
+        let sink = sink.accept().await?;
+
+        let mut subscription = self.engine_state_watcher().await?;
+
+        let mut current_finalized_head = subscription.borrow().finalized_head();
+
+        Self::send_state_update(&sink, current_finalized_head).await?;
+
+        while let Ok(new_state) = subscription
+            .wait_for(|state| state.finalized_head() != current_finalized_head)
+            .await
+            .map(|state| *state)
+        {
+            current_finalized_head = new_state.finalized_head();
+            Self::send_state_update(&sink, current_finalized_head).await?;
+        }
+
+        warn!(target: "rpc::ws", "Subscription to finalized head updates has been closed.");
+        Ok(())
+    }
+
+    async fn ws_unsafe_head_updates(&self, sink: PendingSubscriptionSink) -> SubscriptionResult {
+        let sink = sink.accept().await?;
+
+        let mut subscription = self.engine_state_watcher().await?;
+
+        let mut current_unsafe_head = subscription.borrow().unsafe_head();
+
+        Self::send_state_update(&sink, current_unsafe_head).await?;
+
+        while let Ok(new_state) = subscription
+            .wait_for(|state| state.unsafe_head() != current_unsafe_head)
+            .await
+            .map(|state| *state)
+        {
+            current_unsafe_head = new_state.unsafe_head();
+            Self::send_state_update(&sink, current_unsafe_head).await?;
+        }
+
+        warn!(target: "rpc::ws", "Subscription to unsafe head updates has been closed.");
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Description

This PR adds a couple of websocket endpoints to stream the sync state of the `kona-node`. These endpoints can be useful inside our e2e testing suite to ensure that the node is correctly syncing.

## Follow-ups

Maybe we should provide a configuration flag to make those RPC endpoints optional. We may not want to be able to subscribe to the current node state. Here is a ticket to track that #1842

Close #1825