### PR TITLE
fix(dockerfile): fix the dependency installer

### DIFF
--- a/docker/apps/kona_app_generic.dockerfile
+++ b/docker/apps/kona_app_generic.dockerfile
@@ -8,7 +8,7 @@ FROM ubuntu:22.04 AS dep-setup-stage
 SHELL ["/bin/bash", "-c"]
 
 # Install deps
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
   build-essential \
   git \
   curl \


### PR DESCRIPTION
## Description

Small PR that fixes the dockerfile installer. It seems that the new local builds need the `--fix-missing` flag to correctly install all the dependencies @clabby 