### PR TITLE
feat(rpc): Connect Peer RPC Method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4821,6 +4821,7 @@ dependencies = [
  "kona-p2p",
  "kona-protocol",
  "kona-supervisor-rpc",
+ "libp2p",
  "metrics",
  "op-alloy-consensus",
  "op-alloy-rpc-jsonrpsee",

--- a/crates/node/p2p/src/rpc/request.rs
+++ b/crates/node/p2p/src/rpc/request.rs
@@ -74,11 +74,7 @@ impl P2pRpcRequest {
     }
 
     fn connect_peer(address: Multiaddr, gossip: &mut GossipDriver) {
-        if let Err(e) = gossip.swarm.dial(address.clone()) {
-            warn!(target: "p2p::rpc", "Failed to connect to peer at {}: {:?}", address, e);
-        } else {
-            info!(target: "p2p::rpc", "Dialed peer at {}", address);
-        }
+        gossip.dial_multiaddr(address)
     }
 
     fn disconnect_peer(peer_id: PeerId, gossip: &mut GossipDriver) {

--- a/crates/node/rpc/Cargo.toml
+++ b/crates/node/rpc/Cargo.toml
@@ -36,6 +36,7 @@ alloy-eips = { workspace = true, features = ["serde", "std"] }
 alloy-primitives = { workspace = true, features = ["map", "rlp", "serde", "std"] }
 
 # Misc
+libp2p.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 derive_more = { workspace = true, default-features = false, features = [


### PR DESCRIPTION
### Description

Implements handling for the `opp2p_connectPeer` method using the Multiaddr string.

This follows how [the monorepo parses the addr string](https://github.com/ethereum-optimism/optimism/blob/51cb1a7523ac45e3c3703a1a2c6794b378f27cba/op-node/p2p/rpc_server.go#L353).

Closes #1575