### PR TITLE
chore(ci): Don't fail fast on E2E matrix

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -12,6 +12,7 @@ jobs:
     timeout-minutes: 40
     name: ${{ matrix.devnet-config }}-tests
     strategy:
+      fail-fast: false
       matrix:
         devnet-config: ["simple-kona", "simple-kona-geth", "large-kona"]
     steps:


### PR DESCRIPTION
## Overview

Adjusts the E2E test matrix to not fail fast. Since we're seeing flakes on the large config, we don't want that to prevent the simple configs from executing.