### PR TITLE
chore(derive): Remove Prelude

### DIFF
--- a/bin/client/src/single.rs
+++ b/bin/client/src/single.rs
@@ -5,7 +5,7 @@ use alloc::sync::Arc;
 use alloy_consensus::Sealed;
 use alloy_primitives::B256;
 use core::fmt::Debug;
-use kona_derive::{errors::PipelineErrorKind, prelude::EthereumDataSource};
+use kona_derive::{errors::PipelineErrorKind, sources::EthereumDataSource};
 use kona_driver::{Driver, DriverError};
 use kona_executor::{ExecutorError, TrieDBProvider};
 use kona_preimage::{CommsClient, HintWriterClient, PreimageKey, PreimageOracleClient};

--- a/bin/host/src/interop/handler.rs
+++ b/bin/host/src/interop/handler.rs
@@ -18,7 +18,7 @@ use alloy_rpc_types::Block;
 use anyhow::{Result, anyhow, ensure};
 use ark_ff::{BigInteger, PrimeField};
 use async_trait::async_trait;
-use kona_derive::prelude::EthereumDataSource;
+use kona_derive::sources::EthereumDataSource;
 use kona_driver::Driver;
 use kona_executor::TrieDBProvider;
 use kona_preimage::{

--- a/crates/proof/proof/src/l1/pipeline.rs
+++ b/crates/proof/proof/src/l1/pipeline.rs
@@ -5,9 +5,9 @@ use alloc::{boxed::Box, sync::Arc};
 use async_trait::async_trait;
 use core::fmt::Debug;
 use kona_derive::{
+    attributes::StatefulAttributesBuilder,
     errors::PipelineErrorKind,
-    pipeline::{DerivationPipeline, PipelineBuilder},
-    prelude::{AttributesQueueStage, StatefulAttributesBuilder},
+    pipeline::{AttributesQueueStage, DerivationPipeline, PipelineBuilder},
     traits::{
         ChainProvider, DataAvailabilityProvider, L2ChainProvider, OriginProvider, Pipeline,
         SignalReceiver,

--- a/crates/protocol/derive/src/lib.rs
+++ b/crates/protocol/derive/src/lib.rs
@@ -12,13 +12,6 @@ extern crate alloc;
 #[macro_use]
 extern crate tracing;
 
-/// Required types and traits for kona's derivation pipeline.
-pub mod prelude {
-    pub use crate::{
-        attributes::*, errors::*, pipeline::*, sources::*, stages::*, traits::*, types::*,
-    };
-}
-
 pub mod attributes;
 pub mod errors;
 pub mod pipeline;

--- a/crates/protocol/derive/src/stages/batch/batch_validator.rs
+++ b/crates/protocol/derive/src/stages/batch/batch_validator.rs
@@ -2,9 +2,8 @@
 
 use super::NextBatchProvider;
 use crate::{
-    errors::ResetError,
-    prelude::{OriginProvider, PipelineError, PipelineErrorKind},
-    traits::{AttributesProvider, OriginAdvancer, SignalReceiver},
+    errors::{PipelineError, PipelineErrorKind, ResetError},
+    traits::{AttributesProvider, OriginAdvancer, OriginProvider, SignalReceiver},
     types::{PipelineResult, ResetSignal, Signal},
 };
 use alloc::{boxed::Box, sync::Arc, vec::Vec};

--- a/crates/protocol/derive/src/stages/channel/channel_assembler.rs
+++ b/crates/protocol/derive/src/stages/channel/channel_assembler.rs
@@ -2,8 +2,8 @@
 
 use super::{ChannelReaderProvider, NextFrameProvider};
 use crate::{
-    prelude::{OriginProvider, PipelineError},
-    traits::{OriginAdvancer, SignalReceiver},
+    errors::PipelineError,
+    traits::{OriginAdvancer, OriginProvider, SignalReceiver},
     types::{PipelineResult, Signal},
 };
 use alloc::{boxed::Box, sync::Arc};
@@ -204,7 +204,7 @@ where
 mod test {
     use super::ChannelAssembler;
     use crate::{
-        prelude::PipelineError,
+        errors::PipelineError,
         stages::ChannelReaderProvider,
         test_utils::{CollectingLayer, TestNextFrameProvider, TraceStorage},
     };

--- a/crates/protocol/derive/src/stages/channel/channel_provider.rs
+++ b/crates/protocol/derive/src/stages/channel/channel_provider.rs
@@ -156,10 +156,10 @@ where
 mod test {
     use super::ChannelProvider;
     use crate::{
-        prelude::{OriginProvider, PipelineError},
+        errors::PipelineError,
         stages::ChannelReaderProvider,
         test_utils::TestNextFrameProvider,
-        traits::SignalReceiver,
+        traits::{OriginProvider, SignalReceiver},
         types::ResetSignal,
     };
     use alloc::{sync::Arc, vec};

--- a/crates/providers/providers-alloy/src/pipeline.rs
+++ b/crates/providers/providers-alloy/src/pipeline.rs
@@ -4,9 +4,9 @@ use crate::{AlloyChainProvider, AlloyL2ChainProvider, OnlineBeaconClient, Online
 use async_trait::async_trait;
 use core::fmt::Debug;
 use kona_derive::{
+    attributes::StatefulAttributesBuilder,
     errors::PipelineErrorKind,
-    pipeline::{DerivationPipeline, PipelineBuilder},
-    prelude::{AttributesQueueStage, StatefulAttributesBuilder},
+    pipeline::{AttributesQueueStage, DerivationPipeline, PipelineBuilder},
     sources::EthereumDataSource,
     traits::{L2ChainProvider, OriginProvider, Pipeline, SignalReceiver},
     types::{PipelineResult, ResetSignal, Signal, StepResult},


### PR DESCRIPTION
### Description

Removes the `kona-derive` prelude. Small cleaning to move towards consistent top-level crate exports.