### PR TITLE
feat(node-service): Derivation pipeline L1 origin metric

### DIFF
--- a/crates/node/service/src/metrics/mod.rs
+++ b/crates/node/service/src/metrics/mod.rs
@@ -8,6 +8,9 @@ impl Metrics {
     /// Identifier for the counter that tracks the number of times the L1 has reorganized.
     pub const L1_REORG_COUNT: &str = "kona_node_l1_reorg_count";
 
+    /// Identifier for the counter that tracks the L1 origin of the derivation pipeline.
+    pub const DERIVATION_L1_ORIGIN: &str = "kona_node_derivation_l1_origin";
+
     /// Initializes metrics for the node service.
     ///
     /// This does two things:
@@ -24,6 +27,9 @@ impl Metrics {
     pub fn describe() {
         // L1 reorg count
         metrics::describe_counter!(Self::L1_REORG_COUNT, metrics::Unit::Count, "L1 reorg count");
+
+        // Derivation L1 origin
+        metrics::describe_counter!(Self::DERIVATION_L1_ORIGIN, "Derivation pipeline L1 origin");
     }
 
     /// Initializes metrics to `0` so they can be queried immediately by consumers of prometheus


### PR DESCRIPTION
## Overview

Adds a counter metric for the derivation pipeline's L1 origin.

closes https://github.com/op-rs/kona/issues/1629