### PR TITLE
chore(supervisor): passing l1_provider instead of l1_rpc_url

### DIFF
--- a/bin/supervisor/src/flags/supervisor.rs
+++ b/bin/supervisor/src/flags/supervisor.rs
@@ -152,11 +152,8 @@ impl SupervisorArgs {
         for (i, rpc_url) in self.l2_consensus_nodes.iter().enumerate() {
             let secret = self.l2_consensus_jwt_secret.get(i).unwrap_or(default_secret);
 
-            managed_nodes.push(ManagedNodeConfig {
-                l1_rpc_url: self.l1_rpc.clone(),
-                url: rpc_url.clone(),
-                jwt_path: secret.clone(),
-            });
+            managed_nodes
+                .push(ManagedNodeConfig { url: rpc_url.clone(), jwt_path: secret.clone() });
         }
         Ok(managed_nodes)
     }

--- a/crates/supervisor/core/src/supervisor.rs
+++ b/crates/supervisor/core/src/supervisor.rs
@@ -150,8 +150,9 @@ impl Supervisor {
 
     async fn init_managed_nodes(&mut self) -> Result<(), SupervisorError> {
         for config in self.config.l2_consensus_nodes_config.iter() {
-            let provider =
-                RootProvider::<Ethereum>::new_http(Url::parse(&self.config.l1_rpc).unwrap());
+            let url = Url::parse(&self.config.l1_rpc)
+                .map_err(|e| SupervisorError::Initialise(format!("Invalid L1 RPC URL: {e}")))?;
+            let provider = RootProvider::<Ethereum>::new_http(url);
             let mut managed_node = ManagedNode::<ChainDb>::new(
                 Arc::new(config.clone()),
                 self.cancel_token.clone(),

--- a/crates/supervisor/core/src/supervisor.rs
+++ b/crates/supervisor/core/src/supervisor.rs
@@ -1,7 +1,13 @@
 use core::fmt::Debug;
 
 use alloy_eips::BlockNumHash;
+use alloy_network::Ethereum;
 use alloy_primitives::{B256, ChainId};
+use alloy_provider::{
+    RootProvider,
+    mock::{Asserter, MockTransport},
+};
+use alloy_rpc_client::RpcClient;
 use alloy_rpc_client::RpcClient;
 use async_trait::async_trait;
 use kona_interop::{ExecutingDescriptor, SafetyLevel};
@@ -147,8 +153,15 @@ impl Supervisor {
 
     async fn init_managed_nodes(&mut self) -> Result<(), SupervisorError> {
         for config in self.config.l2_consensus_nodes_config.iter() {
-            let mut managed_node =
-                ManagedNode::<ChainDb>::new(Arc::new(config.clone()), self.cancel_token.clone());
+            let asserter = Asserter::new();
+            let transport = MockTransport::new(asserter.clone());
+            let l1_provider = RootProvider::<Ethereum>::new(RpcClient::new(transport, false));
+
+            let mut managed_node = ManagedNode::<ChainDb>::new(
+                Arc::new(config.clone()),
+                self.cancel_token.clone(),
+                l1_provider,
+            );
 
             let chain_id = managed_node.chain_id().await?;
             let db = self.database_factory.get_db(chain_id)?;

--- a/crates/supervisor/core/src/supervisor.rs
+++ b/crates/supervisor/core/src/supervisor.rs
@@ -12,11 +12,10 @@ use kona_supervisor_storage::{
     ChainDb, ChainDbFactory, DerivationStorageReader, FinalizedL1Storage, HeadRefStorageReader,
 };
 use kona_supervisor_types::SuperHead;
-use op_alloy_rpc_types::error;
 use reqwest::Url;
 use std::{collections::HashMap, sync::Arc};
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn, error};
+use tracing::{error, info, warn};
 
 use crate::{
     ChainProcessor, SupervisorError, config::Config, l1_watcher::L1Watcher, syncnode::ManagedNode,
@@ -151,11 +150,10 @@ impl Supervisor {
 
     async fn init_managed_nodes(&mut self) -> Result<(), SupervisorError> {
         for config in self.config.l2_consensus_nodes_config.iter() {
-            let url = Url::parse(&self.config.l1_rpc)
-                .map_err(|e| {
-                    error!(target: "supervisor_service", %e, "Failed to parse L1 RPC URL");
-                    SupervisorError::Initialise("invalid l1 rpc url".to_string())
-                })?;
+            let url = Url::parse(&self.config.l1_rpc).map_err(|e| {
+                error!(target: "supervisor_service", %e, "Failed to parse L1 RPC URL");
+                SupervisorError::Initialise("invalid l1 rpc url".to_string())
+            })?;
             let provider = RootProvider::<Ethereum>::new_http(url);
             let mut managed_node = ManagedNode::<ChainDb>::new(
                 Arc::new(config.clone()),

--- a/crates/supervisor/core/src/supervisor.rs
+++ b/crates/supervisor/core/src/supervisor.rs
@@ -12,10 +12,11 @@ use kona_supervisor_storage::{
     ChainDb, ChainDbFactory, DerivationStorageReader, FinalizedL1Storage, HeadRefStorageReader,
 };
 use kona_supervisor_types::SuperHead;
+use op_alloy_rpc_types::error;
 use reqwest::Url;
 use std::{collections::HashMap, sync::Arc};
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::{info, warn, error};
 
 use crate::{
     ChainProcessor, SupervisorError, config::Config, l1_watcher::L1Watcher, syncnode::ManagedNode,
@@ -151,7 +152,10 @@ impl Supervisor {
     async fn init_managed_nodes(&mut self) -> Result<(), SupervisorError> {
         for config in self.config.l2_consensus_nodes_config.iter() {
             let url = Url::parse(&self.config.l1_rpc)
-                .map_err(|e| SupervisorError::Initialise(format!("Invalid L1 RPC URL: {e}")))?;
+                .map_err(|e| {
+                    error!(target: "supervisor_service", %e, "Failed to parse L1 RPC URL");
+                    SupervisorError::Initialise("invalid l1 rpc url".to_string())
+                })?;
             let provider = RootProvider::<Ethereum>::new_http(url);
             let mut managed_node = ManagedNode::<ChainDb>::new(
                 Arc::new(config.clone()),

--- a/crates/supervisor/core/src/syncnode/error.rs
+++ b/crates/supervisor/core/src/syncnode/error.rs
@@ -19,6 +19,10 @@ pub enum ManagedNodeError {
     /// Represents an error that occurred while authenticating to the managed node.
     #[error("failed to authenticate: {0}")]
     Authentication(#[from] AuthenticationError),
+
+    /// Represents an error that occured when L1 provider is uninitialized.
+    #[error("L1 provider is not initialized")]
+    L1ProviderUninitialized,
 }
 
 impl PartialEq for ManagedNodeError {

--- a/crates/supervisor/core/src/syncnode/node.rs
+++ b/crates/supervisor/core/src/syncnode/node.rs
@@ -97,7 +97,7 @@ where
             ws_client: Mutex::new(None),
             cancel_token,
             task_handle: Mutex::new(None),
-            l1_provider: l1_provider,
+            l1_provider,
         }
     }
 
@@ -211,7 +211,8 @@ where
         let db_provider =
             self.db_provider.as_ref().ok_or_else(|| SubscriptionError::DatabaseProviderNotFound)?;
         // Creates a task instance to sort and process the events from the subscription
-        let task = ManagedEventTask::new(self.l1_provider.clone(), db_provider.clone(), event_tx, client);
+        let task =
+            ManagedEventTask::new(self.l1_provider.clone(), db_provider.clone(), event_tx, client);
         // Start background task to handle events
         let handle = tokio::spawn(async move {
             info!(target: "managed_node", "Subscription task started");

--- a/crates/supervisor/core/src/syncnode/node.rs
+++ b/crates/supervisor/core/src/syncnode/node.rs
@@ -209,13 +209,13 @@ where
         let db_provider =
             self.db_provider.as_ref().ok_or_else(|| SubscriptionError::DatabaseProviderNotFound)?;
         // Creates a task instance to sort and process the events from the subscription
-        let task = ManagedEventTask::new(
-            self.l1_provider.get().unwrap().clone(),
-            db_provider.clone(),
-            event_tx,
-            client,
-        );
-
+        let l1_provider = self
+            .l1_provider
+            .get()
+            .ok_or_else(|| ManagedNodeError::L1ProviderUninitialized)
+            .unwrap()
+            .clone();
+        let task = ManagedEventTask::new(l1_provider, db_provider.clone(), event_tx, client);
         // Start background task to handle events
         let handle = tokio::spawn(async move {
             info!(target: "managed_node", "Subscription task started");

--- a/crates/supervisor/core/src/syncnode/task.rs
+++ b/crates/supervisor/core/src/syncnode/task.rs
@@ -349,9 +349,11 @@ mod tests {
             replace_block: None,
             derivation_origin_update: None,
         };
-        let provider = RootProvider::<Ethereum>::new_http("http://localhost:8551".parse().unwrap());
 
         let db = Arc::new(MockDb::new());
+        let asserter = Asserter::new();
+        let transport = MockTransport::new(asserter.clone());
+        let provider = RootProvider::<Ethereum>::new(RpcClient::new(transport, false));
         let task = ManagedEventTask::new_for_testing(provider, db, tx);
 
         task.handle_managed_event(Some(managed_event)).await;
@@ -393,7 +395,9 @@ mod tests {
         };
 
         let db = Arc::new(MockDb::new());
-        let provider = RootProvider::<Ethereum>::new_http("http://localhost:8545".parse().unwrap());
+        let asserter = Asserter::new();
+        let transport = MockTransport::new(asserter.clone());
+        let provider = RootProvider::<Ethereum>::new(RpcClient::new(transport, false));
         let task = ManagedEventTask::new_for_testing(provider, db, tx);
 
         task.handle_managed_event(Some(managed_event)).await;
@@ -432,9 +436,11 @@ mod tests {
         };
 
         let db = Arc::new(MockDb::new());
-        let provider = RootProvider::<Ethereum>::new_http("http://localhost:8545".parse().unwrap());
-
+        let asserter = Asserter::new();
+        let transport = MockTransport::new(asserter.clone());
+        let provider = RootProvider::<Ethereum>::new(RpcClient::new(transport, false));
         let task = ManagedEventTask::new_for_testing(provider, db, tx);
+
         task.handle_managed_event(Some(managed_event)).await;
 
         let event = rx.recv().await.expect("Should receive event");
@@ -504,7 +510,7 @@ mod tests {
         let task = ManagedEventTask::new_for_testing(provider, db, tx);
 
         // push the value that we expect on next call
-        asserter.clone().push(MockResponse::Success(serde_json::from_str(next_block).unwrap()));
+        asserter.push(MockResponse::Success(serde_json::from_str(next_block).unwrap()));
 
         let result = task.handle_exhaust_l1(&derived_ref_pair).await;
 

--- a/crates/supervisor/core/src/syncnode/task.rs
+++ b/crates/supervisor/core/src/syncnode/task.rs
@@ -348,7 +348,7 @@ mod tests {
             replace_block: None,
             derivation_origin_update: None,
         };
-        let provider = RootProvider::<Ethereum>::new_http("http://localhost:8545".parse().unwrap());
+        let provider = RootProvider::<Ethereum>::new_http("".parse().unwrap());
 
         let db = Arc::new(MockDb::new());
         let task = ManagedEventTask::new_for_testing(provider, db, tx);


### PR DESCRIPTION
Potentially fixes #2028 

Introduced `l1_provider` in ManageNode and ManagedEventTask and passed it to start_subscription and in the implementations for ManagedEventTask