### PR TITLE
feat(node/service): Introduce backpressure in DA watcher channels

### DIFF
--- a/crates/node/service/src/actors/derivation.rs
+++ b/crates/node/service/src/actors/derivation.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 use tokio::{
     select,
     sync::{
-        mpsc::{UnboundedReceiver, UnboundedSender},
+        mpsc::{self, UnboundedReceiver, UnboundedSender},
         oneshot::Receiver as OneshotReceiver,
         watch::Receiver as WatchReceiver,
     },
@@ -56,7 +56,7 @@ where
     /// Specs: <https://specs.optimism.io/protocol/derivation.html#l1-sync-payload-attributes-processing>
     derivation_signal_rx: UnboundedReceiver<Signal>,
     /// The receiver for L1 head update notifications.
-    l1_head_updates: UnboundedReceiver<BlockInfo>,
+    l1_head_updates: mpsc::Receiver<BlockInfo>,
 
     /// The sender for derived [`OpAttributesWithParent`]s produced by the actor.
     attributes_out: UnboundedSender<OpAttributesWithParent>,
@@ -88,7 +88,7 @@ where
         engine_l2_safe_head: WatchReceiver<L2BlockInfo>,
         sync_complete_rx: OneshotReceiver<()>,
         derivation_signal_rx: UnboundedReceiver<Signal>,
-        l1_head_updates: UnboundedReceiver<BlockInfo>,
+        l1_head_updates: mpsc::Receiver<BlockInfo>,
         attributes_out: UnboundedSender<OpAttributesWithParent>,
         reset_request_tx: UnboundedSender<()>,
         cancellation: CancellationToken,

--- a/crates/node/service/src/actors/engine/actor.rs
+++ b/crates/node/service/src/actors/engine/actor.rs
@@ -16,7 +16,7 @@ use op_alloy_rpc_types_engine::OpNetworkPayloadEnvelope;
 use std::sync::Arc;
 use tokio::{
     sync::{
-        mpsc::{Receiver as MpscReceiver, UnboundedReceiver, UnboundedSender},
+        mpsc::{self, Receiver as MpscReceiver, UnboundedReceiver, UnboundedSender},
         oneshot::Sender as OneshotSender,
         watch::Sender as WatchSender,
     },
@@ -79,7 +79,7 @@ impl EngineActor {
         attributes_rx: UnboundedReceiver<OpAttributesWithParent>,
         unsafe_block_rx: UnboundedReceiver<OpNetworkPayloadEnvelope>,
         reset_request_rx: UnboundedReceiver<()>,
-        finalized_block_rx: UnboundedReceiver<BlockInfo>,
+        finalized_block_rx: mpsc::Receiver<BlockInfo>,
         inbound_queries: Option<MpscReceiver<EngineQueries>>,
         cancellation: CancellationToken,
     ) -> Self {

--- a/crates/node/service/src/actors/engine/finalizer.rs
+++ b/crates/node/service/src/actors/engine/finalizer.rs
@@ -3,7 +3,7 @@
 use kona_engine::{Engine, EngineClient, EngineTask, FinalizeTask};
 use kona_protocol::{BlockInfo, OpAttributesWithParent};
 use std::{collections::BTreeMap, sync::Arc};
-use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::sync::mpsc;
 
 /// An internal type alias for L1 block numbers.
 type L1BlockNumber = u64;
@@ -17,7 +17,7 @@ type L2BlockNumber = u64;
 #[derive(Debug)]
 pub struct L2Finalizer {
     /// A channel that receives new finalized L1 blocks intermittently.
-    finalized_l1_block_rx: UnboundedReceiver<BlockInfo>,
+    finalized_l1_block_rx: mpsc::Receiver<BlockInfo>,
     /// An [`EngineClient`], used to create [`FinalizeTask`]s.
     client: Arc<EngineClient>,
     /// A map of `L1 block number -> highest derived L2 block number` within the L1 epoch, used to
@@ -30,7 +30,7 @@ pub struct L2Finalizer {
 impl L2Finalizer {
     /// Creates a new [`L2Finalizer`] with the given channel receiver for finalized L1 blocks.
     pub const fn new(
-        finalized_l1_block_rx: UnboundedReceiver<BlockInfo>,
+        finalized_l1_block_rx: mpsc::Receiver<BlockInfo>,
         client: Arc<EngineClient>,
     ) -> Self {
         Self { finalized_l1_block_rx, client, awaiting_finalization: BTreeMap::new() }

--- a/crates/node/service/src/actors/network.rs
+++ b/crates/node/service/src/actors/network.rs
@@ -10,7 +10,7 @@ use op_alloy_rpc_types_engine::OpNetworkPayloadEnvelope;
 use thiserror::Error;
 use tokio::{
     select,
-    sync::mpsc::{UnboundedReceiver, UnboundedSender},
+    sync::mpsc::{self, UnboundedSender},
 };
 use tokio_util::sync::CancellationToken;
 
@@ -48,7 +48,7 @@ pub struct NetworkActor {
     /// The sender for [OpNetworkPayloadEnvelope]s received via p2p gossip.
     blocks: UnboundedSender<OpNetworkPayloadEnvelope>,
     /// The receiver for unsafe block signer updates.
-    signer: UnboundedReceiver<Address>,
+    signer: mpsc::Receiver<Address>,
     /// The cancellation token, shared between all tasks.
     cancellation: CancellationToken,
 }
@@ -58,7 +58,7 @@ impl NetworkActor {
     pub const fn new(
         driver: Network,
         blocks: UnboundedSender<OpNetworkPayloadEnvelope>,
-        signer: UnboundedReceiver<Address>,
+        signer: mpsc::Receiver<Address>,
         cancellation: CancellationToken,
     ) -> Self {
         Self { driver, blocks, signer, cancellation }

--- a/crates/node/service/src/service/standard/node.rs
+++ b/crates/node/service/src/service/standard/node.rs
@@ -9,7 +9,7 @@ use alloy_provider::RootProvider;
 use async_trait::async_trait;
 use op_alloy_network::Optimism;
 use std::sync::Arc;
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use kona_genesis::RollupConfig;
@@ -83,9 +83,9 @@ impl ValidatorNodeService for RollupNode {
 
     fn new_da_watcher(
         &self,
-        new_data_tx: UnboundedSender<BlockInfo>,
-        new_finalized_tx: UnboundedSender<BlockInfo>,
-        block_signer_tx: UnboundedSender<Address>,
+        new_data_tx: mpsc::Sender<BlockInfo>,
+        new_finalized_tx: mpsc::Sender<BlockInfo>,
+        block_signer_tx: mpsc::Sender<Address>,
         cancellation: CancellationToken,
         l1_watcher_inbound_queries: Option<tokio::sync::mpsc::Receiver<L1WatcherQueries>>,
     ) -> Self::DataAvailabilityWatcher {


### PR DESCRIPTION
## Overview

Introduces backpressure within the DA watcher channels. This change ensures that if the consumers of the DA watcher events (L1 {head/finalized} updates, unsafe block signer updates) do not process their events in a timely manner, the DA watcher doesn't endlessly fill up the channel queue, and yields until the other actors can process its pending updates.

progress on #1993 