### PR TITLE
chore(tests): Skip `node/p2p` e2e tests

### DIFF
--- a/tests/node/node_test.go
+++ b/tests/node/node_test.go
@@ -10,6 +10,8 @@ import (
 // Contains general system tests for the p2p connectivity of the node.
 // This assumes there is at least two L2 chains. The second chain is used to test a larger network.
 func TestSystemNodeP2p(t *testing.T) {
+	t.Skip("Peering tests are skipped for now as they are unreliable")
+
 	systest.SystemTest(t,
 		allPeersInNetwork(),
 		validators.HasSufficientL2Nodes(0, 2),


### PR DESCRIPTION
## Overview

Temporarily skips the `node/p2p` e2e tests, since they're unreliable and keeping CI red. Once these are fixed to be more reliable, we'll turn them back on in trunk.

cc @theochap 