### PR TITLE
chore(client/host): Prepare for `v1.0.2` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4184,7 +4184,7 @@ dependencies = [
 
 [[package]]
 name = "kona-client"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4416,7 +4416,7 @@ dependencies = [
 
 [[package]]
 name = "kona-host"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,8 +73,8 @@ codegen-units = 1
 
 [workspace.dependencies]
 # Binaries
-kona-host = { path = "bin/host", version = "1.0.1", default-features = false }
-kona-client = { path = "bin/client", version = "1.0.1", default-features = false }
+kona-host = { path = "bin/host", version = "1.0.2", default-features = false }
+kona-client = { path = "bin/client", version = "1.0.2", default-features = false }
 
 # Protocol
 kona-comp = { path = "crates/protocol/comp", version = "0.3.0", default-features = false }

--- a/bin/client/Cargo.toml
+++ b/bin/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kona-client"
-version = "1.0.1"
+version = "1.0.2"
 publish = false
 edition.workspace = true
 authors.workspace = true

--- a/bin/host/Cargo.toml
+++ b/bin/host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kona-host"
-version = "1.0.1"
+version = "1.0.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Overview

Bumps `kona-client` + `kona-host` to `v1.0.2`.