### PR TITLE
chore(rpc): Server Restarts

### DIFF
--- a/bin/node/src/flags/rpc.rs
+++ b/bin/node/src/flags/rpc.rs
@@ -12,6 +12,9 @@ pub struct RpcArgs {
     /// Whether to enable the rpc server.
     #[arg(long = "rpc.disabled", default_value = "false", env = "KONA_NODE_RPC_ENABLED")]
     pub rpc_disabled: bool,
+    /// Prevent the RPC server from attempting to restart.
+    #[arg(long = "rpc.no-restart", default_value = "false", env = "KONA_NODE_RPC_NO_RESTART")]
+    pub no_restart: bool,
     /// RPC listening address.
     #[arg(long = "rpc.addr", default_value = "0.0.0.0", env = "KONA_NODE_RPC_ADDR")]
     pub listen_addr: IpAddr,
@@ -39,6 +42,7 @@ impl From<&RpcArgs> for RpcConfig {
     fn from(args: &RpcArgs) -> Self {
         Self {
             enabled: !args.rpc_disabled,
+            no_restart: args.no_restart,
             listen_addr: args.listen_addr,
             listen_port: args.listen_port,
             enable_admin: args.enable_admin,
@@ -61,6 +65,7 @@ mod tests {
 
     #[rstest]
     #[case::disable_rpc(&["--rpc.disabled"], |args: &mut RpcArgs| { args.rpc_disabled = true; })]
+    #[case::no_restart(&["--rpc.no-restart"], |args: &mut RpcArgs| { args.no_restart = true; })]
     #[case::disable_rpc(&["--rpc.addr", "1.1.1.1"], |args: &mut RpcArgs| { args.listen_addr = IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)); })]
     #[case::disable_rpc(&["--rpc.port", "8743"], |args: &mut RpcArgs| { args.listen_port = 8743; })]
     #[case::disable_rpc(&["--rpc.enable-admin"], |args: &mut RpcArgs| { args.enable_admin = true; })]

--- a/crates/node/rpc/src/config.rs
+++ b/crates/node/rpc/src/config.rs
@@ -11,6 +11,8 @@ use std::{
 pub struct RpcConfig {
     /// If the RPC is enabled.
     pub enabled: bool,
+    /// Prevent the rpc server from being restarted.
+    pub no_restart: bool,
     /// The RPC listening address.
     pub listen_addr: IpAddr,
     /// The RPC listening port.
@@ -29,6 +31,7 @@ impl RpcConfig {
         if !self.enabled {
             launcher.disable();
         }
+        launcher.no_restart = self.no_restart;
         launcher
     }
 }

--- a/crates/node/rpc/src/launcher.rs
+++ b/crates/node/rpc/src/launcher.rs
@@ -28,13 +28,15 @@ impl PartialEq for RpcLauncherError {
 #[derive(Debug, Clone, Default)]
 pub struct RpcLauncher {
     disabled: bool,
+    /// If `true`, the RPC server will not attempt to restart if it stops.
+    pub no_restart: bool,
     socket: Option<SocketAddr>,
     module: Option<RpcModule<()>>,
 }
 
 impl From<SocketAddr> for RpcLauncher {
     fn from(socket: SocketAddr) -> Self {
-        Self { disabled: false, socket: Some(socket), module: None }
+        Self { disabled: false, no_restart: false, socket: Some(socket), module: None }
     }
 }
 

--- a/crates/node/service/src/actors/rpc.rs
+++ b/crates/node/service/src/actors/rpc.rs
@@ -3,6 +3,7 @@
 use crate::NodeActor;
 use async_trait::async_trait;
 use jsonrpsee::server::ServerHandle;
+use kona_rpc::RpcLauncher;
 use tokio_util::sync::CancellationToken;
 
 /// An error returned by the [`RpcActor`].
@@ -19,6 +20,8 @@ pub enum RpcActorError {
 /// An actor that handles the RPC server for the rollup node.
 #[derive(Debug)]
 pub struct RpcActor {
+    /// A launcher for the rpc.
+    launcher: RpcLauncher,
     /// The handle to the RPC server.
     server: ServerHandle,
     /// The cancellation token, shared between all tasks.
@@ -27,8 +30,12 @@ pub struct RpcActor {
 
 impl RpcActor {
     /// Constructs a new [`RpcActor`] given the [`ServerHandle`] and [`CancellationToken`].
-    pub const fn new(server: ServerHandle, cancellation: CancellationToken) -> Self {
-        Self { server, cancellation }
+    pub const fn new(
+        launcher: RpcLauncher,
+        server: ServerHandle,
+        cancellation: CancellationToken,
+    ) -> Self {
+        Self { launcher, server, cancellation }
     }
 }
 
@@ -38,18 +45,35 @@ impl NodeActor for RpcActor {
     type Error = RpcActorError;
 
     async fn start(mut self) -> Result<(), Self::Error> {
-        let server = self.server.clone();
-        tokio::select! {
-            _ = server.stopped() => {
-                // The server has stopped, so we should stop as well.
-                self.cancellation.cancel();
-                return Err(RpcActorError::ServerStopped);
-            }
-            _ = self.cancellation.cancelled() => {
-                // The cancellation token has been triggered, so we should stop the server.
-                self.server.stop().map_err(|_| RpcActorError::StopFailed)?;
-                // Since the RPC Server didn't originate the error, we should return Ok.
-                return Ok(());
+        let mut server = self.server.clone();
+        let mut restarts = if self.launcher.no_restart { 3 } else { 0 };
+        loop {
+            tokio::select! {
+                _ = server.clone().stopped() => {
+                    // Stop the node if there has already been 3 rpc restarts.
+                    if restarts >= 3 {
+                        self.cancellation.cancel();
+                        return Err(RpcActorError::ServerStopped);
+                    }
+                    restarts += 1;
+                    match self.launcher.launch().await {
+                        Ok(Some(h)) => server = h,
+                        Ok(None) => {
+                            warn!(target: "rpc", "Rpc Launcher returned missing server handle");
+                        }
+                        Err(err) => {
+                            error!(target: "rpc", ?err, "Failed to launch rpc server");
+                            self.cancellation.cancel();
+                            return Err(RpcActorError::ServerStopped);
+                        }
+                    }
+                }
+                _ = self.cancellation.cancelled() => {
+                    // The cancellation token has been triggered, so we should stop the server.
+                    self.server.stop().map_err(|_| RpcActorError::StopFailed)?;
+                    // Since the RPC Server didn't originate the error, we should return Ok.
+                    return Ok(());
+                }
             }
         }
     }

--- a/crates/node/service/src/service/validator.rs
+++ b/crates/node/service/src/service/validator.rs
@@ -180,7 +180,7 @@ pub trait ValidatorNodeService {
         launcher = launcher.merge(Some(subscriptions_rpc.into_rpc())).map_err(Self::Error::from)?;
 
         let handle = launcher.launch().await?;
-        let rpc = handle.map(|h| RpcActor::new(h, cancellation.clone()));
+        let rpc = handle.map(|h| RpcActor::new(launcher, h, cancellation.clone()));
 
         spawn_and_wait!(
             cancellation,


### PR DESCRIPTION
### Description

Allows the RPC server to be restarted up to 3 times before failing and killing the node.

Closes #1320