### PR TITLE
Add Arun as code owner for ci

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 * @clabby @refcell @emhane @theochap
+.github @dhyaniarun1993
 bin/supervisor @dhyaniarun1993 @itschaindev @sadiq1971
 crates/supervisor @dhyaniarun1993 @itschaindev @sadiq1971


### PR DESCRIPTION
Adds @dhyaniarun1993 as code owner of CI to be able to merge prs related to https://github.com/op-rs/kona/issues/2181 in absence of OP Labs