### PR TITLE
chore(derive): Metrics Mod Visibility

### DIFF
--- a/bin/node/src/flags/metrics.rs
+++ b/bin/node/src/flags/metrics.rs
@@ -15,7 +15,7 @@ pub fn init_unified_metrics(args: &MetricsArgs) -> anyhow::Result<()> {
         kona_p2p::Metrics::init();
         kona_engine::Metrics::init();
         kona_node_service::Metrics::init();
-        kona_derive::metrics::Metrics::init();
+        kona_derive::Metrics::init();
         VersionInfo::from_build().register_version_metrics();
     }
     Ok(())

--- a/crates/protocol/derive/src/lib.rs
+++ b/crates/protocol/derive/src/lib.rs
@@ -49,7 +49,7 @@ pub use traits::{
 mod types;
 pub use types::{ActivationSignal, PipelineResult, ResetSignal, Signal, StepResult};
 
-pub mod metrics;
+mod metrics;
 pub use metrics::Metrics;
 
 #[cfg(feature = "test-utils")]


### PR DESCRIPTION
### Description

Tiny PR to cleanup the `metrics` module in `kona-derive` being public.