### PR TITLE
chore(supervisor): Remove deprecated supervisor api from `kona-node`

### DIFF
--- a/crates/node/rpc/src/jsonrpsee.rs
+++ b/crates/node/rpc/src/jsonrpsee.rs
@@ -2,17 +2,14 @@
 
 use crate::{OutputResponse, SafeHeadResponse};
 use alloy_eips::BlockNumberOrTag;
-use alloy_primitives::B256;
 use core::net::IpAddr;
 use jsonrpsee::{
     core::{RpcResult, SubscriptionResult},
     proc_macros::rpc,
 };
 use kona_genesis::RollupConfig;
-use kona_interop::ExecutingDescriptor;
 use kona_p2p::{PeerCount, PeerDump, PeerInfo, PeerStats};
 use kona_protocol::SyncStatus;
-use op_alloy_consensus::interop::SafetyLevel;
 
 #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), allow(unused_imports))]
 use getrandom as _; // required for compiling wasm32-unknown-unknown
@@ -146,16 +143,3 @@ pub trait Ws {
     async fn ws_unsafe_head_updates(&self) -> SubscriptionResult;
 }
 
-/// Supervisor API for interop.
-#[cfg_attr(not(feature = "client"), rpc(server, namespace = "supervisor"))]
-#[cfg_attr(feature = "client", rpc(server, client, namespace = "supervisor"))]
-pub trait SupervisorApi {
-    /// Checks if the given inbox entries meet the given minimum safety level.
-    #[method(name = "checkAccessList")]
-    async fn check_access_list(
-        &self,
-        inbox_entries: Vec<B256>,
-        min_safety: SafetyLevel,
-        executing_descriptor: ExecutingDescriptor,
-    ) -> RpcResult<()>;
-}


### PR DESCRIPTION
Remove deprecated supervisor api from `kona-node` which isn't used since the same API is re-exported from `kona-rpc` in crate root