### PR TITLE
feat(derive): Decompressed Channel Size Metric

### DIFF
--- a/crates/protocol/derive/src/metrics/mod.rs
+++ b/crates/protocol/derive/src/metrics/mod.rs
@@ -93,6 +93,14 @@ impl Metrics {
     /// Identifier for a gauge that tracks the block height at which a system config update errored.
     pub const PIPELINE_SYS_CONFIG_UPDATE_ERROR: &'static str =
         "kona_genesis_sys_config_update_error";
+
+    /// Gauge that tracks the latest decompressed batch size.
+    pub const PIPELINE_LATEST_DECOMPRESSED_BATCH_SIZE: &str =
+        "kona_derive_latest_decompressed_batch_size";
+
+    /// Gauge that tracks the latest decompressed batch type.
+    pub const PIPELINE_LATEST_DECOMPRESSED_BATCH_TYPE: &str =
+        "kona_derive_latest_decompressed_batch_type";
 }
 
 impl Metrics {
@@ -117,6 +125,14 @@ impl Metrics {
         metrics::describe_gauge!(
             Self::PIPELINE_LATEST_SYS_CONFIG_UPDATE,
             "The latest block number for a system config update"
+        );
+        metrics::describe_gauge!(
+            Self::PIPELINE_LATEST_DECOMPRESSED_BATCH_SIZE,
+            "The latest decompressed batch size"
+        );
+        metrics::describe_gauge!(
+            Self::PIPELINE_LATEST_DECOMPRESSED_BATCH_TYPE,
+            "The latest decompressed batch type"
         );
         metrics::describe_gauge!(
             Self::PIPELINE_ORIGIN,

--- a/crates/protocol/protocol/src/batch/mod.rs
+++ b/crates/protocol/protocol/src/batch/mod.rs
@@ -4,7 +4,7 @@ mod r#type;
 pub use r#type::*;
 
 mod reader;
-pub use reader::BatchReader;
+pub use reader::{BatchReader, DecompressionError};
 
 mod tx;
 pub use tx::BatchTransaction;

--- a/crates/protocol/protocol/src/batch/reader.rs
+++ b/crates/protocol/protocol/src/batch/reader.rs
@@ -1,19 +1,31 @@
 //! Contains the [BatchReader] which is used to iteratively consume batches from raw data.
 
-use crate::{Batch, decompress_brotli};
+use crate::{Batch, BrotliDecompressionError, decompress_brotli};
 use alloc::vec::Vec;
 use alloy_primitives::Bytes;
 use alloy_rlp::Decodable;
 use kona_genesis::RollupConfig;
-use miniz_oxide::inflate::decompress_to_vec_zlib;
-/// ZLIB Deflate Compression Method.
-const ZLIB_DEFLATE_COMPRESSION_METHOD: u8 = 8;
+use miniz_oxide::inflate::{DecompressError, decompress_to_vec_zlib};
 
-/// ZLIB Reserved Compression Info.
-const ZLIB_RESERVED_COMPRESSION_METHOD: u8 = 15;
-
-/// Brotili Compression Channel Version.
-const CHANNEL_VERSION_BROTLI: u8 = 1;
+/// Error type for decompression failures.
+#[derive(Debug, thiserror::Error)]
+pub enum DecompressionError {
+    /// The data to decompress was empty.
+    #[error("the data to decompress was empty")]
+    EmptyData,
+    /// The compression type is not supported.
+    #[error("the compression type {0} is not supported")]
+    UnsupportedType(u8),
+    /// A brotli decompression error.
+    #[error("brotli decompression error: {0}")]
+    BrotliError(#[from] BrotliDecompressionError),
+    /// A zlib decompression error.
+    #[error("zlib decompression error: {0}")]
+    ZlibError(#[from] DecompressError),
+    /// The RLP data is too large for the configured maximum.
+    #[error("the RLP data is too large: {0} bytes, maximum allowed: {1} bytes")]
+    RlpTooLarge(usize, usize),
+}
 
 /// Batch Reader provides a function that iteratively consumes batches from the reader.
 /// The L1Inclusion block is also provided at creation time.
@@ -24,14 +36,25 @@ pub struct BatchReader {
     /// The raw data to decode.
     data: Option<Vec<u8>>,
     /// Decompressed data.
-    decompressed: Vec<u8>,
+    pub decompressed: Vec<u8>,
     /// The current cursor in the `decompressed` data.
     cursor: usize,
     /// The maximum RLP bytes per channel.
     max_rlp_bytes_per_channel: usize,
+    /// Whether brotli decompression was used.
+    pub brotli_used: bool,
 }
 
 impl BatchReader {
+    /// ZLIB Deflate Compression Method.
+    pub const ZLIB_DEFLATE_COMPRESSION_METHOD: u8 = 8;
+
+    /// ZLIB Reserved Compression Info.
+    pub const ZLIB_RESERVED_COMPRESSION_METHOD: u8 = 15;
+
+    /// Brotili Compression Channel Version.
+    pub const CHANNEL_VERSION_BROTLI: u8 = 1;
+
     /// Creates a new [BatchReader] from the given data and max decompressed RLP bytes per channel.
     pub fn new<T>(data: T, max_rlp_bytes_per_channel: usize) -> Self
     where
@@ -42,38 +65,45 @@ impl BatchReader {
             decompressed: Vec::new(),
             cursor: 0,
             max_rlp_bytes_per_channel,
+            brotli_used: false,
         }
+    }
+
+    /// Helper method to decompress the data contained in the reader.
+    pub fn decompress(&mut self) -> Result<(), DecompressionError> {
+        if let Some(data) = self.data.take() {
+            // Peek at the data to determine the compression type.
+            if data.is_empty() {
+                return Err(DecompressionError::EmptyData);
+            }
+
+            let compression_type = data[0];
+            if (compression_type & 0x0F) == Self::ZLIB_DEFLATE_COMPRESSION_METHOD ||
+                (compression_type & 0x0F) == Self::ZLIB_RESERVED_COMPRESSION_METHOD
+            {
+                self.decompressed = decompress_to_vec_zlib(&data)?;
+
+                // Check the size of the decompressed channel RLP.
+                if self.decompressed.len() > self.max_rlp_bytes_per_channel {
+                    return Err(DecompressionError::RlpTooLarge(
+                        self.decompressed.len(),
+                        self.max_rlp_bytes_per_channel,
+                    ));
+                }
+            } else if compression_type == Self::CHANNEL_VERSION_BROTLI {
+                self.brotli_used = true;
+                self.decompressed = decompress_brotli(&data[1..], self.max_rlp_bytes_per_channel)?;
+            } else {
+                return Err(DecompressionError::UnsupportedType(compression_type));
+            }
+        }
+        Ok(())
     }
 
     /// Pulls out the next batch from the reader.
     pub fn next_batch(&mut self, cfg: &RollupConfig) -> Option<Batch> {
-        // If the data is not already decompressed, decompress it.
-        let mut brotli_used = false;
-
-        if let Some(data) = self.data.take() {
-            // Peek at the data to determine the compression type.
-            if data.is_empty() {
-                return None;
-            }
-
-            let compression_type = data[0];
-            if (compression_type & 0x0F) == ZLIB_DEFLATE_COMPRESSION_METHOD ||
-                (compression_type & 0x0F) == ZLIB_RESERVED_COMPRESSION_METHOD
-            {
-                self.decompressed = decompress_to_vec_zlib(&data).ok()?;
-
-                // Check the size of the decompressed channel RLP.
-                if self.decompressed.len() > self.max_rlp_bytes_per_channel {
-                    return None;
-                }
-            } else if compression_type == CHANNEL_VERSION_BROTLI {
-                brotli_used = true;
-                self.decompressed =
-                    decompress_brotli(&data[1..], self.max_rlp_bytes_per_channel).ok()?;
-            } else {
-                return None;
-            }
-        }
+        // Ensure the data is decompressed.
+        self.decompress().ok()?;
 
         // Decompress and RLP decode the batch data, before finally decoding the batch itself.
         let decompressed_reader = &mut self.decompressed.as_slice()[self.cursor..].as_ref();
@@ -83,7 +113,7 @@ impl BatchReader {
         };
 
         // Confirm that brotli decompression was performed *after* the Fjord hardfork.
-        if brotli_used && !cfg.is_fjord_active(batch.timestamp()) {
+        if self.brotli_used && !cfg.is_fjord_active(batch.timestamp()) {
             return None;
         }
 

--- a/crates/protocol/protocol/src/batch/reader.rs
+++ b/crates/protocol/protocol/src/batch/reader.rs
@@ -52,7 +52,7 @@ impl BatchReader {
     /// ZLIB Reserved Compression Info.
     pub const ZLIB_RESERVED_COMPRESSION_METHOD: u8 = 15;
 
-    /// Brotili Compression Channel Version.
+    /// Brotli Compression Channel Version.
     pub const CHANNEL_VERSION_BROTLI: u8 = 1;
 
     /// Creates a new [BatchReader] from the given data and max decompressed RLP bytes per channel.

--- a/crates/protocol/protocol/src/lib.rs
+++ b/crates/protocol/protocol/src/lib.rs
@@ -12,9 +12,9 @@ extern crate alloc;
 mod batch;
 pub use batch::{
     Batch, BatchDecodingError, BatchEncodingError, BatchReader, BatchTransaction, BatchType,
-    BatchValidationProvider, BatchValidity, BatchWithInclusionBlock, MAX_SPAN_BATCH_ELEMENTS,
-    RawSpanBatch, SINGLE_BATCH_TYPE, SPAN_BATCH_TYPE, SingleBatch, SpanBatch, SpanBatchBits,
-    SpanBatchEip1559TransactionData, SpanBatchEip2930TransactionData,
+    BatchValidationProvider, BatchValidity, BatchWithInclusionBlock, DecompressionError,
+    MAX_SPAN_BATCH_ELEMENTS, RawSpanBatch, SINGLE_BATCH_TYPE, SPAN_BATCH_TYPE, SingleBatch,
+    SpanBatch, SpanBatchBits, SpanBatchEip1559TransactionData, SpanBatchEip2930TransactionData,
     SpanBatchEip7702TransactionData, SpanBatchElement, SpanBatchError,
     SpanBatchLegacyTransactionData, SpanBatchPayload, SpanBatchPrefix, SpanBatchTransactionData,
     SpanBatchTransactions, SpanDecodingError,


### PR DESCRIPTION
### Description

Adds two metrics to `kona-derive` tracking when the batch reader decompresses data and reads it into a batch as part of the `ChannelReader` stage of the derivation pipeline.

- Gauge that tracks the latest decompressed channel size.
- Gauge that tracks the latest decompressed channel type (brotli or zlib).

Closes #1999

<img width="655" alt="Screenshot 2025-06-06 at 12 01 39 PM" src="https://github.com/user-attachments/assets/f4ea86d6-036c-49ef-8edf-8dec9692852a" />
