### PR TITLE
feat (supervisor/rpc): implemented `crossDerivedToSource` RPC method

### DIFF
--- a/crates/supervisor/core/src/rpc/server.rs
+++ b/crates/supervisor/core/src/rpc/server.rs
@@ -38,6 +38,33 @@ impl<T> SupervisorApiServer for SupervisorRpc<T>
 where
     T: SupervisorService + 'static,
 {
+    async fn cross_derived_to_source(
+        &self,
+        chain_id: ChainId,
+        derived: BlockNumHash,
+    ) -> RpcResult<BlockInfo> {
+        trace!(
+            target: "supervisor_rpc",
+            %chain_id,
+            ?derived,
+            "Received cross_derived_to_source request"
+        );
+
+        let source_block =
+            self.supervisor.derived_to_source_block(chain_id, derived).map_err(|err| {
+                warn!(
+                    target: "supervisor_rpc",
+                    %chain_id,
+                    ?derived,
+                    %err,
+                    "Failed to get source block for derived block"
+                );
+                ErrorObject::from(err)
+            })?;
+
+        Ok(source_block)
+    }
+
     async fn local_unsafe(&self, chain_id: ChainId) -> RpcResult<BlockNumHash> {
         trace!(target: "supervisor_rpc",
             %chain_id,

--- a/crates/supervisor/core/src/supervisor.rs
+++ b/crates/supervisor/core/src/supervisor.rs
@@ -90,6 +90,14 @@ pub trait SupervisorService: Debug + Send + Sync {
         chain: ChainId,
     ) -> Result<BlockInfo, SupervisorError>;
 
+    /// Returns the L1 source block that the given L2 derived block was based on, for the specified
+    /// chain.
+    fn derived_to_source_block(
+        &self,
+        chain: ChainId,
+        derived: BlockNumHash,
+    ) -> Result<BlockInfo, SupervisorError>;
+
     /// Returns the
     /// Verifies if an access-list references only valid messages
     async fn check_access_list(
@@ -212,6 +220,14 @@ impl SupervisorService for Supervisor {
         chain: ChainId,
     ) -> Result<BlockInfo, SupervisorError> {
         Ok(self.database_factory.get_db(chain)?.latest_derived_block_at_source(l1_block)?)
+    }
+
+    fn derived_to_source_block(
+        &self,
+        chain: ChainId,
+        derived: BlockNumHash,
+    ) -> Result<BlockInfo, SupervisorError> {
+        Ok(self.database_factory.get_db(chain)?.derived_to_source(derived)?)
     }
 
     async fn check_access_list(

--- a/crates/supervisor/rpc/src/jsonrpsee.rs
+++ b/crates/supervisor/rpc/src/jsonrpsee.rs
@@ -25,6 +25,14 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "supervisor"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "supervisor"))]
 pub trait SupervisorApi {
+    /// Gets the source block for a given derived block
+    #[method(name = "crossDerivedToSource")]
+    async fn cross_derived_to_source(
+        &self,
+        chain_id: ChainId,
+        block_id: BlockNumHash,
+    ) -> RpcResult<BlockInfo>;
+
     /// Gets the localUnsafe BlockId
     #[method(name = "localUnsafe")]
     async fn local_unsafe(&self, chain_id: ChainId) -> RpcResult<BlockNumHash>;


### PR DESCRIPTION
Closes #1721 