### PR TITLE
chore(docker): Move root docker builds into `docker` dir

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -80,30 +80,6 @@ test-docs:
 build-native *args='':
   cargo build --workspace $@
 
-# Build target for the `kona-node` docker image specify a custom tag.
-build-node-with-tag TAG:
-  docker build \
-    --progress plain \
-    -f docker/apps/kona_app_generic.dockerfile \
-    --build-arg "BIN_TARGET=kona-node" \
-    --build-arg "TAG={{TAG}}" \
-    -t kona-node:local \
-    .
-
-# Build target for the `kona-supervisor` docker image specify a custom tag.
-build-supervisor-with-tag TAG:
-  docker build \
-    --progress plain \
-    -f docker/apps/kona_app_generic.dockerfile \
-    --build-arg "BIN_TARGET=kona-supervisor" \
-    --build-arg "TAG={{TAG}}" \
-    -t kona-supervisor:local \
-    .
-
-# Build target for the `kona-node` docker image. Uses the current remote commit tag.
-build-node:
-  just build-node-with-tag $(git rev-parse HEAD)
-
 # Build `kona-client` for the `cannon` target.
 build-cannon-client:
   docker run \

--- a/tests/Justfile
+++ b/tests/Justfile
@@ -16,7 +16,7 @@ _build-node COMMIT_TAG="":
         export COMMIT_TAG=$(git rev-parse HEAD)
     fi
 
-    cd {{SOURCE}}/.. && just build-node-with-tag $COMMIT_TAG
+    cd {{SOURCE}}/../docker/apps && just build-remote kona-node "$COMMIT_TAG" kona-node:local
 
 _build-supervisor COMMIT_TAG="":
     #!/usr/bin/env bash
@@ -25,7 +25,7 @@ _build-supervisor COMMIT_TAG="":
         export COMMIT_TAG=$(git rev-parse HEAD)
     fi
 
-    cd {{SOURCE}}/.. && just build-supervisor-with-tag $COMMIT_TAG
+    cd {{SOURCE}}/../docker/apps && just build-remote kona-supervisor "$COMMIT_TAG" kona-supervisor:local
 
 deploy DEVNET_FILE_PATH COMMIT_TAG="" NAME="": (_build-node COMMIT_TAG) setup clone-optimism install-optimism
     #!/usr/bin/env bash


### PR DESCRIPTION
## Overview

Removes the `build-node`, `build-node-with-tag`, and `build-supervisor-with-tag` recipes in favor of `docker/apps/justfile`'s recipes.

closes https://github.com/op-rs/kona/issues/1596