### PR TITLE
chore(rpc): Cleanup IpNet TODOs

### DIFF
--- a/crates/node/rpc/src/jsonrpsee.rs
+++ b/crates/node/rpc/src/jsonrpsee.rs
@@ -4,6 +4,7 @@ use crate::{OutputResponse, SafeHeadResponse};
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::B256;
 use core::net::IpAddr;
+use ipnet::IpNet;
 use jsonrpsee::{
     core::{RpcResult, SubscriptionResult},
     proc_macros::rpc,
@@ -100,20 +101,17 @@ pub trait OpP2PApi {
     #[method(name = "listBlockedAddrs")]
     async fn opp2p_list_blocked_addrs(&self) -> RpcResult<Vec<IpAddr>>;
 
-    // TODO: should be IPNet?
     /// Blocks the given subnet
     #[method(name = "blockSubnet")]
-    async fn opp2p_block_subnet(&self, subnet: String) -> RpcResult<()>;
+    async fn opp2p_block_subnet(&self, subnet: IpNet) -> RpcResult<()>;
 
-    // TODO: should be IPNet?
     /// Unblocks the given subnet
     #[method(name = "unblockSubnet")]
-    async fn opp2p_unblock_subnet(&self, subnet: String) -> RpcResult<()>;
+    async fn opp2p_unblock_subnet(&self, subnet: IpNet) -> RpcResult<()>;
 
-    // TODO: should be IPNet?
     /// Lists blocked subnets
     #[method(name = "listBlockedSubnets")]
-    async fn opp2p_list_blocked_subnets(&self) -> RpcResult<Vec<String>>;
+    async fn opp2p_list_blocked_subnets(&self) -> RpcResult<Vec<IpNet>>;
 
     /// Protects the given peer
     #[method(name = "protectPeer")]

--- a/crates/node/rpc/src/p2p.rs
+++ b/crates/node/rpc/src/p2p.rs
@@ -139,37 +139,24 @@ impl OpP2PApiServer for NetworkRpc {
         rx.await.map_err(|_| ErrorObject::from(ErrorCode::InternalError))
     }
 
-    async fn opp2p_block_subnet(&self, subnet: String) -> RpcResult<()> {
+    async fn opp2p_block_subnet(&self, subnet: IpNet) -> RpcResult<()> {
         kona_macros::inc!(gauge, kona_p2p::Metrics::RPC_CALLS, "method" => "opp2p_blockSubnet");
-
-        let subnet_id = match subnet.parse::<IpNet>() {
-            Ok(net) => net,
-            Err(_) => {
-                return Err(ErrorObject::from(ErrorCode::ParseError));
-            }
-        };
         self.sender
-            .send(P2pRpcRequest::BlockSubnet { address: subnet_id })
+            .send(P2pRpcRequest::BlockSubnet { address: subnet })
             .await
             .map_err(|_| ErrorObject::from(ErrorCode::InternalError))
     }
 
-    async fn opp2p_unblock_subnet(&self, subnet: String) -> RpcResult<()> {
+    async fn opp2p_unblock_subnet(&self, subnet: IpNet) -> RpcResult<()> {
         kona_macros::inc!(gauge, kona_p2p::Metrics::RPC_CALLS, "method" => "opp2p_unblockSubnet");
 
-        let subnet_id = match subnet.parse::<IpNet>() {
-            Ok(net) => net,
-            Err(_) => {
-                return Err(ErrorObject::from(ErrorCode::ParseError));
-            }
-        };
         self.sender
-            .send(P2pRpcRequest::UnblockSubnet { address: subnet_id })
+            .send(P2pRpcRequest::UnblockSubnet { address: subnet })
             .await
             .map_err(|_| ErrorObject::from(ErrorCode::InternalError))
     }
 
-    async fn opp2p_list_blocked_subnets(&self) -> RpcResult<Vec<String>> {
+    async fn opp2p_list_blocked_subnets(&self) -> RpcResult<Vec<IpNet>> {
         kona_macros::inc!(
             gauge,
             kona_p2p::Metrics::RPC_CALLS,
@@ -181,9 +168,7 @@ impl OpP2PApiServer for NetworkRpc {
             .await
             .map_err(|_| ErrorObject::from(ErrorCode::InternalError))?;
 
-        rx.await
-            .map(|s| s.iter().map(|s| s.to_string()).collect::<Vec<String>>())
-            .map_err(|_| ErrorObject::from(ErrorCode::InternalError))
+        rx.await.map_err(|_| ErrorObject::from(ErrorCode::InternalError))
     }
 
     async fn opp2p_protect_peer(&self, id: String) -> RpcResult<()> {


### PR DESCRIPTION
### Description

Small PR to remove the `IpNet` todo comments + `String` fields since `IpNet` can be serialized.