### PR TITLE
feat(protocol/derive): Provide Block Signal

### DIFF
--- a/crates/protocol/derive/src/errors/pipeline.rs
+++ b/crates/protocol/derive/src/errors/pipeline.rs
@@ -98,6 +98,9 @@ pub enum PipelineError {
     /// Provider error variant.
     #[error("Provider error: {0}")]
     Provider(String),
+    /// The signal is unsupported by the pipeline.
+    #[error("Unsupported signal")]
+    UnsupportedSignal,
 }
 
 impl PipelineError {

--- a/crates/protocol/derive/src/pipeline/core.rs
+++ b/crates/protocol/derive/src/pipeline/core.rs
@@ -121,6 +121,9 @@ where
             Signal::FlushChannel => {
                 self.attributes.signal(signal).await?;
             }
+            Signal::ProvideBlock(_) => {
+                self.attributes.signal(signal).await?;
+            }
         }
         kona_macros::inc!(
             gauge,

--- a/crates/protocol/derive/src/stages/attributes_queue.rs
+++ b/crates/protocol/derive/src/stages/attributes_queue.rs
@@ -196,6 +196,9 @@ where
                 self.batch = None;
                 self.prev.signal(s).await?;
             }
+            s @ Signal::ProvideBlock(_) => {
+                self.prev.signal(s).await?;
+            }
         }
         Ok(())
     }

--- a/crates/protocol/derive/src/stages/batch/batch_queue.rs
+++ b/crates/protocol/derive/src/stages/batch/batch_queue.rs
@@ -452,6 +452,9 @@ where
                 self.batches.clear();
                 self.next_spans.clear();
             }
+            s @ Signal::ProvideBlock(_) => {
+                self.prev.signal(s).await?;
+            }
         }
         Ok(())
     }

--- a/crates/protocol/derive/src/stages/batch/batch_validator.rs
+++ b/crates/protocol/derive/src/stages/batch/batch_validator.rs
@@ -315,7 +315,7 @@ where
                 self.l1_blocks.clear();
                 self.l1_blocks.push(l1_origin);
             }
-            s @ Signal::Activation(_) | s @ Signal::FlushChannel => {
+            s @ Signal::Activation(_) | s @ Signal::FlushChannel | s @ Signal::ProvideBlock(_) => {
                 self.prev.signal(s).await?;
             }
         }

--- a/crates/protocol/derive/src/stages/l1_traversal.rs
+++ b/crates/protocol/derive/src/stages/l1_traversal.rs
@@ -160,6 +160,11 @@ impl<F: ChainProvider + Send> SignalReceiver for L1Traversal<F> {
                 self.update_origin(l1_origin);
                 self.system_config = system_config.expect("System config must be provided.");
             }
+            Signal::ProvideBlock(_) => {
+                /* Not supported in this stage. */
+                warn!(target: "l1_traversal", "ProvideBlock signal not supported in L1Traversal stage.");
+                return Err(PipelineError::UnsupportedSignal.temp());
+            }
             _ => {}
         }
 

--- a/crates/protocol/derive/src/types/signals.rs
+++ b/crates/protocol/derive/src/types/signals.rs
@@ -17,6 +17,8 @@ pub enum Signal {
     Activation(ActivationSignal),
     /// Flush the currently active channel.
     FlushChannel,
+    /// Provide a new L1 block to the L1 traversal stage.
+    ProvideBlock(BlockInfo),
 }
 
 impl core::fmt::Display for Signal {
@@ -25,6 +27,7 @@ impl core::fmt::Display for Signal {
             Self::Reset(_) => write!(f, "reset"),
             Self::Activation(_) => write!(f, "activation"),
             Self::FlushChannel => write!(f, "flush_channel"),
+            Self::ProvideBlock(_) => write!(f, "provide_block"),
         }
     }
 }
@@ -36,6 +39,7 @@ impl Signal {
             Self::Reset(reset) => reset.with_system_config(system_config).signal(),
             Self::Activation(activation) => activation.with_system_config(system_config).signal(),
             Self::FlushChannel => Self::FlushChannel,
+            Self::ProvideBlock(block) => Self::ProvideBlock(block),
         }
     }
 }


### PR DESCRIPTION
### Description

Adds a `Signal` variant for the supervisor to provide the next l1 block to the traversal stage.

Closes #2226