### PR TITLE
fix(ci): Prefix-key designation in generic setup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -14,7 +14,7 @@ inputs:
   prefix-key:
     description: The prefix key for the rust cache
     required: false
-    default: ""
+    default: "v0-rust"
 
 runs:
   using: "composite"
@@ -33,9 +33,7 @@ runs:
       uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: 1.85
-        components: $COMPONENTS
-      env:
-        COMPONENTS: ${{ inputs.components }}
+        components: ${{ inputs.components }}
 
     - name: Installs nightly rust toolchain
       if: ${{ inputs.channel == 'nightly' && inputs.components == '' }}
@@ -45,14 +43,10 @@ runs:
       if: ${{ inputs.channel == 'nightly' && inputs.components != '' }}
       uses: dtolnay/rust-toolchain@nightly
       with:
-        components: $COMPONENTS
-      env:
-        COMPONENTS: ${{ inputs.components }}
+        components: ${{ inputs.components }}
 
     - name: Installs the rust cache
       uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: true
-        prefix-key: $PREFIX_KEY
-      env:
-        PREFIX_KEY: ${{ inputs.prefix-key }}
+        prefix-key: ${{ inputs.prefix-key }}


### PR DESCRIPTION
## Overview

Fixes the prefix-key designation in the generic Rust CI setup job. At the moment, the prefix key isn't being correctly set, causing cache collisions on jobs with dynamic prefix-key settings.

<img width="575" alt="Screenshot 2025-06-02 at 12 29 49 PM" src="https://github.com/user-attachments/assets/29fbc873-ca1b-4e18-bf29-0070121ed9d6" />