### PR TITLE
chore(node/p2p): Enable peer monitoring if configured

### DIFF
--- a/bin/node/src/flags/p2p.rs
+++ b/bin/node/src/flags/p2p.rs
@@ -358,14 +358,10 @@ impl P2PArgs {
             .build()?;
         let block_time = config.block_time;
 
-        let monitor_peers = if self.ban_enabled {
-            Some(PeerMonitoring {
-                ban_duration: Duration::from_secs(60 * self.ban_duration),
-                ban_threshold: self.ban_threshold as f64,
-            })
-        } else {
-            None
-        };
+        let monitor_peers = self.ban_enabled.then_some(PeerMonitoring {
+            ban_duration: Duration::from_secs(60 * self.ban_duration),
+            ban_threshold: self.ban_threshold as f64,
+        });
 
         let discovery_listening_address = SocketAddr::new(self.listen_ip, self.listen_udp_port);
         let discovery_config = self.discv5_config(discovery_listening_address.into(), static_ip);

--- a/crates/node/p2p/src/net/builder.rs
+++ b/crates/node/p2p/src/net/builder.rs
@@ -43,6 +43,7 @@ impl From<Config> for NetworkBuilder {
             .with_unsafe_block_signer(config.unsafe_block_signer)
             .with_gossip_config(config.gossip_config)
             .with_peer_scoring(config.scoring)
+            .with_peer_monitoring(config.monitor_peers)
             .with_block_time(config.block_time)
             .with_keypair(config.keypair)
             .with_topic_scoring(config.topic_scoring)


### PR DESCRIPTION
## Overview

Allows for peer monitoring to be enabled, if it is configured.