### PR TITLE
feat(supervisor/core): finalized l1 process handling

### DIFF
--- a/crates/supervisor/core/src/chain_processor/chain.rs
+++ b/crates/supervisor/core/src/chain_processor/chain.rs
@@ -11,7 +11,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
 /// Responsible for managing [`ManagedNodeProvider`] and processing
-/// [`NodeEvent`]. It listens for events emitted by the managed node
+/// [`ChainEvent`]. It listens for events emitted by the managed node
 /// and handles them accordingly.
 // chain processor will support multiple managed nodes in the future.
 #[derive(Debug)]

--- a/crates/supervisor/core/src/chain_processor/chain.rs
+++ b/crates/supervisor/core/src/chain_processor/chain.rs
@@ -156,11 +156,6 @@ mod tests {
                 block_info: BlockInfo,
             ) -> Result<(), StorageError>;
 
-            fn update_finalized_l1(
-                &self,
-                block_info: BlockInfo,
-            ) -> Result<(), StorageError>;
-
             fn update_safety_head_ref(
                 &self,
                 safety_level: SafetyLevel,

--- a/crates/supervisor/core/src/chain_processor/chain.rs
+++ b/crates/supervisor/core/src/chain_processor/chain.rs
@@ -44,6 +44,7 @@ where
         state_manager: Arc<W>,
         cancel_token: CancellationToken,
     ) -> Self {
+        // todo: validate chain_id against managed_node
         Self { chain_id, managed_node, state_manager, cancel_token, task_handle: Mutex::new(None) }
     }
 

--- a/crates/supervisor/core/src/chain_processor/task.rs
+++ b/crates/supervisor/core/src/chain_processor/task.rs
@@ -74,30 +74,11 @@ where
             ChainEvent::BlockReplaced { replacement } => {
                 self.handle_block_replacement(replacement).await
             }
