### PR TITLE
chore(node): Standardize envvars

### DIFF
--- a/bin/node/src/commands/node.rs
+++ b/bin/node/src/commands/node.rs
@@ -28,20 +28,20 @@ use url::Url;
 #[command(about = "Runs the consensus node")]
 pub struct NodeCommand {
     /// URL of the L1 execution client RPC API.
-    #[arg(long, visible_alias = "l1", env = "L1_ETH_RPC")]
+    #[arg(long, visible_alias = "l1", env = "KONA_NODE_L1_ETH_RPC")]
     pub l1_eth_rpc: Url,
     /// URL of the L1 beacon API.
-    #[arg(long, visible_alias = "l1.beacon", env = "L1_BEACON")]
+    #[arg(long, visible_alias = "l1.beacon", env = "KONA_NODE_L1_BEACON")]
     pub l1_beacon: Url,
     /// URL of the engine API endpoint of an L2 execution client.
-    #[arg(long, visible_alias = "l2", env = "L2_ENGINE_RPC")]
+    #[arg(long, visible_alias = "l2", env = "KONA_NODE_L2_ENGINE_RPC")]
     pub l2_engine_rpc: Url,
     /// An L2 RPC Url.
-    #[arg(long, visible_alias = "l2.provider", env = "L2_ETH_RPC")]
+    #[arg(long, visible_alias = "l2.provider", env = "KONA_NODE_L2_ETH_RPC")]
     pub l2_provider_rpc: Url,
     /// JWT secret for the auth-rpc endpoint of the execution client.
     /// This MUST be a valid path to a file containing the hex-encoded JWT secret.
-    #[arg(long, visible_alias = "l2.jwt-secret", env = "L2_ENGINE_AUTH")]
+    #[arg(long, visible_alias = "l2.jwt-secret", env = "KONA_NODE_L2_ENGINE_AUTH")]
     pub l2_engine_jwt_secret: Option<PathBuf>,
     /// Path to a custom L2 rollup configuration file
     /// (overrides the default rollup configuration from the registry)
@@ -52,7 +52,7 @@ pub struct NodeCommand {
         long,
         visible_alias = "l2.enginekind",
         default_value = "geth",
-        env = "L2_ENGINE_KIND",
+        env = "KONA_NODE_L2_ENGINE_KIND",
         help = "DEPRECATED. The kind of engine client, used to control the behavior of optimism in respect to different types of engine clients. Supported engine clients are: [\"geth\", \"reth\", \"erigon\"]."
     )]
     pub l2_engine_kind: EngineKind,
@@ -63,7 +63,7 @@ pub struct NodeCommand {
         long,
         visible_alias = "l1.runtime-config-reload-interval",
         default_value = "600", // 10 minutes in seconds
-        env = "L1_RUNTIME_CONFIG_RELOAD_INTERVAL",
+        env = "KONA_NODE_L1_RUNTIME_CONFIG_RELOAD_INTERVAL",
     )]
     pub l1_runtime_config_reload_interval: u64,
     /// P2P CLI arguments.

--- a/bin/node/src/flags/sequencer.rs
+++ b/bin/node/src/flags/sequencer.rs
@@ -11,12 +11,20 @@ use clap::Parser;
 pub struct SequencerArgs {
     /// Enable sequencing of new L2 blocks. A separate batch submitter has to be deployed to
     /// publish the data for verifiers.
-    #[arg(long = "sequencer.enabled", default_value = "false", env = "KONA_SEQUENCER_ENABLED")]
+    #[arg(
+        long = "sequencer.enabled",
+        default_value = "false",
+        env = "KONA_NODE_SEQUENCER_ENABLED"
+    )]
     pub enabled: bool,
 
     /// Initialize the sequencer in a stopped state. The sequencer can be started using the
     /// admin_startSequencer RPC.
-    #[arg(long = "sequencer.stopped", default_value = "false", env = "KONA_SEQUENCER_STOPPED")]
+    #[arg(
+        long = "sequencer.stopped",
+        default_value = "false",
+        env = "KONA_NODE_SEQUENCER_STOPPED"
+    )]
     pub stopped: bool,
 
     /// Maximum number of L2 blocks for restricting the distance between L2 safe and unsafe.
@@ -24,17 +32,21 @@ pub struct SequencerArgs {
     #[arg(
         long = "sequencer.max-safe-lag",
         default_value = "0",
-        env = "KONA_SEQUENCER_MAX_SAFE_LAG"
+        env = "KONA_NODE_SEQUENCER_MAX_SAFE_LAG"
     )]
     pub max_safe_lag: u64,
 
     /// Number of L1 blocks to keep distance from the L1 head as a sequencer for picking an L1
     /// origin.
-    #[arg(long = "sequencer.l1-confs", default_value = "4", env = "KONA_SEQUENCER_L1_CONFS")]
+    #[arg(long = "sequencer.l1-confs", default_value = "4", env = "KONA_NODE_SEQUENCER_L1_CONFS")]
     pub l1_confs: u64,
 
     /// Forces the sequencer to strictly prepare the next L1 origin and create empty L2 blocks
-    #[arg(long = "sequencer.recover", default_value = "false", env = "KONA_SSEQUENCER_RECOVER")]
+    #[arg(
+        long = "sequencer.recover",
+        default_value = "false",
+        env = "KONA_NODE_SSEQUENCER_RECOVER"
+    )]
     pub recover: bool,
 }
 

--- a/crates/utilities/cli/src/metrics_args.rs
+++ b/crates/utilities/cli/src/metrics_args.rs
@@ -14,16 +14,21 @@ pub struct MetricsArgs {
         long = "metrics.enabled",
         global = true,
         default_value_t = false,
-        env = "METRICS_ENABLED"
+        env = "KONA_METRICS_ENABLED"
     )]
     pub enabled: bool,
 
     /// The port to serve Prometheus metrics on.
-    #[arg(long = "metrics.port", global = true, default_value = "9090", env = "METRICS_PORT")]
+    #[arg(long = "metrics.port", global = true, default_value = "9090", env = "KONA_METRICS_PORT")]
     pub port: u16,
 
     /// The IP address to use for Prometheus metrics.
-    #[arg(long = "metrics.addr", global = true, default_value = "0.0.0.0", env = "METRICS_ADDR")]
+    #[arg(
+        long = "metrics.addr",
+        global = true,
+        default_value = "0.0.0.0",
+        env = "KONA_METRICS_ADDR"
+    )]
     pub addr: IpAddr,
 }
 


### PR DESCRIPTION
## Overview

Standardizes the envvar prefix for all kona-node CLI options.

Also adds the `KONA_` prefix for the global metrics args.