### PR TITLE
fix(kurtosis/config): fix kurtosis config to use teku instead of nimbus.

### DIFF
--- a/.config/kurtosis_network_params.yaml
+++ b/.config/kurtosis_network_params.yaml
@@ -13,6 +13,9 @@ optimism_package:
         count: 1
       - el_type: op-reth
         cl_type: kona-node
+        # We are using a local image for the kona-node for now. Once we get more stability we can
+        # switch back to the docker repository's one.
+        cl_image: kona-node:local
         el_log_level: "debug"
         cl_log_level: "debug"
         count: 1
@@ -31,7 +34,7 @@ optimism_package:
 ethereum_package:
   participants:
   - el_type: geth
-    cl_type: nimbus
+    cl_type: teku
   network_params:
     preset: minimal
     genesis_delay: 5

--- a/.config/kurtosis_network_params_supervisor.yaml
+++ b/.config/kurtosis_network_params_supervisor.yaml
@@ -22,7 +22,7 @@ optimism_package:
 ethereum_package:
   participants:
     - el_type: reth
-      cl_type: nimbus
+      cl_type: teku
   network_params:
     preset: minimal
     genesis_delay: 5

--- a/tests/devnets/large-kona.yaml
+++ b/tests/devnets/large-kona.yaml
@@ -55,7 +55,7 @@ optimism_package:
 ethereum_package:
   participants:
   - el_type: geth
-    cl_type: nimbus
+    cl_type: teku
   network_params:
     preset: minimal
     genesis_delay: 5

--- a/tests/devnets/simple-kona.yaml
+++ b/tests/devnets/simple-kona.yaml
@@ -58,7 +58,7 @@ optimism_package:
 ethereum_package:
   participants:
   - el_type: geth
-    cl_type: nimbus
+    cl_type: teku
   network_params:
     preset: minimal
     genesis_delay: 5


### PR DESCRIPTION
## Description

Fixes the kurtosis configuration to use `teku` instead of `nimbus` for L1 consensus client. The latest version of `nimbus` seems to have broken the `optimism-package`.

Also sets the `cl_image` to point to a local image of the node by default. This will improve DX until we reach more stability