### PR TITLE
chore(node): Hardfork Metrics

### DIFF
--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -66,6 +66,11 @@ impl Cli {
             Commands::Info(ref info) => info.init_logs(&self.global)?,
         }
 
+        // If metrics are enabled, initialize the global cli metrics.
+        if self.metrics.enabled {
+            self.global.init_cli_metrics();
+        }
+
         // Allow subcommands to initialize cli metrics.
         match self.subcommand {
             Commands::Node(ref node) => node.init_cli_metrics(&self.metrics)?,

--- a/bin/node/src/flags/globals.rs
+++ b/bin/node/src/flags/globals.rs
@@ -1,5 +1,6 @@
 //! Global arguments for the CLI.
 
+use crate::metrics::CliMetrics;
 use alloy_primitives::Address;
 use clap::{ArgAction, Parser};
 use kona_cli::init_tracing_subscriber;
@@ -24,6 +25,30 @@ impl GlobalArgs {
     /// Initializes the telemetry stack and Prometheus metrics recorder.
     pub fn init_tracing(&self, filter: Option<EnvFilter>) -> anyhow::Result<()> {
         Ok(init_tracing_subscriber(self.v, filter)?)
+    }
+
+    /// Initializes cli metrics for global argument values.
+    pub fn init_cli_metrics(&self) {
+        let hardforks = self.rollup_config().map(|config| config.hardforks).unwrap_or_default();
+        metrics::gauge!(
+            CliMetrics::HARDFORK_ACTIVATION_TIMES,
+            &[
+                ("regolith_time", hardforks.regolith_time.unwrap_or_default().to_string()),
+                ("canyon_time", hardforks.canyon_time.unwrap_or_default().to_string()),
+                ("delta_time", hardforks.delta_time.unwrap_or_default().to_string()),
+                ("ecotone_time", hardforks.ecotone_time.unwrap_or_default().to_string()),
+                ("fjord_time", hardforks.fjord_time.unwrap_or_default().to_string()),
+                ("granite_time", hardforks.granite_time.unwrap_or_default().to_string()),
+                ("holocene_time", hardforks.holocene_time.unwrap_or_default().to_string()),
+                (
+                    "pectra_blob_schedule_time",
+                    hardforks.pectra_blob_schedule_time.unwrap_or_default().to_string()
+                ),
+                ("isthmus_time", hardforks.isthmus_time.unwrap_or_default().to_string()),
+                ("interop_time", hardforks.interop_time.unwrap_or_default().to_string()),
+            ]
+        )
+        .set(1);
     }
 
     /// Returns the [`RollupConfig`] for the [`GlobalArgs::l2_chain_id`] specified on the global

--- a/bin/node/src/metrics/cli_opts.rs
+++ b/bin/node/src/metrics/cli_opts.rs
@@ -35,6 +35,9 @@ impl CliMetrics {
     /// The advertised udp port via P2P.
     pub const P2P_ADVERTISE_UDP_PORT: &'static str = "kona_node_advertise_udp";
 
+    /// Hardfork activation times.
+    pub const HARDFORK_ACTIVATION_TIMES: &'static str = "kona_node_hardforks";
+
     /// Initializes the CLI metrics.
     pub fn init() {
         let labels: [(&str, &str); 9] = [


### PR DESCRIPTION
### Description

Hardforks can be overridden and are very useful to have visibility into when the node is considering them to be active.

This PR adds "hardfork metrics" that just records the timestamp when hardforks are active similar to other cli metrics.