### PR TITLE
fix(node/p2p): reactivate e2e tests for gossip.

### DIFF
--- a/tests/devnets/large-kona.yaml
+++ b/tests/devnets/large-kona.yaml
@@ -7,6 +7,9 @@ optimism_package:
     - participants:
       - el_type: op-geth
         cl_type: op-node
+        cl_extra_env_vars: {
+          "OP_NODE_P2P_SYNC_REQ_RESP": "false"
+        }
         count: 2
       - el_type: op-reth
         cl_type: kona-node

--- a/tests/devnets/simple-kona.yaml
+++ b/tests/devnets/simple-kona.yaml
@@ -9,11 +9,16 @@ optimism_package:
       # So we use op-geth for now.
       - el_type: op-geth
         cl_type: op-node
+        cl_extra_env_vars: {
+          "OP_NODE_P2P_SYNC_REQ_RESP": "false"
+        }
+        cl_log_level: "debug"
         count: 1
       - el_type: op-reth
         cl_type: kona-node
         # Note: we use the local image for now. This allows us to run the tests in CI pipelines without publishing new docker images every time.
         cl_image: "kona-node:local"
+        cl_log_level: "debug"
         count: 1
       network_params:
         network: "kurtosis"

--- a/tests/justfile
+++ b/tests/justfile
@@ -1,6 +1,6 @@
 SOURCE := source_directory()
 DEFAULT_DEVNET_PATH := source_directory() + "/devnets/simple-kona.yaml"
-DEFAULT_OP_PACKAGE_PATH := "github.com/ethpandaops/optimism-package"
+DEFAULT_OP_PACKAGE_PATH := "github.com/ethpandaops/optimism-package@stable"
 
 build-devnet BINARY:
     #!/usr/bin/env bash

--- a/tests/node/node_test.go
+++ b/tests/node/node_test.go
@@ -11,7 +11,6 @@ import (
 // This assumes there is at least two L2 chains. The second chain is used to test a larger network.
 func TestSystemNodeP2p(t *testing.T) {
 	t.Parallel()
-	t.Skip("TODO(@theochap): for now this test is disabled because it is very flaky. Once we have better p2p performance, we should re-enable this test.")
 
 	systest.SystemTest(t,
 		allPeersInNetwork(),
@@ -28,11 +27,10 @@ func TestSystemNodeP2p(t *testing.T) {
 // TODO(@theochap): for now this test is disabled because it is very flaky.
 // Once we have better p2p performance, we should re-enable this test.
 func TestSystemNodeP2pLargeNetwork(t *testing.T) {
-	t.Skip("TODO(@theochap): for now this test is disabled because it is very flaky. Once we have better p2p performance, we should re-enable this test.")
 	// Check that the node has at least 4 peers that are connected to its topics when there is more than 9 peers in the network initially.
 	// We put a lower bound on the number of connected peers to account for network instability.
 	systest.SystemTest(t,
-		peerCount(5, 3),
+		peerCount(5, 5),
 		validators.HasSufficientL2Nodes(0, 6),
 	)
 }


### PR DESCRIPTION
## Description

This PR reactivates e2e tests for p2p gossip. I had to change the link to the stable branch of the `optimism-package` because it appears that the main version is broken