### PR TITLE
Add chainsafe as codeowners of `kona-interop`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 * @clabby @refcell @emhane @theochap
-.github @dhyaniarun1993
+.github/ @dhyaniarun1993
 bin/supervisor @dhyaniarun1993 @itschaindev @sadiq1971
 crates/supervisor @dhyaniarun1993 @itschaindev @sadiq1971
 crates/protocol/interop/ @dhyaniarun1993 @itschaindev @sadiq1971

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 .github @dhyaniarun1993
 bin/supervisor @dhyaniarun1993 @itschaindev @sadiq1971
 crates/supervisor @dhyaniarun1993 @itschaindev @sadiq1971
-crates/protocol/interop @dhyaniarun1993 @itschaindev @sadiq1971
+crates/protocol/interop/ @dhyaniarun1993 @itschaindev @sadiq1971

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 * @clabby @refcell @emhane @theochap
+.github @dhyaniarun1993
 bin/supervisor @dhyaniarun1993 @itschaindev @sadiq1971
 crates/supervisor @dhyaniarun1993 @itschaindev @sadiq1971

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,4 @@
 .github @dhyaniarun1993
 bin/supervisor @dhyaniarun1993 @itschaindev @sadiq1971
 crates/supervisor @dhyaniarun1993 @itschaindev @sadiq1971
+crates/protocol/interop @dhyaniarun1993 @itschaindev @sadiq1971


### PR DESCRIPTION
Adds @dhyaniarun1993 @itschaindev @sadiq1971 as code owners for interop protocol types to unblock merging prs relating to these types during OP Labs collective pause