### PR TITLE
fix(node/e2e-sync): fix large sync test

### DIFF
--- a/docker/apps/kona_app_generic.dockerfile
+++ b/docker/apps/kona_app_generic.dockerfile
@@ -8,7 +8,7 @@ FROM ubuntu:22.04 AS dep-setup-stage
 SHELL ["/bin/bash", "-c"]
 
 # Install deps
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y \
   build-essential \
   git \
   curl \

--- a/tests/node/sync.go
+++ b/tests/node/sync.go
@@ -22,12 +22,15 @@ func syncUnsafeBecomesSafe() systest.SystemTestFunc {
 	return func(t systest.T, sys system.System) {
 		l2s := sys.L2s()
 		for _, l2 := range l2s {
-			for _, konaNode := range l2.Nodes() {
+			for _, node := range l2.Nodes() {
 
-				clRPC := konaNode.CLRPC()
-				clName := konaNode.CLName()
+				clRPC := node.CLRPC()
+				clName := node.CLName()
 
-				require.True(t, nodeSupportsKonaWs(t, clRPC, clName), "kona node doesn't support ws endpoint")
+				if !nodeSupportsKonaWs(t, clRPC, clName) {
+					t.Log("node does not support ws endpoint, skipping sync test", clName)
+					continue
+				}
 
 				wsRPC := websocketRPC(clRPC)
 				t.Log("node supports ws endpoint, continuing sync test", clName, wsRPC)


### PR DESCRIPTION
## Description

Small PR that fixes the kurtosis sync tests. Since the op-nodes don't support the websocket endpoint this test was always failing