### PR TITLE
perf: Remove Duplicated L2 Block Query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4909,8 +4909,8 @@ dependencies = [
 name = "kona-supervisor-core"
 version = "0.1.0"
 dependencies = [
- "alloy-network",
  "alloy-eips",
+ "alloy-network",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types-engine",


### PR DESCRIPTION
### Description

Removes the duplicated l2 block network request by directly transforming the l2 block into `L2BlockInfo`.