### PR TITLE
chore(node/cli): fix todos

### DIFF
--- a/crates/node/p2p/src/gossip/driver.rs
+++ b/crates/node/p2p/src/gossip/driver.rs
@@ -39,7 +39,11 @@ pub struct GossipDriver<G: ConnectionGate> {
     #[debug(skip)]
     pub sync_handler: libp2p_stream::Control,
     /// The inbound streams for the sync request/response protocol.
-    /// Set to `None` if the sync request/response protocol is not enabled.
+    ///
+    /// This is an option to allow to take the underlying value when the gossip driver gets
+    /// activated.
+    ///
+    /// TODO(@theochap, `<https://github.com/op-rs/kona/issues/2141>`): remove the sync-req-resp protocol once the `op-node` phases it out.
     #[debug(skip)]
     pub sync_protocol: Option<IncomingStreams>,
     /// A mapping from [`PeerId`] to [`Multiaddr`].
@@ -86,7 +90,6 @@ where
             peer_monitoring: None,
             peer_connection_start: Default::default(),
             sync_handler,
-            // TODO(@theochap): make this field truly optional (through CLI args).
             sync_protocol: Some(sync_protocol),
             connection_gate: gate,
             ping: Arc::new(Mutex::new(Default::default())),

--- a/crates/node/p2p/src/gossip/mod.rs
+++ b/crates/node/p2p/src/gossip/mod.rs
@@ -18,6 +18,7 @@ mod gater;
 pub use gater::{
     ConnectionGater, // implementation
     DialInfo,
+    GaterConfig,
 };
 
 mod builder;

--- a/crates/node/p2p/src/lib.rs
+++ b/crates/node/p2p/src/lib.rs
@@ -26,7 +26,7 @@ mod gossip;
 pub use gossip::{
     Behaviour, BehaviourError, BlockHandler, BlockInvalidError, ConnectionGate, ConnectionGater,
     DEFAULT_MESH_D, DEFAULT_MESH_DHI, DEFAULT_MESH_DLAZY, DEFAULT_MESH_DLO, DialInfo, Event,
-    GLOBAL_VALIDATE_THROTTLE, GOSSIP_HEARTBEAT, GossipDriver, GossipDriverBuilder,
+    GLOBAL_VALIDATE_THROTTLE, GOSSIP_HEARTBEAT, GaterConfig, GossipDriver, GossipDriverBuilder,
     GossipDriverBuilderError, Handler, HandlerEncodeError, MAX_GOSSIP_SIZE, MAX_OUTBOUND_QUEUE,
     MAX_VALIDATE_QUEUE, MIN_GOSSIP_SIZE, PEER_SCORE_INSPECT_FREQUENCY, PublishError,
     SEEN_MESSAGES_TTL, default_config, default_config_builder,

--- a/crates/node/p2p/src/net/builder.rs
+++ b/crates/node/p2p/src/net/builder.rs
@@ -11,7 +11,7 @@ use tokio::sync::broadcast::Sender as BroadcastSender;
 
 use crate::{
     Broadcast, Config, Discv5Builder, GossipDriverBuilder, Network, NetworkBuilderError,
-    P2pRpcRequest, discv5::LocalNode,
+    P2pRpcRequest, discv5::LocalNode, gossip::GaterConfig,
 };
 
 /// Constructs a [`Network`] for the OP Stack Consensus Layer.
@@ -48,7 +48,7 @@ impl From<Config> for NetworkBuilder {
             .with_block_time(config.block_time)
             .with_keypair(config.keypair)
             .with_topic_scoring(config.topic_scoring)
-            .with_peer_redial(config.redial)
+            .with_gater_config(config.gater_config)
     }
 }
 
@@ -65,9 +65,9 @@ impl NetworkBuilder {
         }
     }
 
-    /// Sets the number of times to redial a peer.
-    pub fn with_peer_redial(self, redial: Option<u64>) -> Self {
-        Self { gossip: self.gossip.with_peer_redial(redial), ..self }
+    /// Sets the configuration for the connection gater.
+    pub fn with_gater_config(self, config: GaterConfig) -> Self {
+        Self { gossip: self.gossip.with_gater_config(config), ..self }
     }
 
     /// Sets the bootstore path for the [`crate::Discv5Driver`].

--- a/crates/node/p2p/src/net/config.rs
+++ b/crates/node/p2p/src/net/config.rs
@@ -1,6 +1,6 @@
 //! Configuration for the `Network`.
 
-use crate::discv5::LocalNode;
+use crate::{discv5::LocalNode, gossip::GaterConfig};
 use alloy_primitives::Address;
 use discv5::Enr;
 use kona_genesis::RollupConfig;
@@ -39,8 +39,8 @@ pub struct Config {
     pub block_time: u64,
     /// An optional path to the bootstore.
     pub bootstore: Option<PathBuf>,
-    /// The optional number of times to redial a peer.
-    pub redial: Option<u64>,
+    /// The configuration for the connection gater.
+    pub gater_config: GaterConfig,
     /// An optional list of bootnode ENRs to start the node with.
     pub bootnodes: Vec<Enr>,
     /// The [`RollupConfig`].

--- a/crates/node/p2p/tests/common/mod.rs
+++ b/crates/node/p2p/tests/common/mod.rs
@@ -2,9 +2,9 @@
 
 use alloy_primitives::Address;
 use kona_genesis::RollupConfig;
-use kona_p2p::{Behaviour, BlockHandler, ConnectionGater, GossipDriver};
+use kona_p2p::{Behaviour, BlockHandler, ConnectionGater, GaterConfig, GossipDriver};
 use libp2p::{Multiaddr, StreamProtocol, SwarmBuilder, identity::Keypair, multiaddr::Protocol};
-use std::net::Ipv4Addr;
+use std::{net::Ipv4Addr, time::Duration};
 
 /// Helper function to create a new gossip driver instance.
 pub(crate) fn gossip_driver(port: u16) -> GossipDriver<ConnectionGater> {
@@ -51,6 +51,10 @@ pub(crate) fn gossip_driver(port: u16) -> GossipDriver<ConnectionGater> {
         .with_swarm_config(|c| c.with_idle_connection_timeout(timeout))
         .build();
 
-    let gate = ConnectionGater::new(Some(2)); // Allow redialing peers twice.
+    let gate = ConnectionGater::new(GaterConfig {
+        peer_redialing: Some(2),
+        dial_period: Duration::from_secs(60 * 60),
+    });
+
     GossipDriver::new(swarm, addr, handler, sync_handler, sync_protocol, gate)
 }


### PR DESCRIPTION
## Description

This PR fixes some of the outstanding todos in kona's codebase. In particular:

- Promotes the dial period to CLI argument for p2p. Also does a small refactor to the way the connection gater is configured
- Open an issue to phase out the `sync-req-resp` optimism protocol #2141. Removed the todo to promote the configuration to CLI since the node would not sync properly if the flag is not set, and this protocol will eventually get phased out.

Progress towards #2119