### PR TITLE
fix(node/p2p): fix opp2p_peers rpc handler. Only return total peer score

### DIFF
--- a/crates/node/p2p/README.md
+++ b/crates/node/p2p/README.md
@@ -51,6 +51,12 @@ async fn main() {
 
 [!WARNING]: ###example
 
+### Technical note:
+
+Contrarily to the `op-node`, `kona-node`s don't manually track peer scores. For simplicity, we're relying on the peer score computed by `rust-libp2p`. Since this library doesn't expose all the factors used to compute the peer score (like per topic scores, or the ip-collocation-factor), we're only exposing the total peer score.
+
+See `<https://github.com/libp2p/rust-libp2p/issues/6058>`
+
 ### Acknowledgements
 
 Largely based off [magi]'s [p2p module][p2p].


### PR DESCRIPTION
## Description

This PR amends some of the changes from #2118 to only serve the total peer score inside `opp2p_peers`, as this is the only field supported by `rust_libp2p` as of now. 

See https://github.com/libp2p/rust-libp2p/issues/6058