### PR TITLE
fix(docker): Use cache busting for generic app dockerfile

### DIFF
--- a/docker/apps/kona_app_generic.dockerfile
+++ b/docker/apps/kona_app_generic.dockerfile
@@ -8,7 +8,7 @@ FROM ubuntu:22.04 AS dep-setup-stage
 SHELL ["/bin/bash", "-c"]
 
 # Install deps
-RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
+RUN apt-get update && apt-get install -y --no-install-recommends \
   build-essential \
   git \
   curl \
@@ -67,7 +67,7 @@ FROM build-entrypoint AS planner
 COPY --from=app-setup kona .
 RUN cargo chef prepare --recipe-path recipe.json
 
-FROM build-entrypoint AS builder 
+FROM build-entrypoint AS builder
 # Since we only copy recipe.json, if the dependencies don't change, this step and the next one will be cached.
 COPY --from=planner /app/recipe.json recipe.json
 
@@ -76,7 +76,7 @@ RUN RUSTFLAGS="-C target-cpu=native" cargo chef cook --bin "${BIN_TARGET}" --pro
 
 # Build application. This step will systematically trigger a cache invalidation if the source code changes.
 COPY --from=app-setup kona .
-# Build the application binary on the selected tag. Since we build the external dependencies in the previous step, 
+# Build the application binary on the selected tag. Since we build the external dependencies in the previous step,
 # this step will reuse the target directory from the previous step.
 RUN RUSTFLAGS="-C target-cpu=native" cargo build --bin "${BIN_TARGET}" --profile "${BUILD_PROFILE}"
 


### PR DESCRIPTION
## Overview

Removes `--fix-missing` from `kona_app_generic`'s `apt-get install` command, as recommended by the [best practices](https://docs.docker.com/build/building/best-practices/#apt-get) document from docker. Claude also recommends against it:
<img width="724" alt="Screenshot 2025-06-02 at 1 16 43 PM" src="https://github.com/user-attachments/assets/5b93098a-0034-4baa-9692-6cbfc5ce4c60" />
