### PR TITLE
fix(protocol/interop): made `override_message_expiry_window` as optional

### DIFF
--- a/bin/supervisor/src/flags/supervisor.rs
+++ b/bin/supervisor/src/flags/supervisor.rs
@@ -310,7 +310,7 @@ mod tests {
 
         let expected_depset = DependencySet {
             dependencies: expected_dependencies,
-            override_message_expiry_window: 3600,
+            override_message_expiry_window: Some(3600),
         };
 
         assert_eq!(loaded_depset, expected_depset);

--- a/crates/protocol/interop/src/depset.rs
+++ b/crates/protocol/interop/src/depset.rs
@@ -17,16 +17,16 @@ pub struct DependencySet {
     pub dependencies: HashMap<ChainId, ChainDependency>,
 
     /// Override message expiry window to use for this dependency set.
-    pub override_message_expiry_window: u64,
+    pub override_message_expiry_window: Option<u64>,
 }
 
 impl DependencySet {
     /// Returns the message expiry window associated with this dependency set.
     pub const fn get_message_expiry_window(&self) -> u64 {
-        if self.override_message_expiry_window == 0 {
-            return MESSAGE_EXPIRY_WINDOW;
+        match self.override_message_expiry_window {
+            Some(window) if window > 0 => window,
+            _ => MESSAGE_EXPIRY_WINDOW,
         }
-        self.override_message_expiry_window
     }
 }
 
@@ -40,7 +40,7 @@ mod tests {
         dependencies: HashMap<ChainId, ChainDependency>,
         override_expiry: u64,
     ) -> DependencySet {
-        DependencySet { dependencies, override_message_expiry_window: override_expiry }
+        DependencySet { dependencies, override_message_expiry_window: Some(override_expiry) }
     }
 
     #[test]

--- a/crates/supervisor/core/src/rpc/server.rs
+++ b/crates/supervisor/core/src/rpc/server.rs
@@ -356,7 +356,7 @@ mod tests {
     async fn test_sync_status_empty_chains() {
         let mut deps = HashMap::default();
         deps.insert(1, ChainDependency {});
-        let ds = DependencySet { dependencies: deps, override_message_expiry_window: 0 };
+        let ds = DependencySet { dependencies: deps, override_message_expiry_window: Some(0) };
 
         let mock_service = MockSupervisorService {
             chain_ids: vec![],
@@ -375,7 +375,7 @@ mod tests {
     async fn test_sync_status_single_chain() {
         let mut deps = HashMap::default();
         deps.insert(1, ChainDependency {});
-        let ds = DependencySet { dependencies: deps, override_message_expiry_window: 0 };
+        let ds = DependencySet { dependencies: deps, override_message_expiry_window: Some(0) };
         let chain_id = ChainId::from(1u64);
 
         let block_info = BlockInfo { number: 42, ..Default::default() };
@@ -408,7 +408,7 @@ mod tests {
         let mut deps = HashMap::default();
         deps.insert(1, ChainDependency {});
         deps.insert(2, ChainDependency {});
-        let ds = DependencySet { dependencies: deps, override_message_expiry_window: 0 };
+        let ds = DependencySet { dependencies: deps, override_message_expiry_window: Some(0) };
         let chain_id_1 = ChainId::from(1u64);
         let chain_id_2 = ChainId::from(2u64);
 


### PR DESCRIPTION
Part of #2181