### PR TITLE
feat(node/e2e-tests): add a restart recipe for hot reloads of the kurtosis network

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,6 @@
 [tools]
 
 kurtosis = "1.8.1"
+
+[alias]
+kurtosis = "ubi:kurtosis-tech/kurtosis-cli-release-artifacts[exe=kurtosis]"

--- a/tests/justfile
+++ b/tests/justfile
@@ -62,13 +62,16 @@ build-deploy-devnet DEVNET BINARY OP_PACKAGE_PATH="": (build-devnet BINARY)
 
     just devnet $DEVNET_PATH {{DEVNET}} {{OP_PACKAGE_PATH}}
 
-build-devnet-and-test-e2e DEVNET BINARY OP_PACKAGE_PATH="": (build-deploy-devnet DEVNET BINARY OP_PACKAGE_PATH)
+build-devnet-and-test-e2e DEVNET BINARY OP_PACKAGE_PATH="": (build-devnet BINARY)
     #!/bin/bash
     export DEVNET_PATH="{{SOURCE}}/devnets/{{DEVNET}}.yaml"
 
+    just devnet $DEVNET_PATH {{DEVNET}} {{OP_PACKAGE_PATH}}
+
     just test-e2e "ktnative://{{DEVNET}}$DEVNET_PATH" "{{BINARY}}"
 
-# Updates the devnet with the latest local changes. This is useful to rapidely iterate on the devnet without having to redeploy the whole kurtosis network.
+# Updates the devnet with the latest local changes. This is useful to
+# rapidly iterate on the devnet without having to redeploy the whole kurtosis network.
 update-node-devnet DEVNET OP_PACKAGE_PATH="": (build-devnet "node")
     #!/bin/bash
 

--- a/tests/justfile
+++ b/tests/justfile
@@ -18,8 +18,6 @@ build-devnet BINARY:
 # The ENCLAVE variable can be used to specify a custom enclave name to use for kurtosis.
 devnet CUSTOM_DEVNET_PATH="" ENCLAVE="" OP_PACKAGE_PATH="":
   #!/bin/bash
-  mise install && mise activate
-
   export ENCLAVE=""
   if ! [ -z "{{ENCLAVE}}" ]; then
     export ENCLAVE="--enclave {{ENCLAVE}}"
@@ -39,7 +37,7 @@ devnet CUSTOM_DEVNET_PATH="" ENCLAVE="" OP_PACKAGE_PATH="":
   fi
 
   # Run the kurtosis test
-  mise x -- kurtosis run $OP_PACKAGE_PATH --args-file $DEVNET_PATH $ENCLAVE
+  kurtosis run $OP_PACKAGE_PATH --args-file $DEVNET_PATH $ENCLAVE
 
 # Winds down kurtosis, cleaning up the network
 cleanup-kurtosis:

--- a/tests/justfile
+++ b/tests/justfile
@@ -56,9 +56,32 @@ test-e2e DEVNET GO_PKG_NAME="":
 
     cd {{SOURCE}} && go test -v ./$GO_PKG_NAME
 
-build-devnet-and-test-e2e DEVNET BINARY OP_PACKAGE_PATH="": (build-devnet BINARY)
+build-deploy-devnet DEVNET BINARY OP_PACKAGE_PATH="": (build-devnet BINARY)
     #!/bin/bash
     export DEVNET_PATH="{{SOURCE}}/devnets/{{DEVNET}}.yaml"
 
     just devnet $DEVNET_PATH {{DEVNET}} {{OP_PACKAGE_PATH}}
+
+build-devnet-and-test-e2e DEVNET BINARY OP_PACKAGE_PATH="": (build-deploy-devnet DEVNET BINARY OP_PACKAGE_PATH)
+    #!/bin/bash
+    export DEVNET_PATH="{{SOURCE}}/devnets/{{DEVNET}}.yaml"
+
     just test-e2e "ktnative://{{DEVNET}}$DEVNET_PATH" "{{BINARY}}"
+
+# Updates the devnet with the latest local changes. This is useful to rapidely iterate on the devnet without having to redeploy the whole kurtosis network.
+update-node-devnet DEVNET OP_PACKAGE_PATH="": (build-devnet "node")
+    #!/bin/bash
+
+    # Ensure there is a kurtosis enclave running with the name {{DEVNET}}
+    ENCLAVE_EXISTS=$(kurtosis enclave ls | grep {{DEVNET}} || true)
+    if [ -z "$ENCLAVE_EXISTS" ]; then
+        echo "No kurtosis enclave found with name {{DEVNET}}"
+        exit 1
+    fi
+
+    # Get all the services that contain the words "cl" and "kona"
+    SERVICES=$(kurtosis enclave inspect {{DEVNET}} | grep "cl" | grep "kona" | awk '{print $2}')
+
+    for service in $SERVICES; do
+        kurtosis service update {{DEVNET}} $service --image kona-node:local
+    done

--- a/tests/justfile
+++ b/tests/justfile
@@ -18,6 +18,7 @@ build-devnet BINARY:
 # The ENCLAVE variable can be used to specify a custom enclave name to use for kurtosis.
 devnet CUSTOM_DEVNET_PATH="" ENCLAVE="" OP_PACKAGE_PATH="":
   #!/bin/bash
+  mise install && mise activate
 
   export ENCLAVE=""
   if ! [ -z "{{ENCLAVE}}" ]; then
@@ -38,7 +39,7 @@ devnet CUSTOM_DEVNET_PATH="" ENCLAVE="" OP_PACKAGE_PATH="":
   fi
 
   # Run the kurtosis test
-  kurtosis run $OP_PACKAGE_PATH --args-file $DEVNET_PATH $ENCLAVE
+  mise x -- kurtosis run $OP_PACKAGE_PATH --args-file $DEVNET_PATH $ENCLAVE
 
 # Winds down kurtosis, cleaning up the network
 cleanup-kurtosis:
@@ -62,11 +63,9 @@ build-deploy-devnet DEVNET BINARY OP_PACKAGE_PATH="": (build-devnet BINARY)
 
     just devnet $DEVNET_PATH {{DEVNET}} {{OP_PACKAGE_PATH}}
 
-build-devnet-and-test-e2e DEVNET BINARY OP_PACKAGE_PATH="": (build-devnet BINARY)
+build-devnet-and-test-e2e DEVNET BINARY OP_PACKAGE_PATH="": (build-deploy-devnet DEVNET BINARY OP_PACKAGE_PATH)
     #!/bin/bash
     export DEVNET_PATH="{{SOURCE}}/devnets/{{DEVNET}}.yaml"
-
-    just devnet $DEVNET_PATH {{DEVNET}} {{OP_PACKAGE_PATH}}
 
     just test-e2e "ktnative://{{DEVNET}}$DEVNET_PATH" "{{BINARY}}"
 


### PR DESCRIPTION
## Description

This PR enables hot restarts of the kurtosis network by updating only the CL clients by swapping their docker image. This and #1896 greatly reduce the iteration time for local kurtosis development (from 5-10 mins to <1 min for reloading a kurtosis network).

Depends on #1914