### PR TITLE
test(supervisor): Comment out kona-supervisor in kurtosis network params

### DIFF
--- a/tests/devnets/simple-supervisor.yaml
+++ b/tests/devnets/simple-supervisor.yaml
@@ -15,10 +15,11 @@ optimism_package:
   supervisors:
     supervisor-a: # default op-supervisor
       superchain: superchain-a
-    supervisor-b:
-      superchain: superchain-a
-      image: "kona-supervisor:local"
-      extra_params: ["-vvvv"]
+    # uncomment when closed <https://github.com/ethpandaops/optimism-package/issues/281> 
+    #supervisor-b: 
+      #superchain: superchain-a
+      #image: "kona-supervisor:local"
+      #extra_params: ["-vvvv"]
 ethereum_package:
   participants:
     - el_type: reth


### PR DESCRIPTION
Unblocks https://github.com/op-rs/kona/issues/1716. Allows writing supervisor e2e tests in kona and only running against `op-supervisor` until `kona-supervisor` support is integrated into `optimism-package`.

Ref
https://github.com/op-rs/kona/tree/main/tests/supervisor
https://github.com/ethpandaops/optimism-package/issues/281