### PR TITLE
fix(p2p): Peer Blacklisting

### DIFF
--- a/crates/node/p2p/src/rpc/request.rs
+++ b/crates/node/p2p/src/rpc/request.rs
@@ -142,10 +142,12 @@ impl P2pRpcRequest {
 
     fn block_peer<G: ConnectionGate>(id: PeerId, gossip: &mut GossipDriver<G>) {
         gossip.connection_gate.block_peer(&id);
+        gossip.swarm.behaviour_mut().gossipsub.blacklist_peer(&id);
     }
 
     fn unblock_peer<G: ConnectionGate>(id: PeerId, gossip: &mut GossipDriver<G>) {
         gossip.connection_gate.unblock_peer(&id);
+        gossip.swarm.behaviour_mut().gossipsub.remove_blacklisted_peer(&id);
     }
 
     fn list_blocked_peers<G: ConnectionGate>(s: Sender<Vec<PeerId>>, gossip: &GossipDriver<G>) {


### PR DESCRIPTION
### Description

Properly blacklist peers when they are blocked via libp2p's gossipsub behaviour.
Also removes them from the blacklist when they are unblocked.