### PR TITLE
patch(node/p2p): patch the default p2p params

### DIFF
--- a/bin/node/src/flags/p2p.rs
+++ b/bin/node/src/flags/p2p.rs
@@ -125,7 +125,9 @@ pub struct P2PArgs {
     pub gossip_flood_publish: bool,
     /// Sets the peer scoring strategy for the P2P stack.
     /// Can be one of: none or light.
-    #[arg(long = "p2p.scoring", default_value = "light", env = "KONA_NODE_P2P_SCORING")]
+    ///
+    /// TODO(@theochap, `<https://github.com/op-rs/kona/issues/1855>`): By default, the P2P stack is configured to not score peers.
+    #[arg(long = "p2p.scoring", default_value = "off", env = "KONA_NODE_P2P_SCORING")]
     pub scoring: PeerScoreLevel,
 
     /// Allows to ban peers based on their score.
@@ -159,7 +161,10 @@ pub struct P2PArgs {
     /// Peer Redialing threshold is the maximum amount of times to attempt to redial a peer that
     /// disconnects. By default, peers are *not* redialed. If set to 0, the peer will be
     /// redialed indefinitely.
-    #[arg(long = "p2p.redial", env = "KONA_NODE_P2P_REDIAL")]
+    ///
+    /// TODO(@theochap, `<https://github.com/op-rs/kona/issues/1854>`): we are temporarily setting this to 0 to redial all peers indefinitely.
+    /// We will change this default to `None` once we have a more robust p2p stack.
+    #[arg(long = "p2p.redial", env = "KONA_NODE_P2P_REDIAL", default_value = "0")]
     pub peer_redial: Option<u64>,
 
     /// An optional list of bootnode ENRs to start the node with.


### PR DESCRIPTION
## Description

This PR patches the default p2p params inside the kona-node to help with keeping gossip connections alive