### PR TITLE
feat(node/p2p): record peer score distribution metrics

### DIFF
--- a/crates/node/p2p/src/net/driver.rs
+++ b/crates/node/p2p/src/net/driver.rs
@@ -179,7 +179,7 @@ impl Network {
                                 let score = self.gossip.swarm.behaviour().gossipsub.peer_score(peer_id).unwrap_or_default();
 
                                 // Record the peer score in the metrics.
-                                kona_macros::record!(histogram, crate::Metrics::PEER_SCORES, score);
+                                kona_macros::record!(histogram, crate::Metrics::PEER_SCORES, "peer", peer_id.to_string(), score);
 
                                 if score < ban_peers.ban_threshold {
                                    return Some(*peer_id);


### PR DESCRIPTION
## Description

- Record the p2p score distribution for a given peer at a more frequent period (during pings and connection drops)