### PR TITLE
feat(ci): improve caching of e2e jobs

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -23,26 +23,23 @@ jobs:
         uses: jlumbroso/free-disk-space@main
         with:
           large-packages: false
+
       - uses: taiki-e/install-action@just
+
+      - uses: jdx/mise-action@v2       # installs Mise + runs `mise install`
+
       - name: Setup Go 1.24.3
         uses: actions/setup-go@v5
         with:
           # Semantic version range syntax or exact version of Go
           go-version: '1.24.3'
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-            - name: Set up Docker Buildx
+          cache-dependency-path: "**/go.sum"
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Cache Docker layers
-        uses: actions/cache@v4
+      - name: Restore Docker cache
+        uses: actions/cache/restore@v4
         with:
           path: ${{ runner.temp }}/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -68,8 +65,6 @@ jobs:
             *.cache-from=type=local,src=${{ runner.temp }}/.buildx-cache
             *.cache-to=type=local,dest=${{ runner.temp }}/.buildx-cache-new,mode=max
 
-      - uses: jdx/mise-action@v2       # installs Mise + runs `mise install`
-
       - name: test with ${{ matrix.devnet-config }} devnet
         run: just deploy-devnet-and-test-e2e "${{ matrix.devnet-config }}" node
 
@@ -80,3 +75,10 @@ jobs:
         run: |
           rm -rf ${{ runner.temp }}/.buildx-cache
           mv ${{ runner.temp }}/.buildx-cache-new ${{ runner.temp }}/.buildx-cache
+
+      - name: Save docker cache
+        uses: actions/cache/save@v4
+        if: github.ref == 'refs/heads/main'
+        with:
+          path: ${{ runner.temp }}/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -29,6 +29,54 @@ jobs:
         with:
           # Semantic version range syntax or exact version of Go
           go-version: '1.24.3'
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+            - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build kona node docker image
+        uses: docker/bake-action@v6
+        env:
+          BIN_TARGET: kona-node
+          BUILD_PROFILE: release
+          REPO_LOCATION: local
+          PLATFORMS: linux/${{ runner.arch == 'X64' && 'amd64' || runner.arch == 'ARM64' && 'arm64' || runner.arch }}
+        with:
+          files: |
+            ./docker/docker-bake.hcl
+          load: true
+          context: .
+          targets: |
+            generic
+          set: |
+            *.tags=kona-node:local
+            *.cache-from=type=local,src=${{ runner.temp }}/.buildx-cache
+            *.cache-to=type=local,dest=${{ runner.temp }}/.buildx-cache-new,mode=max
+
       - uses: jdx/mise-action@v2       # installs Mise + runs `mise install`
+
       - name: test with ${{ matrix.devnet-config }} devnet
-        run: just build-devnet-and-test-e2e "${{ matrix.devnet-config }}" node
+        run: just deploy-devnet-and-test-e2e "${{ matrix.devnet-config }}" node
+
+      - # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf ${{ runner.temp }}/.buildx-cache
+          mv ${{ runner.temp }}/.buildx-cache-new ${{ runner.temp }}/.buildx-cache

--- a/tests/justfile
+++ b/tests/justfile
@@ -60,12 +60,16 @@ build-deploy-devnet DEVNET BINARY OP_PACKAGE_PATH="": (build-devnet BINARY)
     export DEVNET_PATH="{{SOURCE}}/devnets/{{DEVNET}}.yaml"
 
     just devnet $DEVNET_PATH {{DEVNET}} {{OP_PACKAGE_PATH}}
-
-build-devnet-and-test-e2e DEVNET BINARY OP_PACKAGE_PATH="": (build-deploy-devnet DEVNET BINARY OP_PACKAGE_PATH)
+  
+deploy-devnet-and-test-e2e DEVNET BINARY OP_PACKAGE_PATH="": 
     #!/bin/bash
     export DEVNET_PATH="{{SOURCE}}/devnets/{{DEVNET}}.yaml"
 
+    just devnet $DEVNET_PATH {{DEVNET}} {{OP_PACKAGE_PATH}}
+
     just test-e2e "ktnative://{{DEVNET}}$DEVNET_PATH" "{{BINARY}}"
+
+build-devnet-and-test-e2e DEVNET BINARY OP_PACKAGE_PATH="": (build-devnet BINARY) (deploy-devnet-and-test-e2e DEVNET BINARY OP_PACKAGE_PATH)
 
 # Updates the devnet with the latest local changes. This is useful to
 # rapidly iterate on the devnet without having to redeploy the whole kurtosis network.


### PR DESCRIPTION
## Description

This PR aggressively caches the docker/go dependencies for e2e tests in CI. This allows to take advantage of `cargo-chef`. This seems to considerably improve CI runtimes if we're not updating the dependencies in rust/go.

Locally tested, works like a charm