-            ChainEvent::L1Finalized { block } => self.handle_l1_finalized(block).await,
         }
     }
 
     async fn handle_block_replacement(&self, _replacement: BlockReplacement) {
         // Logic to handle block replacement
-    }
-
-    async fn handle_l1_finalized(&self, block: BlockInfo) {
-        debug!(
-            target: "chain_processor",
-            chain_id = self.chain_id,
-            block_number = block.number,
-            "Processing finalized L1 block"
-        );
-        if let Err(err) = self.state_manager.update_finalized_l1(block) {
-            error!(
-                target: "chain_processor",
-                chain_id = self.chain_id,
-                block_number = block.number,
-                %err,
-                "Failed to update finalized L1 block"
-            );
-        }
     }
 
     fn handle_derivation_origin_update(&self, origin: BlockInfo) {
@@ -216,11 +197,6 @@ mod tests {
 
         impl HeadRefStorageWriter for Db {
             fn update_current_l1(
-                &self,
-                block_info: BlockInfo,
-            ) -> Result<(), StorageError>;
-
-            fn update_finalized_l1(
                 &self,
                 block_info: BlockInfo,
             ) -> Result<(), StorageError>;

--- a/crates/supervisor/core/src/event/chain.rs
+++ b/crates/supervisor/core/src/event/chain.rs
@@ -33,10 +33,4 @@ pub enum ChainEvent {
         /// hash.
         replacement: BlockReplacement,
     },
-
-    /// A L1 finalized event, indicating that a new L1 block has been finalized.
-    L1Finalized {
-        /// The [`BlockInfo`] of the finalized L1 block.
-        block: BlockInfo,
-    },
 }

--- a/crates/supervisor/core/src/event/chain.rs
+++ b/crates/supervisor/core/src/event/chain.rs
@@ -34,6 +34,7 @@ pub enum ChainEvent {
         replacement: BlockReplacement,
     },
 
+    /// A L1 finalized event, indicating that a new L1 block has been finalized.
     L1Finalized {
         /// The [`BlockInfo`] of the finalized L1 block.
         block: BlockInfo,

--- a/crates/supervisor/core/src/event/chain.rs
+++ b/crates/supervisor/core/src/event/chain.rs
@@ -2,18 +2,19 @@ use kona_interop::DerivedRefPair;
 use kona_protocol::BlockInfo;
 use kona_supervisor_types::BlockReplacement;
 
-/// Represents node events that [`ManagedNode`](`super::ManagedNode`) emits.
-/// These events are used to notify the supervisor about changes in block states,
-/// such as unsafe blocks, safe blocks, or block replacements.
+/// Represents chain events that are emitted from modules in the supervisor.
+/// These events are used to notify the [`ChainProcessor`](crate::chain_processor::ChainProcessor)
+/// about changes in block states, such as unsafe blocks, safe blocks, or block replacements.
 /// Each event carries relevant information about the block involved,
 /// allowing the supervisor to take appropriate actions based on the event type.
 #[derive(Debug, Clone)]
-pub enum NodeEvent {
+pub enum ChainEvent {
     /// An unsafe block event, indicating that a new unsafe block has been detected.
     UnsafeBlock {
         /// The [`BlockInfo`] of the unsafe block.
         block: BlockInfo,
     },
+
     /// A derived block event, indicating that a new derived block has been detected.
     DerivedBlock {
         /// The [`DerivedRefPair`] containing the derived block and its source block.
@@ -31,5 +32,10 @@ pub enum NodeEvent {
         /// The [`BlockReplacement`] containing the replacement block and the invalidated block
         /// hash.
         replacement: BlockReplacement,
+    },
+
+    L1Finalized {
+        /// The [`BlockInfo`] of the finalized L1 block.
+        block: BlockInfo,
     },
 }

--- a/crates/supervisor/core/src/event/mod.rs
+++ b/crates/supervisor/core/src/event/mod.rs
@@ -1,0 +1,4 @@
+//! Event module for the chain processor and supervisor coordination.
+
+mod chain;
+pub use chain::ChainEvent;

--- a/crates/supervisor/core/src/lib.rs
+++ b/crates/supervisor/core/src/lib.rs
@@ -14,4 +14,5 @@ pub use rpc::SupervisorRpc;
 
 pub mod chain_processor;
 pub mod config;
+pub mod event;
 pub mod syncnode;

--- a/crates/supervisor/core/src/syncnode/mod.rs
+++ b/crates/supervisor/core/src/syncnode/mod.rs
@@ -4,9 +4,6 @@
 mod node;
 pub use node::{ManagedNode, ManagedNodeConfig};
 
-mod event;
-pub use event::NodeEvent;
-
 mod error;
 pub use error::{AuthenticationError, ManagedEventTaskError, ManagedNodeError, SubscriptionError};
 

--- a/crates/supervisor/core/src/syncnode/node.rs
+++ b/crates/supervisor/core/src/syncnode/node.rs
@@ -16,10 +16,10 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use super::{
-    AuthenticationError, ManagedNodeError, NodeEvent, NodeSubscriber, ReceiptProvider,
+    AuthenticationError, ManagedEventTask, ManagedNodeError, NodeSubscriber, ReceiptProvider,
     SubscriptionError,
 };
-use crate::syncnode::task::ManagedEventTask;
+use crate::event::ChainEvent;
 
 /// [`ManagedNodeConfig`] sets the configuration for the managed node.
 #[derive(Debug, Clone)]
@@ -181,7 +181,7 @@ where
     /// Spawns a background task to process incoming events.
     async fn start_subscription(
         &self,
-        event_tx: mpsc::Sender<NodeEvent>,
+        event_tx: mpsc::Sender<ChainEvent>,
     ) -> Result<(), ManagedNodeError> {
         let mut task_handle_guard = self.task_handle.lock().await;
         if task_handle_guard.is_some() {
@@ -313,6 +313,7 @@ mod tests {
 
         impl HeadRefStorageReader for Db {
             fn get_current_l1(&self) -> Result<BlockInfo, StorageError>;
+            fn get_finalized_l1(&self) -> Result<BlockInfo, StorageError>;
             fn get_safety_head_ref(&self, level: SafetyLevel) -> Result<BlockInfo, StorageError>;
         }
     }

--- a/crates/supervisor/core/src/syncnode/node.rs
+++ b/crates/supervisor/core/src/syncnode/node.rs
@@ -313,7 +313,6 @@ mod tests {
 
         impl HeadRefStorageReader for Db {
             fn get_current_l1(&self) -> Result<BlockInfo, StorageError>;
-            fn get_finalized_l1(&self) -> Result<BlockInfo, StorageError>;
             fn get_safety_head_ref(&self, level: SafetyLevel) -> Result<BlockInfo, StorageError>;
         }
     }

--- a/crates/supervisor/core/src/syncnode/task.rs
+++ b/crates/supervisor/core/src/syncnode/task.rs
@@ -1,5 +1,5 @@
 use super::ManagedEventTaskError;
-use crate::syncnode::NodeEvent;
+use crate::event::ChainEvent;
 use alloy_eips::BlockNumberOrTag;
 use alloy_network::Ethereum;
 use alloy_provider::{Provider, RootProvider};
@@ -23,7 +23,7 @@ pub struct ManagedEventTask<DB> {
     /// The database provider for fetching information
     db_provider: Arc<DB>,
     /// The channel to send the events to which require further processing e.g. db updates
-    event_tx: mpsc::Sender<NodeEvent>,
+    event_tx: mpsc::Sender<ChainEvent>,
     /// The WebSocket client to use for connecting to managed node (optional for testing)
     client: Option<Arc<WsClient>>,
 }
@@ -36,7 +36,7 @@ where
     pub const fn new(
         l1_rpc_url: String,
         db_provider: Arc<DB>,
-        event_tx: mpsc::Sender<NodeEvent>,
+        event_tx: mpsc::Sender<ChainEvent>,
         client: Arc<WsClient>,
     ) -> Self {
         Self { l1_rpc_url, db_provider, event_tx, client: Some(client) }
@@ -61,7 +61,7 @@ where
 
                     // todo: check any pre processing needed
                     if let Err(err) =
-                        self.event_tx.send(NodeEvent::UnsafeBlock { block: *unsafe_block }).await
+                        self.event_tx.send(ChainEvent::UnsafeBlock { block: *unsafe_block }).await
                     {
                         warn!(target: "managed_event_task", %err, "Failed to send unsafe block event, channel closed or receiver dropped");
                     }
@@ -73,7 +73,7 @@ where
                     // todo: check any pre processing needed
                     if let Err(err) = self
                         .event_tx
-                        .send(NodeEvent::DerivedBlock {
+                        .send(ChainEvent::DerivedBlock {
                             derived_ref_pair: derived_ref_pair.clone(),
                         })
                         .await
@@ -99,7 +99,7 @@ where
                     // todo: check any pre processing needed
                     if let Err(err) = self
                         .event_tx
-                        .send(NodeEvent::BlockReplaced { replacement: replacement.clone() })
+                        .send(ChainEvent::BlockReplaced { replacement: replacement.clone() })
                         .await
                     {
                         warn!(target: "managed_event_task", %err, "Failed to send block replacement event, channel closed or receiver dropped");
@@ -111,7 +111,7 @@ where
 
                     if let Err(err) = self
                         .event_tx
-                        .send(NodeEvent::DerivationOriginUpdate { origin: *origin })
+                        .send(ChainEvent::DerivationOriginUpdate { origin: *origin })
                         .await
                     {
                         warn!(target: "managed_event_task", %err, "Failed to send derivation origin update event, channel closed or receiver dropped");
@@ -294,7 +294,7 @@ where
     const fn new_for_testing(
         l1_rpc_url: String,
         db_provider: Arc<DB>,
-        event_tx: mpsc::Sender<NodeEvent>,
+        event_tx: mpsc::Sender<ChainEvent>,
     ) -> Self {
         Self { l1_rpc_url, db_provider, event_tx, client: None }
     }
@@ -329,6 +329,7 @@ mod tests {
 
         impl HeadRefStorageReader for Db {
             fn get_current_l1(&self) -> Result<BlockInfo, StorageError>;
+            fn get_finalized_l1(&self) -> Result<BlockInfo, StorageError>;
             fn get_safety_head_ref(&self, level: SafetyLevel) -> Result<BlockInfo, StorageError>;
         }
     }
@@ -361,7 +362,7 @@ mod tests {
 
         let event = rx.recv().await.expect("Should receive event");
         match event {
-            NodeEvent::UnsafeBlock { block } => assert_eq!(block, block_info),
+            ChainEvent::UnsafeBlock { block } => assert_eq!(block, block_info),
             _ => panic!("Expected UnsafeBlock event"),
         }
     }
@@ -402,7 +403,7 @@ mod tests {
 
         let event = rx.recv().await.expect("Should receive event");
         match event {
-            NodeEvent::DerivedBlock { derived_ref_pair: pair } => {
+            ChainEvent::DerivedBlock { derived_ref_pair: pair } => {
                 assert_eq!(pair, derived_ref_pair)
             }
             _ => panic!("Expected DerivedBlock event"),
@@ -439,7 +440,7 @@ mod tests {
 
         let event = rx.recv().await.expect("Should receive event");
         match event {
-            NodeEvent::BlockReplaced { replacement: r } => assert_eq!(r, replacement),
+            ChainEvent::BlockReplaced { replacement: r } => assert_eq!(r, replacement),
             _ => panic!("Expected BlockReplaced event"),
         }
     }

--- a/crates/supervisor/core/src/syncnode/task.rs
+++ b/crates/supervisor/core/src/syncnode/task.rs
@@ -329,7 +329,6 @@ mod tests {
 
         impl HeadRefStorageReader for Db {
             fn get_current_l1(&self) -> Result<BlockInfo, StorageError>;
-            fn get_finalized_l1(&self) -> Result<BlockInfo, StorageError>;
             fn get_safety_head_ref(&self, level: SafetyLevel) -> Result<BlockInfo, StorageError>;
         }
     }

--- a/crates/supervisor/core/src/syncnode/traits.rs
+++ b/crates/supervisor/core/src/syncnode/traits.rs
@@ -1,4 +1,5 @@
-use crate::syncnode::{ManagedNodeError, NodeEvent};
+use super::ManagedNodeError;
+use crate::event::ChainEvent;
 use alloy_primitives::B256;
 use async_trait::async_trait;
 use kona_supervisor_types::Receipts;
@@ -14,14 +15,14 @@ pub trait NodeSubscriber: Send + Sync {
     /// Starts a subscription to the node's event stream.
     ///
     /// # Arguments
-    /// * `event_tx` - A Tokio MPSC sender through which [`NodeEvent`]s will be emitted.
+    /// * `event_tx` - A Tokio MPSC sender through which [`ChainEvent`]s will be emitted.
     ///
     /// # Returns
     /// * `Ok(())` on successful subscription
     /// * `Err(ManagedNodeError)` if subscription setup fails
     async fn start_subscription(
         &self,
-        event_tx: mpsc::Sender<NodeEvent>,
+        event_tx: mpsc::Sender<ChainEvent>,
     ) -> Result<(), ManagedNodeError>;
 }
 

--- a/crates/supervisor/service/src/actors/l1_watcher_rpc.rs
+++ b/crates/supervisor/service/src/actors/l1_watcher_rpc.rs
@@ -164,8 +164,6 @@ impl SupervisorActor for L1WatcherRpc {
             .into_stream()
             .flat_map(futures::stream::iter);
 
-        let mut a = self.l1_provider.watch_blocks().await.unwrap();
-
         let inbound_queries = mem::take(&mut self.inbound_queries);
         let inbound_query_processor =
             inbound_queries.map(|queries| self.start_query_processor(queries));

--- a/crates/supervisor/service/src/actors/l1_watcher_rpc.rs
+++ b/crates/supervisor/service/src/actors/l1_watcher_rpc.rs
@@ -164,6 +164,8 @@ impl SupervisorActor for L1WatcherRpc {
             .into_stream()
             .flat_map(futures::stream::iter);
 
+        let mut a = self.l1_provider.watch_blocks().await.unwrap();
+
         let inbound_queries = mem::take(&mut self.inbound_queries);
         let inbound_query_processor =
             inbound_queries.map(|queries| self.start_query_processor(queries));

--- a/crates/supervisor/storage/src/chaindb.rs
+++ b/crates/supervisor/storage/src/chaindb.rs
@@ -212,6 +212,9 @@ impl HeadRefStorageWriter for ChainDb {
             }
         }
         *guard = Some(block);
+
+        // todo: update safety head ref for finalized level
+
         Ok(())
     }
 
@@ -529,12 +532,12 @@ mod tests {
         assert!(matches!(err, StorageError::FutureData));
 
         // Update current_l1 with block1
-        db.update_current_l1(block1.clone()).unwrap();
+        db.update_current_l1(block1).unwrap();
         let got = db.get_current_l1().unwrap();
         assert_eq!(got, block1);
 
         // Update with a higher block number
-        db.update_current_l1(block2.clone()).unwrap();
+        db.update_current_l1(block2).unwrap();
         let got = db.get_current_l1().unwrap();
         assert_eq!(got, block2);
 
@@ -558,12 +561,12 @@ mod tests {
         assert!(matches!(err, StorageError::FutureData));
 
         // Update finalized_l1 with block1
-        db.update_finalized_l1(block1.clone()).unwrap();
+        db.update_finalized_l1(block1).unwrap();
         let got = db.get_finalized_l1().unwrap();
         assert_eq!(got, block1);
 
         // Update with a higher block number
-        db.update_finalized_l1(block2.clone()).unwrap();
+        db.update_finalized_l1(block2).unwrap();
         let got = db.get_finalized_l1().unwrap();
         assert_eq!(got, block2);
 

--- a/crates/supervisor/storage/src/chaindb.rs
+++ b/crates/supervisor/storage/src/chaindb.rs
@@ -29,16 +29,13 @@ pub struct ChainDb {
     /// Current L1 block reference, used for tracking the latest L1 block processed.
     /// In-memory only, not persisted.
     current_l1: RwLock<Option<BlockInfo>>,
-    /// Finalized L1 block reference, used for tracking the finalized L1 block.
-    /// In-memory only, not persisted.
-    finalized_l1: RwLock<Option<BlockInfo>>,
 }
 
 impl ChainDb {
     /// Creates or opens a database environment at the given path.
     pub fn new(path: &Path) -> Result<Self, StorageError> {
         let env = init_db_for::<_, crate::models::Tables>(path, DatabaseArguments::default())?;
-        Ok(Self { env, current_l1: RwLock::new(None), finalized_l1: RwLock::new(None) })
+        Ok(Self { env, current_l1: RwLock::new(None) })
     }
 
     /// initialises the database with a given anchor derived block pair.
@@ -153,14 +150,6 @@ impl HeadRefStorageReader for ChainDb {
         guard.as_ref().cloned().ok_or(StorageError::FutureData)
     }
 
-    fn get_finalized_l1(&self) -> Result<BlockInfo, StorageError> {
-        let guard = self.finalized_l1.read().map_err(|err| {
-            error!(target: "supervisor_storage", %err, "Failed to acquire read lock on finalized_l1");
-            StorageError::LockPoisoned
-        })?;
-        guard.as_ref().cloned().ok_or(StorageError::FutureData)
-    }
-
     fn get_safety_head_ref(&self, safety_level: SafetyLevel) -> Result<BlockInfo, StorageError> {
         self.env.view(|tx| SafetyHeadRefProvider::new(tx).get_safety_head_ref(safety_level))?
     }
@@ -188,33 +177,6 @@ impl HeadRefStorageWriter for ChainDb {
             }
         }
         *guard = Some(block);
-        Ok(())
-    }
-
-    fn update_finalized_l1(&self, block: BlockInfo) -> Result<(), StorageError> {
-        let mut guard = self
-            .finalized_l1
-            .write()
-            .map_err(|err| {
-                error!(target: "supervisor_storage", %err, "Failed to acquire write lock on finalized_l1");
-                StorageError::LockPoisoned
-            })?;
-
-        // Check if the new block number is greater than the current finalized block
-        if let Some(ref current) = *guard {
-            if block.number <= current.number {
-                error!(target: "supervisor_storage",
-                    current_block_number = current.number,
-                    new_block_number = block.number,
-                    "New finalized block number is not greater than current finalized block number",
-                );
-                return Err(StorageError::BlockOutOfOrder);
-            }
-        }
-        *guard = Some(block);
-
-        // todo: update safety head ref for finalized level
-
         Ok(())
     }
 
@@ -544,35 +506,6 @@ mod tests {
         // Update with a lower block number should error
         let block3 = BlockInfo { number: 15, ..Default::default() };
         let err = db.update_current_l1(block3).unwrap_err();
-        assert!(matches!(err, StorageError::BlockOutOfOrder));
-    }
-
-    #[test]
-    fn test_update_and_get_finalized_l1() {
-        let tmp_dir = tempfile::TempDir::new().unwrap();
-        let db_path = tmp_dir.path().join("chaindb_finalized_l1");
-        let db = ChainDb::new(&db_path).unwrap();
-
-        let block1 = BlockInfo { number: 100, ..Default::default() };
-        let block2 = BlockInfo { number: 200, ..Default::default() };
-
-        // Initially, get_finalized_l1 should return FutureData error
-        let err = db.get_finalized_l1().unwrap_err();
-        assert!(matches!(err, StorageError::FutureData));
-
-        // Update finalized_l1 with block1
-        db.update_finalized_l1(block1).unwrap();
-        let got = db.get_finalized_l1().unwrap();
-        assert_eq!(got, block1);
-
-        // Update with a higher block number
-        db.update_finalized_l1(block2).unwrap();
-        let got = db.get_finalized_l1().unwrap();
-        assert_eq!(got, block2);
-
-        // Update with a lower block number should error
-        let block3 = BlockInfo { number: 150, ..Default::default() };
-        let err = db.update_finalized_l1(block3).unwrap_err();
         assert!(matches!(err, StorageError::BlockOutOfOrder));
     }
 }

--- a/crates/supervisor/storage/src/chaindb_factory.rs
+++ b/crates/supervisor/storage/src/chaindb_factory.rs
@@ -5,8 +5,10 @@ use std::{
 };
 
 use alloy_primitives::ChainId;
+use kona_protocol::BlockInfo;
+use tracing::error;
 
-use crate::{chaindb::ChainDb, error::StorageError};
+use crate::{FinalizedL1Storage, chaindb::ChainDb, error::StorageError};
 
 /// Factory for managing multiple chain databases.
 /// This struct allows for the creation and retrieval of `ChainDb` instances
@@ -15,12 +17,16 @@ use crate::{chaindb::ChainDb, error::StorageError};
 pub struct ChainDbFactory {
     db_path: PathBuf,
     dbs: RwLock<HashMap<ChainId, Arc<ChainDb>>>,
+
+    /// Finalized L1 block reference, used for tracking the finalized L1 block.
+    /// In-memory only, not persisted.
+    finalized_l1: RwLock<Option<BlockInfo>>,
 }
 
 impl ChainDbFactory {
     /// Create a new, empty factory.
     pub fn new(db_path: PathBuf) -> Self {
-        Self { db_path, dbs: RwLock::new(HashMap::new()) }
+        Self { db_path, dbs: RwLock::new(HashMap::new()), finalized_l1: RwLock::new(None) }
     }
 
     /// Get or create a [`ChainDb`] for the given chain id.
@@ -58,6 +64,43 @@ impl ChainDbFactory {
         dbs.get(&chain_id)
             .cloned()
             .ok_or_else(|| StorageError::EntryNotFound("chain not found".to_string()))
+    }
+}
+
+impl FinalizedL1Storage for ChainDbFactory {
+    fn get_finalized_l1(&self) -> Result<BlockInfo, StorageError> {
+        let guard = self.finalized_l1.read().map_err(|err| {
+            error!(target: "supervisor_storage", %err, "Failed to acquire read lock on finalized_l1");
+            StorageError::LockPoisoned
+        })?;
+        guard.as_ref().cloned().ok_or(StorageError::FutureData)
+    }
+
+    fn update_finalized_l1(&self, block: BlockInfo) -> Result<(), StorageError> {
+        let mut guard = self
+            .finalized_l1
+            .write()
+            .map_err(|err| {
+                error!(target: "supervisor_storage", %err, "Failed to acquire write lock on finalized_l1");
+                StorageError::LockPoisoned
+            })?;
+
+        // Check if the new block number is greater than the current finalized block
+        if let Some(ref current) = *guard {
+            if block.number <= current.number {
+                error!(target: "supervisor_storage",
+                    current_block_number = current.number,
+                    new_block_number = block.number,
+                    "New finalized block number is not greater than current finalized block number",
+                );
+                return Err(StorageError::BlockOutOfOrder);
+            }
+        }
+        *guard = Some(block);
+
+        // todo: update safety head ref for finalized level for all chains
+
+        Ok(())
     }
 }
 
@@ -111,5 +154,49 @@ mod tests {
 
         assert!(tmp.path().join("1").exists());
         assert!(tmp.path().join("2").exists());
+    }
+
+    #[test]
+    fn test_get_finalized_l1_returns_error_when_none() {
+        let (_tmp, factory) = temp_factory();
+        let err = factory.get_finalized_l1().unwrap_err();
+        assert!(matches!(err, StorageError::FutureData));
+    }
+
+    #[test]
+    fn test_update_and_get_finalized_l1_success() {
+        let (_tmp, factory) = temp_factory();
+        let block1 = BlockInfo { number: 100, ..Default::default() };
+        let block2 = BlockInfo { number: 200, ..Default::default() };
+
+        // Set first finalized block
+        factory.update_finalized_l1(block1.clone()).unwrap();
+        assert_eq!(factory.get_finalized_l1().unwrap(), block1);
+
+        // Update with higher block number
+        factory.update_finalized_l1(block2.clone()).unwrap();
+        assert_eq!(factory.get_finalized_l1().unwrap(), block2);
+    }
+
+    #[test]
+    fn test_update_finalized_l1_with_lower_block_number_errors() {
+        let (_tmp, factory) = temp_factory();
+        let block1 = BlockInfo { number: 100, ..Default::default() };
+        let block2 = BlockInfo { number: 50, ..Default::default() };
+
+        factory.update_finalized_l1(block1.clone()).unwrap();
+        let err = factory.update_finalized_l1(block2).unwrap_err();
+        assert!(matches!(err, StorageError::BlockOutOfOrder));
+    }
+
+    #[test]
+    fn test_update_finalized_l1_with_same_block_number_errors() {
+        let (_tmp, factory) = temp_factory();
+        let block1 = BlockInfo { number: 100, ..Default::default() };
+        let block2 = BlockInfo { number: 100, ..Default::default() };
+
+        factory.update_finalized_l1(block1.clone()).unwrap();
+        let err = factory.update_finalized_l1(block2).unwrap_err();
+        assert!(matches!(err, StorageError::BlockOutOfOrder));
     }
 }

--- a/crates/supervisor/storage/src/chaindb_factory.rs
+++ b/crates/supervisor/storage/src/chaindb_factory.rs
@@ -170,11 +170,11 @@ mod tests {
         let block2 = BlockInfo { number: 200, ..Default::default() };
 
         // Set first finalized block
-        factory.update_finalized_l1(block1.clone()).unwrap();
+        factory.update_finalized_l1(block1).unwrap();
         assert_eq!(factory.get_finalized_l1().unwrap(), block1);
 
         // Update with higher block number
-        factory.update_finalized_l1(block2.clone()).unwrap();
+        factory.update_finalized_l1(block2).unwrap();
         assert_eq!(factory.get_finalized_l1().unwrap(), block2);
     }
 
@@ -184,7 +184,7 @@ mod tests {
         let block1 = BlockInfo { number: 100, ..Default::default() };
         let block2 = BlockInfo { number: 50, ..Default::default() };
 
-        factory.update_finalized_l1(block1.clone()).unwrap();
+        factory.update_finalized_l1(block1).unwrap();
         let err = factory.update_finalized_l1(block2).unwrap_err();
         assert!(matches!(err, StorageError::BlockOutOfOrder));
     }
@@ -195,7 +195,7 @@ mod tests {
         let block1 = BlockInfo { number: 100, ..Default::default() };
         let block2 = BlockInfo { number: 100, ..Default::default() };
 
-        factory.update_finalized_l1(block1.clone()).unwrap();
+        factory.update_finalized_l1(block1).unwrap();
         let err = factory.update_finalized_l1(block2).unwrap_err();
         assert!(matches!(err, StorageError::BlockOutOfOrder));
     }

--- a/crates/supervisor/storage/src/lib.rs
+++ b/crates/supervisor/storage/src/lib.rs
@@ -34,6 +34,7 @@ pub use chaindb_factory::ChainDbFactory;
 
 mod traits;
 pub use traits::{
-    DerivationStorage, DerivationStorageReader, DerivationStorageWriter, HeadRefStorage,
-    HeadRefStorageReader, HeadRefStorageWriter, LogStorage, LogStorageReader, LogStorageWriter,
+    DerivationStorage, DerivationStorageReader, DerivationStorageWriter, FinalizedL1Storage,
+    HeadRefStorage, HeadRefStorageReader, HeadRefStorageWriter, LogStorage, LogStorageReader,
+    LogStorageWriter,
 };

--- a/crates/supervisor/storage/src/traits.rs
+++ b/crates/supervisor/storage/src/traits.rs
@@ -159,13 +159,6 @@ pub trait HeadRefStorageReader: Debug {
     /// * `Err(StorageError)` if there is an issue retrieving the reference.
     fn get_current_l1(&self) -> Result<BlockInfo, StorageError>;
 
-    /// Retrieves the finalized L1 block reference from the storage.
-    ///
-    /// # Returns
-    /// * `Ok(BlockInfo)` containing the finalized L1 block reference.
-    /// * `Err(StorageError)` if there is an issue retrieving the reference.
-    fn get_finalized_l1(&self) -> Result<BlockInfo, StorageError>;
-
     /// Retrieves the current [`BlockInfo`] for a given [`SafetyLevel`].
     ///
     /// # Arguments
@@ -195,16 +188,6 @@ pub trait HeadRefStorageWriter: Debug {
     /// * `Err(StorageError)` if there is an issue updating the reference.
     fn update_current_l1(&self, block: BlockInfo) -> Result<(), StorageError>;
 
-    /// Updates the finalized L1 block reference in the storage.
-    ///
-    /// # Arguments
-    /// * `block` - The new [`BlockInfo`] to set as the finalized L1 block reference.
-    ///
-    /// # Returns
-    /// * `Ok(())` if the reference was successfully updated.
-    /// * `Err(StorageError)` if there is an issue updating the reference.
-    fn update_finalized_l1(&self, block: BlockInfo) -> Result<(), StorageError>;
-
     /// Updates the safety head reference for a given [`SafetyLevel`].
     ///
     /// # Arguments
@@ -228,3 +211,25 @@ pub trait HeadRefStorageWriter: Debug {
 pub trait HeadRefStorage: HeadRefStorageReader + HeadRefStorageWriter {}
 
 impl<T: HeadRefStorageReader + HeadRefStorageWriter> HeadRefStorage for T {}
+
+/// Provides an interface for managing the finalized L1 block reference in the storage.
+/// 
+/// This trait defines methods to update and retrieve the finalized L1 block reference.
+pub trait FinalizedL1Storage {
+    /// Updates the finalized L1 block reference in the storage.
+    ///
+    /// # Arguments
+    /// * `block` - The new [`BlockInfo`] to set as the finalized L1 block reference.
+    ///
+    /// # Returns
+    /// * `Ok(())` if the reference was successfully updated.
+    /// * `Err(StorageError)` if there is an issue updating the reference.
+    fn update_finalized_l1(&self, block: BlockInfo) -> Result<(), StorageError>;
+
+    /// Retrieves the finalized L1 block reference from the storage.
+    ///
+    /// # Returns
+    /// * `Ok(BlockInfo)` containing the finalized L1 block reference.
+    /// * `Err(StorageError)` if there is an issue retrieving the reference.
+    fn get_finalized_l1(&self) -> Result<BlockInfo, StorageError>;
+}

--- a/crates/supervisor/storage/src/traits.rs
+++ b/crates/supervisor/storage/src/traits.rs
@@ -158,6 +158,14 @@ pub trait HeadRefStorageReader: Debug {
     /// * `Ok(BlockInfo)` containing the current L1 block reference.
     /// * `Err(StorageError)` if there is an issue retrieving the reference.
     fn get_current_l1(&self) -> Result<BlockInfo, StorageError>;
+
+    /// Retrieves the finalized L1 block reference from the storage.
+    ///
+    /// # Returns
+    /// * `Ok(BlockInfo)` containing the finalized L1 block reference.
+    /// * `Err(StorageError)` if there is an issue retrieving the reference.
+    fn get_finalized_l1(&self) -> Result<BlockInfo, StorageError>;
+
     /// Retrieves the current [`BlockInfo`] for a given [`SafetyLevel`].
     ///
     /// # Arguments
@@ -186,6 +194,17 @@ pub trait HeadRefStorageWriter: Debug {
     /// * `Ok(())` if the reference was successfully updated.
     /// * `Err(StorageError)` if there is an issue updating the reference.
     fn update_current_l1(&self, block: BlockInfo) -> Result<(), StorageError>;
+
+    /// Updates the finalized L1 block reference in the storage.
+    ///
+    /// # Arguments
+    /// * `block` - The new [`BlockInfo`] to set as the finalized L1 block reference.
+    ///
+    /// # Returns
+    /// * `Ok(())` if the reference was successfully updated.
+    /// * `Err(StorageError)` if there is an issue updating the reference.
+    fn update_finalized_l1(&self, block: BlockInfo) -> Result<(), StorageError>;
+
     /// Updates the safety head reference for a given [`SafetyLevel`].
     ///
     /// # Arguments

--- a/crates/supervisor/storage/src/traits.rs
+++ b/crates/supervisor/storage/src/traits.rs
@@ -213,7 +213,7 @@ pub trait HeadRefStorage: HeadRefStorageReader + HeadRefStorageWriter {}
 impl<T: HeadRefStorageReader + HeadRefStorageWriter> HeadRefStorage for T {}
 
 /// Provides an interface for managing the finalized L1 block reference in the storage.
-/// 
+///
 /// This trait defines methods to update and retrieve the finalized L1 block reference.
 pub trait FinalizedL1Storage {
     /// Updates the finalized L1 block reference in the storage.


### PR DESCRIPTION
Part of #2069 

This PR refactors the event handling architecture and introduces support for finalized L1 block events, including their storage and processing.

Key Changes:
**Refactor Node Event Handling**
- Moves `NodeEvent` out of the `syncnode` module and renames it to `ChainEvent`
- All chain-processing will now be handled by the chain processor. Other modules will emit `ChainEvent` to the chain processor for unified handling.
**Finalized L1 Event Support**
- Introduces database logic for storing and retrieving the finalized L1 block

Motivation
- Centralizes all per-chain event processing, making the codebase easier to reason about and maintain.
- Enables future extensibility for new event types and sources.