### PR TITLE
chore(supervisor): Rename `ManagedNodeApi` to `ManagedModeApi` to match specs

### DIFF
--- a/crates/supervisor/core/src/syncnode/node.rs
+++ b/crates/supervisor/core/src/syncnode/node.rs
@@ -5,7 +5,7 @@ use jsonrpsee::{
     core::{SubscriptionError, client::Subscription},
     ws_client::{HeaderMap, HeaderValue, WsClientBuilder},
 };
-use kona_supervisor_rpc::ManagedNodeApiClient;
+use kona_supervisor_rpc::ManagedModeApiClient;
 use kona_supervisor_types::ManagedEvent;
 use std::sync::Arc;
 use tokio::{sync::watch, task::JoinHandle};
@@ -174,7 +174,7 @@ impl ManagedNode {
         )?;
 
         let mut subscription: Subscription<Option<ManagedEvent>> =
-            ManagedNodeApiClient::subscribe_events(&client).await.map_err(|err| {
+            ManagedModeApiClient::subscribe_events(&client).await.map_err(|err| {
                 let err_msg = format!("Failed to subscribe to events: {}", err);
                 error!(
                     target: "managed_node",

--- a/crates/supervisor/rpc/src/jsonrpsee.rs
+++ b/crates/supervisor/rpc/src/jsonrpsee.rs
@@ -46,7 +46,7 @@ pub trait SupervisorApi {
     ) -> RpcResult<()>;
 }
 
-/// ManagedNodeApi to send control signals to a managed node from supervisor
+/// ManagedModeApi to send control signals to a managed node from supervisor
 /// And get info for syncing the state with the given L2.
 ///
 ///
@@ -55,7 +55,7 @@ pub trait SupervisorApi {
 /// Default namespace separator is `_`.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "supervisor"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "supervisor"))]
-pub trait ManagedNodeApi {
+pub trait ManagedModeApi {
     /// Subscribe to the events from the managed node.
     #[subscription(name = "events", item = Option<ManagedEvent>, unsubscribe = "unsubscribeEvents")]
     async fn subscribe_events(&self) -> SubscriptionResult;

--- a/crates/supervisor/rpc/src/lib.rs
+++ b/crates/supervisor/rpc/src/lib.rs
@@ -8,4 +8,4 @@ pub use jsonrpsee::SupervisorApiClient;
 pub use jsonrpsee::SupervisorApiServer;
 
 #[cfg(all(feature = "jsonrpsee", feature = "client"))]
-pub use jsonrpsee::ManagedNodeApiClient;
+pub use jsonrpsee::ManagedModeApiClient;


### PR DESCRIPTION
Ref https://specs.optimism.io/interop/managed-mode.html