### PR TITLE
perf(ci): Only persist rust cache on `main`

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -53,3 +53,4 @@ runs:
       with:
         cache-on-failure: true
         prefix-key: ${{ inputs.prefix-key }}
+        save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -22,6 +22,9 @@ runs:
     - name: Install Just
       uses: taiki-e/install-action@just
 
+    - name: Install mold linker
+      uses: rui314/setup-mold@v1
+
     - name: Installs stable rust toolchain
       if: ${{ inputs.channel == 'stable' && inputs.components == '' }}
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/proof.yaml
+++ b/.github/workflows/proof.yaml
@@ -23,15 +23,11 @@ jobs:
         uses: jlumbroso/free-disk-space@main
         with:
           large-packages: false
-      - uses: taiki-e/install-action@just
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup
         with:
           components: llvm-tools-preview
-          toolchain: 1.85
+          prefix-key: ${{ matrix.kind }}
       - uses: taiki-e/install-action@cargo-llvm-cov
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - name: Prep action test environment
         run: just monorepo
       - name: Restore cached Forge artifacts
@@ -106,17 +102,11 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-      - uses: taiki-e/install-action@just
-      - uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Install Rust stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup
         with:
           components: llvm-tools-preview
-          toolchain: 1.85
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
           prefix-key: ${{ matrix.target }}-${{ matrix.name }}
+      - uses: taiki-e/install-action@cargo-llvm-cov
       - name: Log into ghcr
         if: "!contains(matrix.target, 'native')"
         uses: docker/login-action@v3

--- a/.github/workflows/rust_ci.yaml
+++ b/.github/workflows/rust_ci.yaml
@@ -169,6 +169,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Install mold linker
+        uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: riscv32imac-unknown-none-elf

--- a/.github/workflows/rust_ci.yaml
+++ b/.github/workflows/rust_ci.yaml
@@ -178,6 +178,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: check
         run: ./.github/scripts/check_no_std.sh
 


### PR DESCRIPTION
## Overview

An attempt at reducing cache use. At the moment, we persist caches for every single workflow that is ran, causing a massive amount of cache use:

![image](https://github.com/user-attachments/assets/9a5df6b4-2579-4423-8171-33b86d4095c5)

https://github.com/Swatinem/rust-cache/issues/95 mentions a different route that the `rust-libp2p` authors went, where they only persist caches on the `main` branch, allowing only for PRs to derive caches from `main`'s latest run.

Their setup also introduces a cache factory that generates caches for tests, but since we don't employ a similar strategy, this PR just adds `save-if: ${{ github.ref == 'refs/heads/main' }}` for now.