### PR TITLE
chore(tests): Add `kona-node` + `op-geth` config

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -7,10 +7,13 @@ on:
 env:
   CARGO_TERM_COLOR: always
 jobs:
-  simple-e2e-tests:
+  node-e2e-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    name: simple-e2e-tests
+    name: ${{ matrix.devnet-config }}-tests
+    strategy:
+      matrix:
+        devnet-config: ["simple-kona", "simple-kona-geth", "large-kona"]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -27,27 +30,5 @@ jobs:
           # Semantic version range syntax or exact version of Go
           go-version: '1.24.3'
       - uses: jdx/mise-action@v2       # installs Mise + runs `mise install`
-      - name: test with simple-kona devnet
-        run: just build-devnet-and-test-e2e simple-kona node
-  large-e2e-tests:
-    runs-on: ubuntu-latest
-    timeout-minutes: 40
-    name: large-e2e-tests
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          large-packages: false
-      - uses: taiki-e/install-action@just
-      - name: Setup Go 1.24.3
-        uses: actions/setup-go@v5
-        with:
-          # Semantic version range syntax or exact version of Go
-          go-version: '1.24.3'
-      - uses: jdx/mise-action@v2       # installs Mise + runs `mise install`
-      - name: test with large-kona devnet
-        run: just build-devnet-and-test-e2e large-kona node
+      - name: test with ${{ matrix.devnet-config }} devnet
+        run: just build-devnet-and-test-e2e "${{ matrix.devnet-config }}" node

--- a/tests/devnets/simple-kona-geth.yaml
+++ b/tests/devnets/simple-kona-geth.yaml
@@ -1,5 +1,5 @@
 # A simple network configuration for kurtosis (https://github.com/ethpandaops/optimism-package)
-# Spins up a 2 EL/CL networks. One with op-geth/op-node and one with op-reth/kona-node.
+# Spins up a 2 EL/CL networks. One with op-geth/op-node and one with op-geth/kona-node.
 
 optimism_package:
   chains:
@@ -11,7 +11,7 @@ optimism_package:
         cl_type: op-node
         cl_log_level: "debug"
         count: 1
-      - el_type: op-reth
+      - el_type: op-geth
         cl_type: kona-node
         # Note: we use the local image for now. This allows us to run the tests in CI pipelines without publishing new docker images every time.
         cl_image: "kona-node:local"


### PR DESCRIPTION
## Overview

Adds a `kona-node` + `op-geth` devnet config and runs the e2e tests against this config in CI.