### PR TITLE
fix(docker): add fix-missing to fix docker builds

### DIFF
--- a/docker/apps/kona_app_generic.dockerfile
+++ b/docker/apps/kona_app_generic.dockerfile
@@ -8,7 +8,7 @@ FROM ubuntu:22.04 AS dep-setup-stage
 SHELL ["/bin/bash", "-c"]
 
 # Install deps
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
   build-essential \
   git \
   curl \


### PR DESCRIPTION
## Description

This PR adds a couple of parameters to the ubuntu installs inside kona's docker images to try to recover when package install fails.