### PR TITLE
feat(node/p2p): support chain id info inside opp2p_peers

### DIFF
--- a/crates/node/p2p/src/lib.rs
+++ b/crates/node/p2p/src/lib.rs
@@ -35,9 +35,9 @@ pub use gossip::{
 mod peers;
 pub use peers::{
     AnyNode, BootNode, BootNodes, BootStore, DialOptsError, EnrValidation, NodeRecord,
-    NodeRecordParseError, OP_RAW_BOOTNODES, OP_RAW_TESTNET_BOOTNODES, OpStackEnr, PeerId,
-    PeerIdConversionError, PeerMonitoring, PeerScoreLevel, enr_to_multiaddr, local_id_to_p2p_id,
-    peer_id_to_secp256k1_pubkey,
+    NodeRecordParseError, OP_RAW_BOOTNODES, OP_RAW_TESTNET_BOOTNODES, OpStackEnr, OpStackEnrError,
+    PeerId, PeerIdConversionError, PeerMonitoring, PeerScoreLevel, enr_to_multiaddr,
+    local_id_to_p2p_id, peer_id_to_secp256k1_pubkey,
 };
 
 mod discv5;

--- a/crates/node/p2p/src/peers/mod.rs
+++ b/crates/node/p2p/src/peers/mod.rs
@@ -49,7 +49,7 @@ mod score;
 pub use score::PeerScoreLevel;
 
 mod enr;
-pub use enr::{EnrValidation, OpStackEnr};
+pub use enr::{EnrValidation, OpStackEnr, OpStackEnrError};
 
 mod any;
 pub use any::{AnyNode, DialOptsError};

--- a/crates/node/p2p/src/rpc/request.rs
+++ b/crates/node/p2p/src/rpc/request.rs
@@ -5,7 +5,7 @@ use std::{
     num::TryFromIntError,
 };
 
-use crate::{Discv5Handler, GossipDriver};
+use crate::{Discv5Handler, GossipDriver, OpStackEnr};
 use alloy_primitives::map::foldhash::fast::RandomState;
 use discv5::{
     enr::{NodeId, k256::ecdsa},
@@ -160,6 +160,8 @@ impl P2pRpcRequest {
             let infos: HashMap<String, PeerInfo, RandomState> = table_infos
                 .iter()
                 .filter_map(|(id, enr, status)| {
+                    let opstack_enr = OpStackEnr::try_from(enr).ok();
+
                     // TODO(@theochap, `<https://github.com/op-rs/kona/issues/1562>`): improve the connectedness information to include the other
                     // variants.
                     let connectedness = if status.is_connected() {
@@ -187,10 +189,11 @@ impl P2pRpcRequest {
                                 protocols: protocols.remove(peer_id),
                                 connectedness,
                                 direction,
+                                // Note: we use the chain id from the ENR if it exists, otherwise we
+                                // use 0 to be consistent with op-node's behavior (`<https://github.com/ethereum-optimism/optimism/blob/6a8b2349c29c2a14f948fcb8aefb90526130acec/op-service/apis/p2p.go#L55>`).
+                                chain_id: opstack_enr.map(|enr| enr.chain_id).unwrap_or(0),
                                 // TODO(@theochap, `<https://github.com/op-rs/kona/issues/1562>`): support these fields
                                 protected: false,
-                                // TODO(@theochap, `<https://github.com/op-rs/kona/issues/1562>`): support these fields
-                                chain_id: 0,
                                 // TODO(@theochap, `<https://github.com/op-rs/kona/issues/1562>`): support these fields
                                 latency: 0,
                                 // TODO(@theochap, `<https://github.com/op-rs/kona/issues/1562>`): support these fields


### PR DESCRIPTION
## Description

This PR adds support for chain-id information inside `opp2p_peers` RPC api call. 

Progress towards #1562 