### PR TITLE
feat(node/p2p): add a shim handler for sync req resp protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4616,6 +4616,7 @@ dependencies = [
  "lazy_static",
  "libp2p",
  "libp2p-identity",
+ "libp2p-stream",
  "metrics",
  "multihash",
  "op-alloy-consensus",
@@ -5339,6 +5340,20 @@ dependencies = [
  "socket2",
  "thiserror 2.0.12",
  "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-stream"
+version = "0.3.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826716f1ee125895f1fb44911413cba023485b552ff96c7a2159bd037ac619bb"
+dependencies = [
+ "futures",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "rand 0.8.5",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,6 +216,7 @@ brotli = { version = "8.0.1", default-features = false }
 snap = "1.1.1"
 discv5 = "0.9.1"
 libp2p = "0.55.0"
+libp2p-stream = "0.3.0-alpha"
 libp2p-identity = "0.2.11"
 openssl = "0.10.73"
 

--- a/crates/node/p2p/Cargo.toml
+++ b/crates/node/p2p/Cargo.toml
@@ -37,6 +37,7 @@ futures.workspace = true
 discv5 = { workspace = true, features = ["libp2p"] }
 libp2p-identity = { workspace = true, features = ["secp256k1"] }
 libp2p = { workspace = true, features = ["macros", "tokio", "tcp", "noise", "gossipsub", "ping", "yamux", "identify"] }
+libp2p-stream = { workspace = true }
 openssl = { workspace = true, features = ["vendored"] }
 
 # Cryptography

--- a/crates/node/p2p/src/gossip/behaviour.rs
+++ b/crates/node/p2p/src/gossip/behaviour.rs
@@ -34,6 +34,10 @@ pub struct Behaviour {
     /// Enables the identify protocol.
     #[debug(skip)]
     pub identify: libp2p::identify::Behaviour,
+    /// Enables the sync request/response protocol.
+    /// See `<https://specs.optimism.io/protocol/rollup-node-p2p.html#payload_by_number>`
+    #[debug(skip)]
+    pub sync_req_resp: libp2p_stream::Behaviour,
 }
 
 impl Behaviour {
@@ -53,6 +57,8 @@ impl Behaviour {
             libp2p::identify::Config::new("".to_string(), public_key)
                 .with_agent_version("optimism".to_string()),
         );
+
+        let sync_req_resp = libp2p_stream::Behaviour::new();
 
         let subscriptions = handlers
             .iter()
@@ -78,7 +84,7 @@ impl Behaviour {
             tracing::info!(target: "gossip", "-> {}", topic);
         }
 
-        Ok(Self { identify, ping, gossipsub })
+        Ok(Self { identify, ping, gossipsub, sync_req_resp })
     }
 }
 

--- a/crates/node/p2p/src/gossip/error.rs
+++ b/crates/node/p2p/src/gossip/error.rs
@@ -53,4 +53,10 @@ pub enum GossipDriverBuilderError {
     /// Missing the rollup config.
     #[error("missing rollup config")]
     MissingRollupConfig,
+    /// An error when setting up the sync request/response protocol.
+    #[error("error setting up sync request/response protocol")]
+    SetupSyncReqRespError,
+    /// The sync request/response protocol has already been accepted.
+    #[error("sync request/response protocol already accepted")]
+    SyncReqRespAlreadyAccepted,
 }

--- a/crates/node/p2p/src/gossip/event.rs
+++ b/crates/node/p2p/src/gossip/event.rs
@@ -12,6 +12,8 @@ pub enum Event {
     Gossipsub(gossipsub::Event),
     /// Represents a [identify::Event]
     Identify(identify::Event),
+    /// Stream event
+    Stream,
 }
 
 impl From<ping::Event> for Event {
@@ -32,6 +34,13 @@ impl From<identify::Event> for Event {
     /// Converts [identify::Event] to [Event]
     fn from(value: identify::Event) -> Self {
         Self::Identify(value)
+    }
+}
+
+impl From<()> for Event {
+    /// Converts () to [Event]
+    fn from(_value: ()) -> Self {
+        Self::Stream
     }
 }
 

--- a/crates/node/p2p/src/net/driver.rs
+++ b/crates/node/p2p/src/net/driver.rs
@@ -1,7 +1,9 @@
 //! Driver for network services.
 
 use alloy_primitives::Address;
+use futures::{AsyncReadExt, AsyncWriteExt, StreamExt};
 use libp2p::TransportError;
+use libp2p_stream::IncomingStreams;
 use op_alloy_rpc_types_engine::OpNetworkPayloadEnvelope;
 use std::collections::HashSet;
 use tokio::{
@@ -57,6 +59,50 @@ impl Network {
         self.unsafe_block_signer_sender.take()
     }
 
+    /// Handles the sync request/response protocol.
+    ///
+    /// This is a mock handler that supports the `payload_by_number` protocol.
+    /// It always returns: not found (1), version (0). `<https://specs.optimism.io/protocol/rollup-node-p2p.html#payload_by_number>`
+    ///
+    /// ## Note
+    ///
+    /// This is used to ensure op-nodes are not penalizing kona-nodes for not supporting it.
+    /// This feature is being deprecated by the op-node team. Once it is fully removed from the
+    /// op-node's implementation we will remove this handler.
+    async fn sync_protocol_handler(mut sync_protocol: IncomingStreams) {
+        loop {
+            let Some((peer_id, mut inbound_stream)) = sync_protocol.next().await else {
+                warn!(target: "node::p2p::sync", "The sync protocol stream has ended");
+                return;
+            };
+
+            info!(target: "node::p2p::sync", "Received a sync request from {peer_id}, spawning a new task to handle it");
+
+            tokio::spawn(async move {
+                let mut buffer = Vec::new();
+                let Ok(bytes_received) = inbound_stream.read_to_end(&mut buffer).await else {
+                    error!(target: "node::p2p::sync", "Failed to read the sync request from {peer_id}");
+                    return;
+                };
+
+                debug!(target: "node::p2p::sync", bytes_received = bytes_received, peer_id = ?peer_id, payload = ?buffer, "Received inbound sync request");
+
+                // We return: not found (1), version (0). `<https://specs.optimism.io/protocol/rollup-node-p2p.html#payload_by_number>`
+                // Response format: <response> = <res><version><payload>
+                // No payload is returned.
+                let output = b"10";
+
+                // We only write that we're not supporting the sync request.
+                if let Err(e) = inbound_stream.write_all(output).await {
+                    error!(target: "node::p2p::sync", err = ?e, "Failed to write the sync response to {peer_id}");
+                    return;
+                };
+
+                debug!(target: "node::p2p::sync", bytes_sent = output.len(), peer_id = ?peer_id, "Sent outbound sync response");
+            });
+        }
+    }
+
     /// Starts the Discv5 peer discovery & libp2p services
     /// and continually listens for new peers and messages to handle
     pub async fn start(mut self) -> Result<(), TransportError<std::io::Error>> {
@@ -72,6 +118,11 @@ impl Network {
 
         // Start the libp2p Swarm
         self.gossip.listen().await?;
+
+        // Start the sync request/response protocol handler.
+        if let Some(sync_protocol) = self.gossip.sync_protocol.take() {
+            tokio::spawn(Self::sync_protocol_handler(sync_protocol));
+        }
 
         // Spawn the network handler
         tokio::spawn(async move {

--- a/crates/node/p2p/src/net/driver.rs
+++ b/crates/node/p2p/src/net/driver.rs
@@ -1,6 +1,6 @@
 //! Driver for network services.
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, hex};
 use futures::{AsyncReadExt, AsyncWriteExt, StreamExt};
 use libp2p::TransportError;
 use libp2p_stream::IncomingStreams;
@@ -90,15 +90,15 @@ impl Network {
                 // We return: not found (1), version (0). `<https://specs.optimism.io/protocol/rollup-node-p2p.html#payload_by_number>`
                 // Response format: <response> = <res><version><payload>
                 // No payload is returned.
-                let output = b"10";
+                const OUTPUT: [u8; 2] = hex!("0100");
 
                 // We only write that we're not supporting the sync request.
-                if let Err(e) = inbound_stream.write_all(output).await {
+                if let Err(e) = inbound_stream.write_all(&OUTPUT).await {
                     error!(target: "node::p2p::sync", err = ?e, "Failed to write the sync response to {peer_id}");
                     return;
                 };
 
-                debug!(target: "node::p2p::sync", bytes_sent = output.len(), peer_id = ?peer_id, "Sent outbound sync response");
+                debug!(target: "node::p2p::sync", bytes_sent = OUTPUT.len(), peer_id = ?peer_id, "Sent outbound sync response");
             });
         }
     }

--- a/crates/node/p2p/tests/common/mod.rs
+++ b/crates/node/p2p/tests/common/mod.rs
@@ -3,7 +3,7 @@
 use alloy_primitives::Address;
 use kona_genesis::RollupConfig;
 use kona_p2p::{Behaviour, BlockHandler, GossipDriver};
-use libp2p::{Multiaddr, SwarmBuilder, identity::Keypair, multiaddr::Protocol};
+use libp2p::{Multiaddr, StreamProtocol, SwarmBuilder, identity::Keypair, multiaddr::Protocol};
 use std::net::Ipv4Addr;
 
 /// Helper function to create a new gossip driver instance.
@@ -28,6 +28,16 @@ pub(crate) fn gossip_driver(port: u16) -> GossipDriver {
     let behaviour = Behaviour::new(keypair.public(), config, &[Box::new(handler.clone())])
         .expect("creates behaviour");
 
+    // Create a sync request/response protocol handler.
+    // We are accepting inbound sync requests to the `payload_by_number` protocol.
+    // Since this is only a mock sync protocol, we are not supporting outbound sync requests.
+    let mut sync_handler = behaviour.sync_req_resp.new_control();
+    let protocol = format!("/opstack/req/payload_by_number/{}/0/", 10);
+    let sync_protocol_name =
+        StreamProtocol::try_from_owned(protocol).expect("error creating sync protocol");
+    let sync_protocol =
+        sync_handler.accept(sync_protocol_name).expect("error accepting sync protocol");
+
     let swarm = SwarmBuilder::with_existing_identity(keypair)
         .with_tokio()
         .with_tcp(
@@ -41,5 +51,5 @@ pub(crate) fn gossip_driver(port: u16) -> GossipDriver {
         .with_swarm_config(|c| c.with_idle_connection_timeout(timeout))
         .build();
 
-    GossipDriver::new(swarm, addr, Some(2), handler)
+    GossipDriver::new(swarm, addr, Some(2), handler, sync_handler, sync_protocol)
 }

--- a/tests/devnets/large-kona.yaml
+++ b/tests/devnets/large-kona.yaml
@@ -7,9 +7,6 @@ optimism_package:
     - participants:
       - el_type: op-geth
         cl_type: op-node
-        cl_extra_env_vars: {
-          "OP_NODE_P2P_SYNC_REQ_RESP": "false"
-        }
         count: 2
       - el_type: op-reth
         cl_type: kona-node

--- a/tests/devnets/simple-kona.yaml
+++ b/tests/devnets/simple-kona.yaml
@@ -9,9 +9,6 @@ optimism_package:
       # So we use op-geth for now.
       - el_type: op-geth
         cl_type: op-node
-        cl_extra_env_vars: {
-          "OP_NODE_P2P_SYNC_REQ_RESP": "false"
-        }
         cl_log_level: "debug"
         count: 1
       - el_type: op-reth


### PR DESCRIPTION
## Description

This PR adds a shim protocol for the sync-req-resp protocol supported by the op-node here https://specs.optimism.io/protocol/rollup-node-p2p.html#payload_by_number. 

This handler will always return the `Not Found` response. This will ensure that `op-nodes` are not penalizing the `kona-nodes` for not supporting it.

We can remove this handler once the `op-node` team phases out support for the `sync-req-resp` protocol.

## Side notes

This PR removes the environment variables in the kurtosis network configuration to disable the `req-resp` protocol. Network appears to remain stable and kona-nodes are not penalized

Closes #2032 and hopefully #1929