### PR TITLE
feat(workspace): Performance release build profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,11 @@ panic = "abort"
 codegen-units = 1
 lto = "fat"
 
+[profile.release-perf]
+inherits = "release"
+lto = "fat"
+codegen-units = 1
+
 [workspace.dependencies]
 # Binaries
 kona-host = { path = "bin/host", version = "1.0.1", default-features = false }

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -61,3 +61,9 @@ rstest.workspace = true
 [build-dependencies]
 vergen = { workspace = true, features = ["build", "cargo", "emit_and_set"] }
 vergen-git2.workspace = true
+
+[features]
+default = ["asm-keccak"]
+asm-keccak = [
+  "alloy-primitives/asm-keccak"
+]

--- a/docker/apps/kona_app_generic.dockerfile
+++ b/docker/apps/kona_app_generic.dockerfile
@@ -55,7 +55,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Build the application binary on the selected tag
 RUN cd kona && \
-  cargo build --workspace --bin "${BIN_TARGET}" --profile "${BUILD_PROFILE}" && \
+  RUSTFLAGS="-C target-cpu=native" cargo build --workspace --bin "${BIN_TARGET}" --profile "${BUILD_PROFILE}" && \
   mv "./target/${BUILD_PROFILE}/${BIN_TARGET}" "/${BIN_TARGET}"
 
 # Export stage

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -46,7 +46,7 @@ variable "BIN_TARGET" {
 }
 
 variable "BUILD_PROFILE" {
-  default = "release"
+  default = "release-perf"
   description = "The cargo build profile to use when building the binary in the kona-app-generic target."
 }
 

--- a/tests/Justfile
+++ b/tests/Justfile
@@ -9,6 +9,7 @@ build-devnet BINARY:
         exit 1
     fi
 
+    export BUILD_PROFILE="release"
     cd {{SOURCE}}/../docker/apps && just build-local "kona-{{BINARY}}" "kona-{{BINARY}}:local"
 
 # Spins up kurtosis with the `kona-node` docker image


### PR DESCRIPTION
## Overview

Adds a `release-perf` build profile that has `codegen-units = 1` set and link time optimizations turned on.

This profile is used by default when building application images.

Also enables the `asm-keccak` feature in `alloy-primitives` within `kona-node`'s dependency graph.