### PR TITLE
chore: Rename BlockRef field `time` to `timestamp`

### DIFF
--- a/crates/supervisor/storage/src/models/block.rs
+++ b/crates/supervisor/storage/src/models/block.rs
@@ -26,7 +26,7 @@ pub struct BlockRef {
     /// The hash of the parent block (previous block in the chain).
     pub parent_hash: B256,
     /// The timestamp of the block (seconds since Unix epoch).
-    pub time: u64,
+    pub timestamp: u64,
 }
 
 /// Converts from [`BlockInfo`] (external API format) to [`BlockRef`] (storage
@@ -39,7 +39,7 @@ impl From<BlockInfo> for BlockRef {
             number: block.number,
             hash: block.hash,
             parent_hash: block.parent_hash,
-            time: block.timestamp,
+            timestamp: block.timestamp,
         }
     }
 }
@@ -54,7 +54,7 @@ impl From<BlockRef> for BlockInfo {
             number: block.number,
             hash: block.hash,
             parent_hash: block.parent_hash,
-            timestamp: block.time,
+            timestamp: block.timestamp,
         }
     }
 }
@@ -77,7 +77,7 @@ mod tests {
             number: 42,
             hash: test_b256(10),
             parent_hash: test_b256(11),
-            time: 1678886400,
+            timestamp: 1678886400,
         };
 
         let mut buffer = Vec::new();
@@ -103,7 +103,7 @@ mod tests {
         assert_eq!(block_ref.number, block_info.number, "Number should match");
         assert_eq!(block_ref.hash, block_info.hash, "Hash should match");
         assert_eq!(block_ref.parent_hash, block_info.parent_hash, "Parent hash should match");
-        assert_eq!(block_ref.time, block_info.timestamp, "Time (timestamp) should match");
+        assert_eq!(block_ref.timestamp, block_info.timestamp, "Time (timestamp) should match");
     }
 
     #[test]
@@ -112,7 +112,7 @@ mod tests {
             number: 456,
             hash: test_b256(3),
             parent_hash: test_b256(4),
-            time: 1700000000,
+            timestamp: 1700000000,
         };
 
         let block_info: BlockInfo = block_ref.clone().into();
@@ -120,6 +120,6 @@ mod tests {
         assert_eq!(block_info.number, block_ref.number, "Number should match");
         assert_eq!(block_info.hash, block_ref.hash, "Hash should match");
         assert_eq!(block_info.parent_hash, block_ref.parent_hash, "Parent hash should match");
-        assert_eq!(block_info.timestamp, block_ref.time, "Timestamp (time) should match");
+        assert_eq!(block_info.timestamp, block_ref.timestamp, "Timestamp (time) should match");
     }
 }

--- a/crates/supervisor/storage/src/models/derivation.rs
+++ b/crates/supervisor/storage/src/models/derivation.rs
@@ -89,10 +89,18 @@ mod tests {
 
     #[test]
     fn test_derived_block_pair_compact_roundtrip() {
-        let source_ref =
-            BlockRef { number: 100, hash: test_b256(1), parent_hash: test_b256(2), time: 1000 };
-        let derived_ref =
-            BlockRef { number: 200, hash: test_b256(3), parent_hash: test_b256(4), time: 1010 };
+        let source_ref = BlockRef {
+            number: 100,
+            hash: test_b256(1),
+            parent_hash: test_b256(2),
+            timestamp: 1000,
+        };
+        let derived_ref = BlockRef {
+            number: 200,
+            hash: test_b256(3),
+            parent_hash: test_b256(4),
+            timestamp: 1010,
+        };
 
         let original_pair = StoredDerivedBlockPair { source: source_ref, derived: derived_ref };
 
@@ -113,9 +121,9 @@ mod tests {
     #[test]
     fn test_from_stored_to_derived_ref_pair() {
         let source_ref =
-            BlockRef { number: 1, hash: B256::ZERO, parent_hash: B256::ZERO, time: 100 };
+            BlockRef { number: 1, hash: B256::ZERO, parent_hash: B256::ZERO, timestamp: 100 };
         let derived_ref =
-            BlockRef { number: 2, hash: B256::ZERO, parent_hash: B256::ZERO, time: 200 };
+            BlockRef { number: 2, hash: B256::ZERO, parent_hash: B256::ZERO, timestamp: 200 };
 
         let stored =
             StoredDerivedBlockPair { source: source_ref.clone(), derived: derived_ref.clone() };

--- a/crates/supervisor/storage/src/models/mod.rs
+++ b/crates/supervisor/storage/src/models/mod.rs
@@ -110,8 +110,12 @@ mod tests {
 
     #[test]
     fn test_block_ref_compression_decompression() {
-        let original =
-            BlockRef { number: 1, hash: test_b256(1), parent_hash: test_b256(2), time: 1234567890 };
+        let original = BlockRef {
+            number: 1,
+            hash: test_b256(1),
+            parent_hash: test_b256(2),
+            timestamp: 1234567890,
+        };
 
         let mut compressed_buf = Vec::new();
         original.compress_to_buf(&mut compressed_buf);
@@ -156,13 +160,17 @@ mod tests {
 
     #[test]
     fn test_derived_block_pair_compression_decompression() {
-        let source_ref =
-            BlockRef { number: 100, hash: test_b256(6), parent_hash: test_b256(7), time: 1000 };
+        let source_ref = BlockRef {
+            number: 100,
+            hash: test_b256(6),
+            parent_hash: test_b256(7),
+            timestamp: 1000,
+        };
         let derived_ref = BlockRef {
             number: 200,
             hash: test_b256(8),
             parent_hash: test_b256(8), // Link to source
-            time: 1010,
+            timestamp: 1010,
         };
 
         let original_pair = StoredDerivedBlockPair { source: source_ref, derived: derived_ref };


### PR DESCRIPTION
# Description

Rename BlockRef field `time` to `timestamp` for clarity and consistency

- Updates BlockRef struct and related conversions to use `timestamp` instead of `time`
- Updates documentation and tests to reflect the new field name
- Improves clarity and aligns with other structure