### PR TITLE
feat(node/p2p): improve dial metric granularity

### DIFF
--- a/crates/node/p2p/src/metrics/mod.rs
+++ b/crates/node/p2p/src/metrics/mod.rs
@@ -23,6 +23,9 @@ impl Metrics {
     /// Identifier for the gauge that tracks the number of dialed peers.
     pub const DIAL_PEER: &str = "kona_node_dial_peer";
 
+    /// Identifier for the gauge that tracks the number of errors when dialing peers.
+    pub const DIAL_PEER_ERROR: &str = "kona_node_dial_peer_error";
+
     /// Identifier for discv5 events.
     pub const DISCOVERY_EVENT: &str = "kona_node_discovery_events";
 
@@ -136,6 +139,7 @@ impl Metrics {
 
         // Peer dials
         kona_macros::set!(gauge, Self::DIAL_PEER, 0);
+        kona_macros::set!(gauge, Self::DIAL_PEER_ERROR, 0);
 
         // Unsafe Blocks
         kona_macros::set!(gauge, Self::UNSAFE_BLOCK_PUBLISHED, 0);

--- a/crates/node/p2p/src/net/driver.rs
+++ b/crates/node/p2p/src/net/driver.rs
@@ -160,7 +160,6 @@ impl Network {
                             return;
                         };
                         self.gossip.dial(enr);
-                        kona_macros::inc!(gauge, crate::Metrics::DIAL_PEER);
                     },
 
                     _ = peer_score_inspector.tick(), if self.gossip.peer_monitoring.as_ref().is_some() => {


### PR DESCRIPTION
## Description

This PR improve the granularity of the `DIAL_PEER` metric by making sure we only increase the gauge when a peer is actually dialed. If that's not the case we emit the `DIAL_PEER_ERROR` metric