### PR TITLE
chore(derive): Code Doc Comments

### DIFF
--- a/crates/protocol/derive/src/attributes/stateful.rs
+++ b/crates/protocol/derive/src/attributes/stateful.rs
@@ -19,7 +19,7 @@ use kona_protocol::{
 };
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 
-/// A stateful implementation of the [AttributesBuilder].
+/// A stateful implementation of the [`AttributesBuilder`].
 #[derive(Debug, Default)]
 pub struct StatefulAttributesBuilder<L1P, L2P>
 where
@@ -39,7 +39,7 @@ where
     L1P: ChainProvider + Debug,
     L2P: L2ChainProvider + Debug,
 {
-    /// Create a new [StatefulAttributesBuilder] with the given epoch.
+    /// Create a new [`StatefulAttributesBuilder`] with the given epoch.
     pub const fn new(rcfg: Arc<RollupConfig>, sys_cfg_fetcher: L2P, receipts: L1P) -> Self {
         Self { rollup_cfg: rcfg, config_fetcher: sys_cfg_fetcher, receipts_fetcher: receipts }
     }
@@ -206,7 +206,7 @@ where
 ///
 /// Successful deposits must be emitted by the deposit contract and have the correct event
 /// signature. So the receipt address must equal the specified deposit contract and the first topic
-/// must be the [DEPOSIT_EVENT_ABI_HASH].
+/// must be the [`DEPOSIT_EVENT_ABI_HASH`].
 async fn derive_deposits(
     block_hash: B256,
     receipts: &[Receipt],

--- a/crates/protocol/derive/src/errors/attributes.rs
+++ b/crates/protocol/derive/src/errors/attributes.rs
@@ -5,9 +5,9 @@ use alloy_eips::BlockNumHash;
 use alloy_primitives::B256;
 use thiserror::Error;
 
-/// An [AttributesBuilder] Error.
+/// An [`AttributesBuilder`] Error.
 ///
-/// [AttributesBuilder]: crate::traits::AttributesBuilder
+/// [`AttributesBuilder`]: crate::traits::AttributesBuilder
 #[derive(Error, Clone, Debug, PartialEq, Eq)]
 pub enum BuilderError {
     /// Mismatched blocks.
@@ -16,9 +16,9 @@ pub enum BuilderError {
     /// Mismatched blocks for the start of an Epoch.
     #[error("Block mismatch on epoch reset. Expected {0:?}, got {1:?}")]
     BlockMismatchEpochReset(BlockNumHash, BlockNumHash, B256),
-    /// [SystemConfig] update failed.
+    /// [`SystemConfig`] update failed.
     ///
-    /// [SystemConfig]: kona_genesis::SystemConfig
+    /// [`SystemConfig`]: kona_genesis::SystemConfig
     #[error("System config update failed")]
     SystemConfigUpdate,
     /// Broken time invariant between L2 and L1.

--- a/crates/protocol/derive/src/errors/pipeline.rs
+++ b/crates/protocol/derive/src/errors/pipeline.rs
@@ -17,7 +17,7 @@ macro_rules! ensure {
     };
 }
 
-/// A top level filter for [PipelineError] that sorts by severity.
+/// A top level filter for [`PipelineError`] that sorts by severity.
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum PipelineErrorKind {
     /// A temporary error.
@@ -42,37 +42,37 @@ pub enum PipelineError {
     /// [PipelineError::Eof] will be encountered.
     #[error("Not enough data")]
     NotEnoughData,
-    /// No channels are available in the [ChannelProvider].
+    /// No channels are available in the [`ChannelProvider`].
     ///
-    /// [ChannelProvider]: crate::stages::ChannelProvider
+    /// [`ChannelProvider`]: crate::stages::ChannelProvider
     #[error("The channel provider is empty")]
     ChannelProviderEmpty,
-    /// The channel has already been built by the [ChannelAssembler] stage.
+    /// The channel has already been built by the [`ChannelAssembler`] stage.
     ///
-    /// [ChannelAssembler]: crate::stages::ChannelAssembler
+    /// [`ChannelAssembler`]: crate::stages::ChannelAssembler
     #[error("Channel already built")]
     ChannelAlreadyBuilt,
-    /// Failed to find channel in the [ChannelProvider].
+    /// Failed to find channel in the [`ChannelProvider`].
     ///
-    /// [ChannelProvider]: crate::stages::ChannelProvider
+    /// [`ChannelProvider`]: crate::stages::ChannelProvider
     #[error("Channel not found in channel provider")]
     ChannelNotFound,
-    /// No channel returned by the [ChannelReader] stage.
+    /// No channel returned by the [`ChannelReader`] stage.
     ///
-    /// [ChannelReader]: crate::stages::ChannelReader
+    /// [`ChannelReader`]: crate::stages::ChannelReader
     #[error("The channel reader has no channel available")]
     ChannelReaderEmpty,
-    /// The [BatchQueue] is empty.
+    /// The [`BatchQueue`] is empty.
     ///
-    /// [BatchQueue]: crate::stages::BatchQueue
+    /// [`BatchQueue`]: crate::stages::BatchQueue
     #[error("The batch queue has no batches available")]
     BatchQueueEmpty,
     /// Missing L1 origin.
     #[error("Missing L1 origin from previous stage")]
     MissingOrigin,
-    /// Missing data from [L1Retrieval].
+    /// Missing data from [`L1Retrieval`].
     ///
-    /// [L1Retrieval]: crate::stages::L1Retrieval
+    /// [`L1Retrieval`]: crate::stages::L1Retrieval
     #[error("L1 Retrieval missing data")]
     MissingL1Data,
     /// Invalid batch type passed.
@@ -81,15 +81,15 @@ pub enum PipelineError {
     /// Invalid batch validity variant.
     #[error("Invalid batch validity")]
     InvalidBatchValidity,
-    /// [SystemConfig] update error.
+    /// [`SystemConfig`] update error.
     ///
-    /// [SystemConfig]: kona_genesis::SystemConfig
+    /// [`SystemConfig`]: kona_genesis::SystemConfig
     #[error("Error updating system config: {0}")]
     SystemConfigUpdate(SystemConfigUpdateError),
-    /// Attributes builder error variant, with [BuilderError].
+    /// Attributes builder error variant, with [`BuilderError`].
     #[error("Attributes builder error: {0}")]
     AttributesBuilder(#[from] BuilderError),
-    /// [PipelineEncodingError] variant.
+    /// [`PipelineEncodingError`] variant.
     #[error("Decode error: {0}")]
     BadEncoding(#[from] PipelineEncodingError),
     /// The data source can no longer provide any more data.
@@ -104,12 +104,12 @@ pub enum PipelineError {
 }
 
 impl PipelineError {
-    /// Wrap [PipelineError] as a [PipelineErrorKind::Critical].
+    /// Wrap [`PipelineError`] as a [PipelineErrorKind::Critical].
     pub const fn crit(self) -> PipelineErrorKind {
         PipelineErrorKind::Critical(self)
     }
 
-    /// Wrap [PipelineError] as a [PipelineErrorKind::Temporary].
+    /// Wrap [`PipelineError`] as a [PipelineErrorKind::Temporary].
     pub const fn temp(self) -> PipelineErrorKind {
         PipelineErrorKind::Temporary(self)
     }
@@ -136,7 +136,7 @@ pub enum ResetError {
     /// The second argument is the parent_hash of the next l1 origin block.
     #[error("L1 reorg detected: expected {0}, got {1}")]
     ReorgDetected(B256, B256),
-    /// Attributes builder error variant, with [BuilderError].
+    /// Attributes builder error variant, with [`BuilderError`].
     #[error("Attributes builder error: {0}")]
     AttributesBuilder(#[from] BuilderError),
     /// A Holocene activation temporary error.
@@ -145,7 +145,7 @@ pub enum ResetError {
 }
 
 impl ResetError {
-    /// Wrap [ResetError] as a [PipelineErrorKind::Reset].
+    /// Wrap [`ResetError`] as a [PipelineErrorKind::Reset].
     pub const fn reset(self) -> PipelineErrorKind {
         PipelineErrorKind::Reset(self)
     }

--- a/crates/protocol/derive/src/errors/sources.rs
+++ b/crates/protocol/derive/src/errors/sources.rs
@@ -21,7 +21,7 @@ pub enum BlobDecodingError {
     MissingData,
 }
 
-/// An error returned by the [BlobProviderError].
+/// An error returned by the [`BlobProviderError`].
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum BlobProviderError {
     /// The number of specified blob hashes did not match the number of returned sidecars.

--- a/crates/protocol/derive/src/errors/stages.rs
+++ b/crates/protocol/derive/src/errors/stages.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 /// A frame decompression error.
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum BatchDecompressionError {
-    /// The buffer exceeds the [MAX_SPAN_BATCH_ELEMENTS] protocol parameter.
+    /// The buffer exceeds the [`MAX_SPAN_BATCH_ELEMENTS`] protocol parameter.
     #[error("The batch exceeds the maximum number of elements: {max_size}", max_size = MAX_SPAN_BATCH_ELEMENTS)]
     BatchTooLarge,
 }

--- a/crates/protocol/derive/src/pipeline/builder.rs
+++ b/crates/protocol/derive/src/pipeline/builder.rs
@@ -10,31 +10,31 @@ use core::fmt::Debug;
 use kona_genesis::RollupConfig;
 use kona_protocol::BlockInfo;
 
-/// Type alias for the [L1Traversal] stage.
+/// Type alias for the [`L1Traversal`] stage.
 pub type L1TraversalStage<P> = L1Traversal<P>;
 
-/// Type alias for the [L1Retrieval] stage.
+/// Type alias for the [`L1Retrieval`] stage.
 pub type L1RetrievalStage<DAP, P> = L1Retrieval<DAP, L1TraversalStage<P>>;
 
-/// Type alias for the [FrameQueue] stage.
+/// Type alias for the [`FrameQueue`] stage.
 pub type FrameQueueStage<DAP, P> = FrameQueue<L1RetrievalStage<DAP, P>>;
 
-/// Type alias for the [ChannelProvider] stage.
+/// Type alias for the [`ChannelProvider`] stage.
 pub type ChannelProviderStage<DAP, P> = ChannelProvider<FrameQueueStage<DAP, P>>;
 
-/// Type alias for the [ChannelReader] stage.
+/// Type alias for the [`ChannelReader`] stage.
 pub type ChannelReaderStage<DAP, P> = ChannelReader<ChannelProviderStage<DAP, P>>;
 
-/// Type alias for the [BatchStream] stage.
+/// Type alias for the [`BatchStream`] stage.
 pub type BatchStreamStage<DAP, P, T> = BatchStream<ChannelReaderStage<DAP, P>, T>;
 
-/// Type alias for the [BatchProvider] stage.
+/// Type alias for the [`BatchProvider`] stage.
 pub type BatchProviderStage<DAP, P, T> = BatchProvider<BatchStreamStage<DAP, P, T>, T>;
 
-/// Type alias for the [AttributesQueue] stage.
+/// Type alias for the [`AttributesQueue`] stage.
 pub type AttributesQueueStage<DAP, P, T, B> = AttributesQueue<BatchProviderStage<DAP, P, T>, B>;
 
-/// The `PipelineBuilder` constructs a [DerivationPipeline] using a builder pattern.
+/// The `PipelineBuilder` constructs a [`DerivationPipeline`] using a builder pattern.
 #[derive(Debug)]
 pub struct PipelineBuilder<B, P, T, D>
 where

--- a/crates/protocol/derive/src/pipeline/core.rs
+++ b/crates/protocol/derive/src/pipeline/core.rs
@@ -23,7 +23,7 @@ where
     /// A handle to the next attributes.
     pub attributes: S,
     /// Reset provider for the pipeline.
-    /// A list of prepared [OpAttributesWithParent] to be used by the derivation pipeline
+    /// A list of prepared [`OpAttributesWithParent`] to be used by the derivation pipeline
     /// consumer.
     pub prepared: VecDeque<OpAttributesWithParent>,
     /// The rollup config.
@@ -37,7 +37,7 @@ where
     S: NextAttributes + SignalReceiver + OriginProvider + OriginAdvancer + Debug + Send,
     P: L2ChainProvider + Send + Sync + Debug,
 {
-    /// Creates a new instance of the [DerivationPipeline].
+    /// Creates a new instance of the [`DerivationPipeline`].
     pub const fn new(
         attributes: S,
         rollup_config: Arc<RollupConfig>,
@@ -140,7 +140,7 @@ where
     S: NextAttributes + SignalReceiver + OriginProvider + OriginAdvancer + Debug + Send + Sync,
     P: L2ChainProvider + Send + Sync + Debug,
 {
-    /// Peeks at the next prepared [OpAttributesWithParent] from the pipeline.
+    /// Peeks at the next prepared [`OpAttributesWithParent`] from the pipeline.
     fn peek(&self) -> Option<&OpAttributesWithParent> {
         self.prepared.front()
     }
@@ -150,7 +150,7 @@ where
         &self.rollup_config
     }
 
-    /// Returns the [SystemConfig] by L2 number.
+    /// Returns the [`SystemConfig`] by L2 number.
     async fn system_config_by_number(
         &mut self,
         number: u64,
@@ -172,7 +172,7 @@ where
     /// When [DerivationPipeline::step] returns [Ok(())], it should be called again, to continue the
     /// derivation process.
     ///
-    /// [PipelineError]: crate::errors::PipelineError
+    /// [`PipelineError`]: crate::errors::PipelineError
     async fn step(&mut self, cursor: L2BlockInfo) -> StepResult {
         kona_macros::inc!(gauge, crate::metrics::Metrics::PIPELINE_STEPS);
         kona_macros::set!(

--- a/crates/protocol/derive/src/sources/blob_data.rs
+++ b/crates/protocol/derive/src/sources/blob_data.rs
@@ -25,7 +25,7 @@ pub struct BlobData {
 
 impl BlobData {
     /// Decodes the blob into raw byte data.
-    /// Returns a [BlobDecodingError] if the blob is invalid.
+    /// Returns a [`BlobDecodingError`] if the blob is invalid.
     pub(crate) fn decode(&self) -> Result<Bytes, BlobDecodingError> {
         let data = self.data.as_ref().ok_or(BlobDecodingError::MissingData)?;
 
@@ -101,7 +101,7 @@ impl BlobData {
 
     /// Decodes the next input field element by writing its lower 31 bytes into its
     /// appropriate place in the output and checking the high order byte is valid.
-    /// Returns a [BlobDecodingError] if a field element is seen with either of its
+    /// Returns a [`BlobDecodingError`] if a field element is seen with either of its
     /// two high order bits set.
     pub(crate) fn decode_field_element(
         &self,

--- a/crates/protocol/derive/src/sources/ethereum.rs
+++ b/crates/protocol/derive/src/sources/ethereum.rs
@@ -31,7 +31,7 @@ where
     C: ChainProvider + Send + Clone + Debug,
     B: BlobProvider + Send + Clone + Debug,
 {
-    /// Instantiates a new [EthereumDataSource].
+    /// Instantiates a new [`EthereumDataSource`].
     pub const fn new(
         blob_source: BlobSource<C, B>,
         calldata_source: CalldataSource<C>,
@@ -40,7 +40,7 @@ where
         Self { ecotone_timestamp: cfg.hardforks.ecotone_time, blob_source, calldata_source }
     }
 
-    /// Instantiates a new [EthereumDataSource] from parts.
+    /// Instantiates a new [`EthereumDataSource`] from parts.
     pub fn new_from_parts(provider: C, blobs: B, cfg: &RollupConfig) -> Self {
         Self {
             ecotone_timestamp: cfg.hardforks.ecotone_time,

--- a/crates/protocol/derive/src/stages/attributes_queue.rs
+++ b/crates/protocol/derive/src/stages/attributes_queue.rs
@@ -15,19 +15,19 @@ use kona_genesis::RollupConfig;
 use kona_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent, SingleBatch};
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 
-/// [AttributesQueue] accepts batches from the [BatchQueue] stage
-/// and transforms them into [OpPayloadAttributes].
+/// [`AttributesQueue`] accepts batches from the [`BatchQueue`] stage
+/// and transforms them into [`OpPayloadAttributes`].
 ///
 /// The outputted payload attributes cannot be buffered because each batch->attributes
 /// transformation pulls in data about the current L2 safe head.
 ///
-/// [AttributesQueue] also buffers batches that have been output because
+/// [`AttributesQueue`] also buffers batches that have been output because
 /// multiple batches can be created at once.
 ///
 /// This stage can be reset by clearing its batch buffer.
 /// This stage does not need to retain any references to L1 blocks.
 ///
-/// [BatchQueue]: crate::stages::BatchQueue
+/// [`BatchQueue`]: crate::stages::BatchQueue
 #[derive(Debug)]
 pub struct AttributesQueue<P, AB>
 where
@@ -51,12 +51,12 @@ where
     P: AttributesProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
     AB: AttributesBuilder + Debug,
 {
-    /// Create a new [AttributesQueue] stage.
+    /// Create a new [`AttributesQueue`] stage.
     pub const fn new(cfg: Arc<RollupConfig>, prev: P, builder: AB) -> Self {
         Self { cfg, prev, is_last_in_span: false, batch: None, builder }
     }
 
-    /// Loads a [SingleBatch] from the [AttributesProvider] if needed.
+    /// Loads a [`SingleBatch`] from the [`AttributesProvider`] if needed.
     pub async fn load_batch(&mut self, parent: L2BlockInfo) -> PipelineResult<SingleBatch> {
         if self.batch.is_none() {
             let batch = self.prev.next_batch(parent).await?;
@@ -66,7 +66,7 @@ where
         self.batch.as_ref().cloned().ok_or(PipelineError::Eof.temp())
     }
 
-    /// Returns the next [OpAttributesWithParent] from the current batch.
+    /// Returns the next [`OpAttributesWithParent`] from the current batch.
     pub async fn next_attributes(
         &mut self,
         parent: L2BlockInfo,
@@ -102,7 +102,7 @@ where
         Ok(populated_attributes)
     }
 
-    /// Creates the next attributes, transforming a [SingleBatch] into [OpPayloadAttributes].
+    /// Creates the next attributes, transforming a [`SingleBatch`] into [`OpPayloadAttributes`].
     /// This sets `no_tx_pool` and appends the batched txs to the attributes tx list.
     pub async fn create_next_attributes(
         &mut self,

--- a/crates/protocol/derive/src/stages/batch/batch_provider.rs
+++ b/crates/protocol/derive/src/stages/batch/batch_provider.rs
@@ -1,4 +1,4 @@
-//! This module contains the [BatchProvider] stage.
+//! This module contains the [`BatchProvider`] stage.
 
 use super::NextBatchProvider;
 use crate::{
@@ -11,11 +11,11 @@ use core::fmt::Debug;
 use kona_genesis::RollupConfig;
 use kona_protocol::{BlockInfo, L2BlockInfo, SingleBatch};
 
-/// The [BatchProvider] stage is a mux between the [BatchQueue] and [BatchValidator] stages.
+/// The [`BatchProvider`] stage is a mux between the [`BatchQueue`] and [`BatchValidator`] stages.
 ///
 /// Rules:
-/// When Holocene is not active, the [BatchQueue] is used.
-/// When Holocene is active, the [BatchValidator] is used.
+/// When Holocene is not active, the [`BatchQueue`] is used.
+/// When Holocene is active, the [`BatchValidator`] is used.
 ///
 /// When transitioning between the two stages, the mux will reset the active stage, but
 /// retain `l1_blocks`.
@@ -31,18 +31,18 @@ where
     provider: F,
     /// The previous stage of the derivation pipeline.
     ///
-    /// If this is set to [None], the multiplexer has been activated and the active stage
+    /// If this is set to [`None`], the multiplexer has been activated and the active stage
     /// owns the previous stage.
     ///
-    /// Must be [None] if `batch_queue` or `batch_validator` is [Some].
+    /// Must be [`None`] if `batch_queue` or `batch_validator` is [`Some`].
     prev: Option<P>,
     /// The batch queue stage of the provider.
     ///
-    /// Must be [None] if `prev` or `batch_validator` is [Some].
+    /// Must be [`None`] if `prev` or `batch_validator` is [`Some`].
     batch_queue: Option<BatchQueue<P, F>>,
     /// The batch validator stage of the provider.
     ///
-    /// Must be [None] if `prev` or `batch_queue` is [Some].
+    /// Must be [`None`] if `prev` or `batch_queue` is [`Some`].
     batch_validator: Option<BatchValidator<P>>,
 }
 
@@ -51,7 +51,7 @@ where
     P: NextBatchProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
     F: L2ChainProvider + Clone + Debug,
 {
-    /// Creates a new [BatchProvider] with the given configuration and previous stage.
+    /// Creates a new [`BatchProvider`] with the given configuration and previous stage.
     pub const fn new(cfg: Arc<RollupConfig>, prev: P, provider: F) -> Self {
         Self { cfg, provider, prev: Some(prev), batch_queue: None, batch_validator: None }
     }

--- a/crates/protocol/derive/src/stages/batch/batch_queue.rs
+++ b/crates/protocol/derive/src/stages/batch/batch_queue.rs
@@ -14,7 +14,7 @@ use kona_protocol::{
     Batch, BatchValidity, BatchWithInclusionBlock, BlockInfo, L2BlockInfo, SingleBatch,
 };
 
-/// [BatchQueue] is responsible for ordering unordered batches
+/// [`BatchQueue`] is responsible for ordering unordered batches
 /// and generating empty batches when the sequence window has passed.
 ///
 /// It receives batches that are tagged with the L1 Inclusion block of the batch.
@@ -49,9 +49,9 @@ where
     pub(crate) l1_blocks: Vec<BlockInfo>,
     /// A set of batches in order from when we've seen them.
     pub(crate) batches: Vec<BatchWithInclusionBlock>,
-    /// A set of cached [SingleBatch]es derived from [SpanBatch]es.
+    /// A set of cached [`SingleBatch`]es derived from [`SpanBatch`]es.
     ///
-    /// [SpanBatch]: kona_protocol::SpanBatch
+    /// [`SpanBatch`]: kona_protocol::SpanBatch
     pub(crate) next_spans: Vec<SingleBatch>,
     /// Used to validate the batches.
     pub(crate) fetcher: BF,
@@ -62,7 +62,7 @@ where
     P: NextBatchProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
     BF: L2ChainProvider + Debug,
 {
-    /// Creates a new [BatchQueue] stage.
+    /// Creates a new [`BatchQueue`] stage.
     #[allow(clippy::missing_const_for_fn)]
     pub fn new(cfg: Arc<RollupConfig>, prev: P, fetcher: BF) -> Self {
         Self {

--- a/crates/protocol/derive/src/stages/batch/batch_stream.rs
+++ b/crates/protocol/derive/src/stages/batch/batch_stream.rs
@@ -12,25 +12,25 @@ use kona_protocol::{
     Batch, BatchValidity, BatchWithInclusionBlock, BlockInfo, L2BlockInfo, SingleBatch, SpanBatch,
 };
 
-/// Provides [Batch]es for the [BatchStream] stage.
+/// Provides [`Batch`]es for the [`BatchStream`] stage.
 #[async_trait]
 pub trait BatchStreamProvider {
-    /// Returns the next [Batch] in the [BatchStream] stage.
+    /// Returns the next [`Batch`] in the [`BatchStream`] stage.
     async fn next_batch(&mut self) -> PipelineResult<Batch>;
 
     /// Drains the recent `Channel` if an invalid span batch is found post-holocene.
     fn flush(&mut self);
 }
 
-/// [BatchStream] stage in the derivation pipeline.
+/// [`BatchStream`] stage in the derivation pipeline.
 ///
-/// This stage is introduced in the [Holocene] hardfork.
-/// It slots in between the [ChannelReader] and [BatchQueue]
+/// This stage is introduced in the [`Holocene`] hardfork.
+/// It slots in between the [`ChannelReader`] and [`BatchQueue`]
 /// stages, buffering span batches until they are validated.
 ///
-/// [Holocene]: https://specs.optimism.io/protocol/holocene/overview.html
-/// [ChannelReader]: crate::stages::ChannelReader
-/// [BatchQueue]: crate::stages::BatchQueue
+/// [`Holocene`]: https://specs.optimism.io/protocol/holocene/overview.html
+/// [`ChannelReader`]: crate::stages::ChannelReader
+/// [`BatchQueue`]: crate::stages::BatchQueue
 #[derive(Debug)]
 pub struct BatchStream<P, BF>
 where
@@ -41,10 +41,10 @@ where
     prev: P,
     /// There can only be a single staged span batch.
     span: Option<SpanBatch>,
-    /// A buffer of single batches derived from the [SpanBatch].
+    /// A buffer of single batches derived from the [`SpanBatch`].
     buffer: VecDeque<SingleBatch>,
     /// A reference to the rollup config, used to check
-    /// if the [BatchStream] stage should be activated.
+    /// if the [`BatchStream`] stage should be activated.
     config: Arc<RollupConfig>,
     /// Used to validate the batches.
     fetcher: BF,
@@ -55,19 +55,19 @@ where
     P: BatchStreamProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
     BF: L2ChainProvider + Debug,
 {
-    /// Create a new [BatchStream] stage.
+    /// Create a new [`BatchStream`] stage.
     pub const fn new(prev: P, config: Arc<RollupConfig>, fetcher: BF) -> Self {
         Self { prev, span: None, buffer: VecDeque::new(), config, fetcher }
     }
 
-    /// Returns if the [BatchStream] stage is active based on the
+    /// Returns if the [`BatchStream`] stage is active based on the
     /// origin timestamp and holocene activation timestamp.
     pub fn is_active(&self) -> PipelineResult<bool> {
         let origin = self.prev.origin().ok_or(PipelineError::MissingOrigin.crit())?;
         Ok(self.config.is_holocene_active(origin.timestamp))
     }
 
-    /// Gets a [SingleBatch] from the in-memory buffer.
+    /// Gets a [`SingleBatch`] from the in-memory buffer.
     pub fn get_single_batch(
         &mut self,
         parent: L2BlockInfo,

--- a/crates/protocol/derive/src/stages/batch/batch_validator.rs
+++ b/crates/protocol/derive/src/stages/batch/batch_validator.rs
@@ -12,11 +12,11 @@ use core::fmt::Debug;
 use kona_genesis::RollupConfig;
 use kona_protocol::{Batch, BatchValidity, BlockInfo, L2BlockInfo, SingleBatch};
 
-/// The [BatchValidator] stage is responsible for validating the [SingleBatch]es from
-/// the [BatchStream] [AttributesQueue]'s consumption.
+/// The [`BatchValidator`] stage is responsible for validating the [`SingleBatch`]es from
+/// the [`BatchStream`] [`AttributesQueue`]'s consumption.
 ///
-/// [BatchStream]: crate::stages::BatchStream
-/// [AttributesQueue]: crate::stages::attributes_queue::AttributesQueue
+/// [`BatchStream`]: crate::stages::BatchStream
+/// [`AttributesQueue`]: crate::stages::attributes_queue::AttributesQueue
 #[derive(Debug)]
 pub struct BatchValidator<P>
 where
@@ -41,7 +41,7 @@ impl<P> BatchValidator<P>
 where
     P: NextBatchProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
 {
-    /// Create a new [BatchValidator] stage.
+    /// Create a new [`BatchValidator`] stage.
     pub const fn new(cfg: Arc<RollupConfig>, prev: P) -> Self {
         Self { cfg, prev, origin: None, l1_blocks: Vec::new() }
     }
@@ -57,7 +57,7 @@ where
         self.prev.origin().is_none_or(|origin| origin.number < parent.l1_origin.number)
     }
 
-    /// Updates the [BatchValidator]'s view of the L1 origin blocks.
+    /// Updates the [`BatchValidator`]'s view of the L1 origin blocks.
     ///
     /// ## Takes
     /// - `parent`: The parent block of the current batch.

--- a/crates/protocol/derive/src/stages/batch/mod.rs
+++ b/crates/protocol/derive/src/stages/batch/mod.rs
@@ -1,9 +1,10 @@
 //! Contains stages pertaining to the processing of [Batch]es.
 //!
-//! Sitting after the [ChannelReader] stage, the [BatchStream] and [BatchProvider] stages are
-//! responsible for validating and ordering the [Batch]es. The [BatchStream] stage is responsible
-//! for streaming [SingleBatch]es from [SpanBatch]es, while the [BatchProvider] stage is responsible
-//! for ordering and validating the [Batch]es for the [AttributesQueue] stage.
+//! Sitting after the [ChannelReader] stage, the [`BatchStream`] and [`BatchProvider`] stages are
+//! responsible for validating and ordering the [Batch]es. The [`BatchStream`] stage is
+//! responsible for streaming [SingleBatch]es from [SpanBatch]es, while the [`BatchProvider`]
+//! stage is responsible for ordering and validating the [Batch]es for the [AttributesQueue]
+//! stage.
 //!
 //! [Batch]: kona_protocol::Batch
 //! [SingleBatch]: kona_protocol::SingleBatch
@@ -28,15 +29,15 @@ pub use batch_validator::BatchValidator;
 mod batch_provider;
 pub use batch_provider::BatchProvider;
 
-/// Provides [Batch]es for the [BatchQueue] and [BatchValidator] stages.
+/// Provides [`Batch`]es for the [`BatchQueue`] and [`BatchValidator`] stages.
 #[async_trait]
 pub trait NextBatchProvider {
-    /// Returns the next [Batch] in the [ChannelReader] stage, if the stage is not complete.
+    /// Returns the next [`Batch`] in the [`ChannelReader`] stage, if the stage is not complete.
     /// This function can only be called once while the stage is in progress, and will return
     /// [`None`] on subsequent calls unless the stage is reset or complete. If the stage is
     /// complete and the batch has been consumed, an [PipelineError::Eof] error is returned.
     ///
-    /// [ChannelReader]: crate::stages::ChannelReader
+    /// [`ChannelReader`]: crate::stages::ChannelReader
     /// [PipelineError::Eof]: crate::errors::PipelineError::Eof
     async fn next_batch(
         &mut self,
@@ -44,11 +45,11 @@ pub trait NextBatchProvider {
         l1_origins: &[BlockInfo],
     ) -> PipelineResult<Batch>;
 
-    /// Returns the number of [SingleBatch]es that are currently buffered in the [BatchStream]
-    /// from a [SpanBatch].
+    /// Returns the number of [`SingleBatch`]es that are currently buffered in the [`BatchStream`]
+    /// from a [`SpanBatch`].
     ///
-    /// [SpanBatch]: kona_protocol::SpanBatch
-    /// [SingleBatch]: kona_protocol::SingleBatch
+    /// [`SpanBatch`]: kona_protocol::SpanBatch
+    /// [`SingleBatch`]: kona_protocol::SingleBatch
     fn span_buffer_size(&self) -> usize;
 
     /// Allows the stage to flush the buffer in the [crate::stages::BatchStream]

--- a/crates/protocol/derive/src/stages/channel/channel_assembler.rs
+++ b/crates/protocol/derive/src/stages/channel/channel_assembler.rs
@@ -15,12 +15,12 @@ use kona_genesis::{
 };
 use kona_protocol::{BlockInfo, Channel};
 
-/// The [ChannelAssembler] stage is responsible for assembling the [Frame]s from the [FrameQueue]
-/// stage into a raw compressed [Channel].
+/// The [`ChannelAssembler`] stage is responsible for assembling the [`Frame`]s from the
+/// [`FrameQueue`] stage into a raw compressed [`Channel`].
 ///
-/// [Frame]: kona_protocol::Frame
-/// [FrameQueue]: crate::stages::FrameQueue
-/// [Channel]: kona_protocol::Channel
+/// [`Frame`]: kona_protocol::Frame
+/// [`FrameQueue`]: crate::stages::FrameQueue
+/// [`Channel`]: kona_protocol::Channel
 #[derive(Debug)]
 pub struct ChannelAssembler<P>
 where
@@ -30,7 +30,7 @@ where
     pub(crate) cfg: Arc<RollupConfig>,
     /// The previous stage of the derivation pipeline.
     pub(crate) prev: P,
-    /// The current [Channel] being assembled.
+    /// The current [`Channel`] being assembled.
     pub(crate) channel: Option<Channel>,
 }
 
@@ -38,7 +38,7 @@ impl<P> ChannelAssembler<P>
 where
     P: NextFrameProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
 {
-    /// Creates a new [ChannelAssembler] stage with the given configuration and previous stage.
+    /// Creates a new [`ChannelAssembler`] stage with the given configuration and previous stage.
     pub const fn new(cfg: Arc<RollupConfig>, prev: P) -> Self {
         Self { cfg, prev, channel: None }
     }

--- a/crates/protocol/derive/src/stages/channel/channel_bank.rs
+++ b/crates/protocol/derive/src/stages/channel/channel_bank.rs
@@ -17,7 +17,7 @@ pub(crate) const MAX_CHANNEL_BANK_SIZE: usize = 100_000_000;
 /// The maximum size of a channel bank after the Fjord Hardfork.
 pub(crate) const FJORD_MAX_CHANNEL_BANK_SIZE: usize = 1_000_000_000;
 
-/// [ChannelBank] is a stateful stage that does the following:
+/// [`ChannelBank`] is a stateful stage that does the following:
 /// 1. Unmarshalls frames from L1 transaction data
 /// 2. Applies those frames to a channel
 /// 3. Attempts to read from the channel when it is ready
@@ -27,7 +27,7 @@ pub(crate) const FJORD_MAX_CHANNEL_BANK_SIZE: usize = 1_000_000_000;
 /// As we switch between ingesting data & reading, the prune step occurs at an odd point
 /// Specifically, the channel bank is not allowed to become too large between successive calls
 /// to `IngestData`. This means that we can do an ingest and then do a read while becoming too
-/// large. [ChannelBank] buffers channel frames, and emits full channel data
+/// large. [`ChannelBank`] buffers channel frames, and emits full channel data
 #[derive(Debug)]
 pub struct ChannelBank<P>
 where
@@ -47,7 +47,7 @@ impl<P> ChannelBank<P>
 where
     P: NextFrameProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
 {
-    /// Create a new [ChannelBank] stage.
+    /// Create a new [`ChannelBank`] stage.
     pub fn new(cfg: Arc<RollupConfig>, prev: P) -> Self {
         Self { cfg, channels: HashMap::default(), channel_queue: VecDeque::new(), prev }
     }

--- a/crates/protocol/derive/src/stages/channel/channel_provider.rs
+++ b/crates/protocol/derive/src/stages/channel/channel_provider.rs
@@ -13,11 +13,12 @@ use core::fmt::Debug;
 use kona_genesis::RollupConfig;
 use kona_protocol::BlockInfo;
 
-/// The [ChannelProvider] stage is a mux between the [ChannelBank] and [ChannelAssembler] stages.
+/// The [`ChannelProvider`] stage is a mux between the [`ChannelBank`] and [`ChannelAssembler`]
+/// stages.
 ///
 /// Rules:
-/// When Holocene is not active, the [ChannelBank] is used.
-/// When Holocene is active, the [ChannelAssembler] is used.
+/// When Holocene is not active, the [`ChannelBank`] is used.
+/// When Holocene is active, the [`ChannelAssembler`] is used.
 #[derive(Debug)]
 pub struct ChannelProvider<P>
 where
@@ -27,18 +28,18 @@ where
     cfg: Arc<RollupConfig>,
     /// The previous stage of the derivation pipeline.
     ///
-    /// If this is set to [None], the multiplexer has been activated and the active stage
+    /// If this is set to [`None`], the multiplexer has been activated and the active stage
     /// owns the previous stage.
     ///
-    /// Must be [None] if `channel_bank` or `channel_assembler` is [Some].
+    /// Must be [`None`] if `channel_bank` or `channel_assembler` is [`Some`].
     prev: Option<P>,
     /// The channel bank stage of the provider.
     ///
-    /// Must be [None] if `prev` or `channel_assembler` is [Some].
+    /// Must be [`None`] if `prev` or `channel_assembler` is [`Some`].
     channel_bank: Option<ChannelBank<P>>,
     /// The channel assembler stage of the provider.
     ///
-    /// Must be [None] if `prev` or `channel_bank` is [Some].
+    /// Must be [`None`] if `prev` or `channel_bank` is [`Some`].
     channel_assembler: Option<ChannelAssembler<P>>,
 }
 
@@ -46,7 +47,7 @@ impl<P> ChannelProvider<P>
 where
     P: NextFrameProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
 {
-    /// Creates a new [ChannelProvider] with the given configuration and previous stage.
+    /// Creates a new [`ChannelProvider`] with the given configuration and previous stage.
     pub const fn new(cfg: Arc<RollupConfig>, prev: P) -> Self {
         Self { cfg, prev: Some(prev), channel_bank: None, channel_assembler: None }
     }

--- a/crates/protocol/derive/src/stages/channel/channel_reader.rs
+++ b/crates/protocol/derive/src/stages/channel/channel_reader.rs
@@ -14,7 +14,7 @@ use kona_genesis::{
 use kona_protocol::{Batch, BatchReader, BlockInfo};
 use tracing::{debug, warn};
 
-/// The [ChannelReader] provider trait.
+/// The [`ChannelReader`] provider trait.
 #[async_trait]
 pub trait ChannelReaderProvider {
     /// Pulls the next piece of data from the channel bank. Note that it attempts to pull data out
@@ -24,9 +24,9 @@ pub trait ChannelReaderProvider {
     async fn next_data(&mut self) -> PipelineResult<Option<Bytes>>;
 }
 
-/// [ChannelReader] is a stateful stage that reads [Batch]es from `Channel`s.
+/// [`ChannelReader`] is a stateful stage that reads [`Batch`]es from `Channel`s.
 ///
-/// The [ChannelReader] pulls `Channel`s from the channel bank as raw data
+/// The [`ChannelReader`] pulls `Channel`s from the channel bank as raw data
 /// and pipes it into a `BatchReader`. Since the raw data is compressed,
 /// the `BatchReader` first decompresses the data using the first bytes as
 /// a compression algorithm identifier.
@@ -50,7 +50,7 @@ impl<P> ChannelReader<P>
 where
     P: ChannelReaderProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
 {
-    /// Create a new [ChannelReader] stage.
+    /// Create a new [`ChannelReader`] stage.
     pub const fn new(prev: P, cfg: Arc<RollupConfig>) -> Self {
         Self { prev, next_batch: None, cfg }
     }

--- a/crates/protocol/derive/src/stages/channel/mod.rs
+++ b/crates/protocol/derive/src/stages/channel/mod.rs
@@ -28,11 +28,11 @@ pub use channel_assembler::ChannelAssembler;
 pub(crate) mod channel_reader;
 pub use channel_reader::{ChannelReader, ChannelReaderProvider};
 
-/// Provides frames for the [ChannelBank] and [ChannelAssembler] stages.
+/// Provides frames for the [`ChannelBank`] and [`ChannelAssembler`] stages.
 #[async_trait]
 pub trait NextFrameProvider {
-    /// Retrieves the next [Frame] from the [FrameQueue] stage.
+    /// Retrieves the next [`Frame`] from the [`FrameQueue`] stage.
     ///
-    /// [FrameQueue]: crate::stages::FrameQueue
+    /// [`FrameQueue`]: crate::stages::FrameQueue
     async fn next_frame(&mut self) -> PipelineResult<Frame>;
 }

--- a/crates/protocol/derive/src/stages/frame_queue.rs
+++ b/crates/protocol/derive/src/stages/frame_queue.rs
@@ -11,7 +11,7 @@ use core::fmt::Debug;
 use kona_genesis::RollupConfig;
 use kona_protocol::{BlockInfo, Frame};
 
-/// Provides data frames for the [FrameQueue] stage.
+/// Provides data frames for the [`FrameQueue`] stage.
 #[async_trait]
 pub trait FrameQueueProvider {
     /// An item that can be converted into a byte array.
@@ -23,10 +23,10 @@ pub trait FrameQueueProvider {
     async fn next_data(&mut self) -> PipelineResult<Self::Item>;
 }
 
-/// The [FrameQueue] stage of the derivation pipeline.
-/// This stage takes the output of the [L1Retrieval] stage and parses it into frames.
+/// The [`FrameQueue`] stage of the derivation pipeline.
+/// This stage takes the output of the [`L1Retrieval`] stage and parses it into frames.
 ///
-/// [L1Retrieval]: crate::stages::L1Retrieval
+/// [`L1Retrieval`]: crate::stages::L1Retrieval
 #[derive(Debug)]
 pub struct FrameQueue<P>
 where
@@ -44,9 +44,9 @@ impl<P> FrameQueue<P>
 where
     P: FrameQueueProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
 {
-    /// Create a new [FrameQueue] stage with the given previous [L1Retrieval] stage.
+    /// Create a new [`FrameQueue`] stage with the given previous [`L1Retrieval`] stage.
     ///
-    /// [L1Retrieval]: crate::stages::L1Retrieval
+    /// [`L1Retrieval`]: crate::stages::L1Retrieval
     pub const fn new(prev: P, cfg: Arc<RollupConfig>) -> Self {
         Self { prev, queue: VecDeque::new(), rollup_config: cfg }
     }
@@ -105,7 +105,7 @@ where
         }
     }
 
-    /// Loads more frames into the [FrameQueue].
+    /// Loads more frames into the [`FrameQueue`].
     pub async fn load_frames(&mut self) -> PipelineResult<()> {
         // Skip loading frames if the queue is not empty.
         if !self.queue.is_empty() {

--- a/crates/protocol/derive/src/stages/l1_retrieval.rs
+++ b/crates/protocol/derive/src/stages/l1_retrieval.rs
@@ -9,28 +9,29 @@ use alloy_primitives::Address;
 use async_trait::async_trait;
 use kona_protocol::BlockInfo;
 
-/// Provides L1 blocks for the [L1Retrieval] stage.
+/// Provides L1 blocks for the [`L1Retrieval`] stage.
 /// This is the previous stage in the pipeline.
 #[async_trait]
 pub trait L1RetrievalProvider {
-    /// Returns the next L1 [BlockInfo] in the [L1Traversal] stage, if the stage is not complete.
-    /// This function can only be called once while the stage is in progress, and will return
-    /// [`None`] on subsequent calls unless the stage is reset or complete. If the stage is
-    /// complete and the [BlockInfo] has been consumed, an [PipelineError::Eof] error is returned.
+    /// Returns the next L1 [`BlockInfo`] in the [`L1Traversal`] stage, if the stage is not
+    /// complete. This function can only be called once while the stage is in progress, and will
+    /// return [`None`] on subsequent calls unless the stage is reset or complete. If the stage
+    /// is complete and the [`BlockInfo`] has been consumed, an [PipelineError::Eof] error is
+    /// returned.
     ///
-    /// [L1Traversal]: crate::stages::L1Traversal
+    /// [`L1Traversal`]: crate::stages::L1Traversal
     async fn next_l1_block(&mut self) -> PipelineResult<Option<BlockInfo>>;
 
-    /// Returns the batcher [Address] from the [kona_genesis::SystemConfig].
+    /// Returns the batcher [`Address`] from the [kona_genesis::SystemConfig].
     fn batcher_addr(&self) -> Address;
 }
 
-/// The [L1Retrieval] stage of the derivation pipeline.
+/// The [`L1Retrieval`] stage of the derivation pipeline.
 ///
-/// For each L1 [BlockInfo] pulled from the [L1Traversal] stage, [L1Retrieval] fetches the
-/// associated data from a specified [DataAvailabilityProvider].
+/// For each L1 [`BlockInfo`] pulled from the [`L1Traversal`] stage, [`L1Retrieval`] fetches the
+/// associated data from a specified [`DataAvailabilityProvider`].
 ///
-/// [L1Traversal]: crate::stages::L1Traversal
+/// [`L1Traversal`]: crate::stages::L1Traversal
 #[derive(Debug)]
 pub struct L1Retrieval<DAP, P>
 where
@@ -50,10 +51,10 @@ where
     DAP: DataAvailabilityProvider,
     P: L1RetrievalProvider + OriginAdvancer + OriginProvider + SignalReceiver,
 {
-    /// Creates a new [L1Retrieval] stage with the previous [L1Traversal] stage and given
-    /// [DataAvailabilityProvider].
+    /// Creates a new [`L1Retrieval`] stage with the previous [`L1Traversal`] stage and given
+    /// [`DataAvailabilityProvider`].
     ///
-    /// [L1Traversal]: crate::stages::L1Traversal
+    /// [`L1Traversal`]: crate::stages::L1Traversal
     pub const fn new(prev: P, provider: DAP) -> Self {
         Self { prev, provider, next: None }
     }

--- a/crates/protocol/derive/src/stages/l1_traversal.rs
+++ b/crates/protocol/derive/src/stages/l1_traversal.rs
@@ -10,12 +10,12 @@ use async_trait::async_trait;
 use kona_genesis::{RollupConfig, SystemConfig};
 use kona_protocol::BlockInfo;
 
-/// The [L1Traversal] stage of the derivation pipeline.
+/// The [`L1Traversal`] stage of the derivation pipeline.
 ///
 /// This stage sits at the bottom of the pipeline, holding a handle to the data source
-/// (a [ChainProvider] implementation) and the current L1 [BlockInfo] in the pipeline,
-/// which are used to traverse the L1 chain. When the [L1Traversal] stage is advanced,
-/// it fetches the next L1 [BlockInfo] from the data source and updates the [SystemConfig]
+/// (a [`ChainProvider`] implementation) and the current L1 [`BlockInfo`] in the pipeline,
+/// which are used to traverse the L1 chain. When the [`L1Traversal`] stage is advanced,
+/// it fetches the next L1 [`BlockInfo`] from the data source and updates the [`SystemConfig`]
 /// with the receipts from the block.
 #[derive(Debug, Clone)]
 pub struct L1Traversal<Provider: ChainProvider> {
@@ -48,7 +48,7 @@ impl<F: ChainProvider + Send> L1RetrievalProvider for L1Traversal<F> {
 }
 
 impl<F: ChainProvider> L1Traversal<F> {
-    /// Creates a new [L1Traversal] instance.
+    /// Creates a new [`L1Traversal`] instance.
     pub fn new(data_source: F, cfg: Arc<RollupConfig>) -> Self {
         Self {
             block: Some(BlockInfo::default()),
@@ -69,9 +69,9 @@ impl<F: ChainProvider> L1Traversal<F> {
 
 #[async_trait]
 impl<F: ChainProvider + Send> OriginAdvancer for L1Traversal<F> {
-    /// Advances the internal state of the [L1Traversal] stage to the next L1 block.
-    /// This function fetches the next L1 [BlockInfo] from the data source and updates the
-    /// [SystemConfig] with the receipts from the block.
+    /// Advances the internal state of the [`L1Traversal`] stage to the next L1 block.
+    /// This function fetches the next L1 [`BlockInfo`] from the data source and updates the
+    /// [`SystemConfig`] with the receipts from the block.
     async fn advance_origin(&mut self) -> PipelineResult<()> {
         // Advance start time for metrics.
         #[cfg(feature = "metrics")]

--- a/crates/protocol/derive/src/test_utils/attributes_queue.rs
+++ b/crates/protocol/derive/src/test_utils/attributes_queue.rs
@@ -27,7 +27,7 @@ pub struct TestAttributesBuilder {
 
 #[async_trait]
 impl AttributesBuilder for TestAttributesBuilder {
-    /// Prepares the [OptimismPayloadAttributes] for the next payload.
+    /// Prepares the [`OptimismPayloadAttributes`] for the next payload.
     async fn prepare_payload_attributes(
         &mut self,
         _l2_parent: L2BlockInfo,

--- a/crates/protocol/derive/src/test_utils/batch_provider.rs
+++ b/crates/protocol/derive/src/test_utils/batch_provider.rs
@@ -10,7 +10,7 @@ use alloc::{boxed::Box, vec::Vec};
 use async_trait::async_trait;
 use kona_protocol::{Batch, BlockInfo, L2BlockInfo};
 
-/// A mock provider for the [BatchQueue] stage.
+/// A mock provider for the [`BatchQueue`] stage.
 #[derive(Debug, Default)]
 pub struct TestNextBatchProvider {
     /// The origin of the L1 block.
@@ -24,7 +24,7 @@ pub struct TestNextBatchProvider {
 }
 
 impl TestNextBatchProvider {
-    /// Creates a new [MockBatchQueueProvider] with the given origin and batches.
+    /// Creates a new [`MockBatchQueueProvider`] with the given origin and batches.
     pub fn new(batches: Vec<PipelineResult<Batch>>) -> Self {
         Self { origin: Some(BlockInfo::default()), batches, flushed: false, reset: false }
     }

--- a/crates/protocol/derive/src/test_utils/batch_stream.rs
+++ b/crates/protocol/derive/src/test_utils/batch_stream.rs
@@ -26,7 +26,7 @@ pub struct TestBatchStreamProvider {
 }
 
 impl TestBatchStreamProvider {
-    /// Creates a new [TestBatchStreamProvider] with the given origin and batches.
+    /// Creates a new [`TestBatchStreamProvider`] with the given origin and batches.
     pub fn new(batches: Vec<PipelineResult<Batch>>) -> Self {
         Self { origin: Some(BlockInfo::default()), batches, reset: false, flushed: false }
     }

--- a/crates/protocol/derive/src/test_utils/chain_providers.rs
+++ b/crates/protocol/derive/src/test_utils/chain_providers.rs
@@ -76,7 +76,7 @@ impl TestChainProvider {
     }
 }
 
-/// An error for the [TestChainProvider] and [TestL2ChainProvider].
+/// An error for the [`TestChainProvider`] and [`TestL2ChainProvider`].
 #[derive(Error, Debug)]
 pub enum TestProviderError {
     /// The block was not found.
@@ -150,7 +150,7 @@ impl ChainProvider for TestChainProvider {
     }
 }
 
-/// An [L2ChainProvider] implementation for testing.
+/// An [`L2ChainProvider`] implementation for testing.
 #[derive(Debug, Default, Clone)]
 pub struct TestL2ChainProvider {
     /// Blocks
@@ -164,7 +164,7 @@ pub struct TestL2ChainProvider {
 }
 
 impl TestL2ChainProvider {
-    /// Creates a new [MockBlockFetcher] with the given origin and batches.
+    /// Creates a new [`MockBlockFetcher`] with the given origin and batches.
     pub const fn new(
         blocks: Vec<L2BlockInfo>,
         op_blocks: Vec<OpBlock>,

--- a/crates/protocol/derive/src/test_utils/channel_provider.rs
+++ b/crates/protocol/derive/src/test_utils/channel_provider.rs
@@ -12,9 +12,9 @@ use alloc::{boxed::Box, vec::Vec};
 use async_trait::async_trait;
 use kona_protocol::{BlockInfo, Frame};
 
-/// A mock [NextFrameProvider] for testing the [ChannelBank] stage.
+/// A mock [`NextFrameProvider`] for testing the [`ChannelBank`] stage.
 ///
-/// [ChannelBank]: crate::stages::ChannelBank
+/// [`ChannelBank`]: crate::stages::ChannelBank
 #[derive(Debug, Default)]
 pub struct TestNextFrameProvider {
     /// The data to return.
@@ -26,7 +26,7 @@ pub struct TestNextFrameProvider {
 }
 
 impl TestNextFrameProvider {
-    /// Creates a new [TestNextFrameProvider] with the given data.
+    /// Creates a new [`TestNextFrameProvider`] with the given data.
     pub fn new(data: Vec<PipelineResult<Frame>>) -> Self {
         Self { data, block_info: Some(BlockInfo::default()), reset: false }
     }

--- a/crates/protocol/derive/src/test_utils/channel_reader.rs
+++ b/crates/protocol/derive/src/test_utils/channel_reader.rs
@@ -11,9 +11,9 @@ use alloy_primitives::Bytes;
 use async_trait::async_trait;
 use kona_protocol::BlockInfo;
 
-/// A mock [ChannelReaderProvider] for testing the [ChannelReader] stage.
+/// A mock [`ChannelReaderProvider`] for testing the [`ChannelReader`] stage.
 ///
-/// [ChannelReader]: crate::stages::ChannelReader
+/// [`ChannelReader`]: crate::stages::ChannelReader
 #[derive(Debug, Default)]
 pub struct TestChannelReaderProvider {
     /// The data to return.
@@ -25,7 +25,7 @@ pub struct TestChannelReaderProvider {
 }
 
 impl TestChannelReaderProvider {
-    /// Creates a new [TestChannelReaderProvider] with the given data.
+    /// Creates a new [`TestChannelReaderProvider`] with the given data.
     pub fn new(data: Vec<PipelineResult<Option<Bytes>>>) -> Self {
         Self { data, block_info: Some(BlockInfo::default()), reset: false }
     }

--- a/crates/protocol/derive/src/test_utils/frame_queue.rs
+++ b/crates/protocol/derive/src/test_utils/frame_queue.rs
@@ -9,9 +9,9 @@ use alloy_primitives::Bytes;
 use async_trait::async_trait;
 use kona_protocol::BlockInfo;
 
-/// A mock [FrameQueueProvider] for testing the [FrameQueue] stage.
+/// A mock [`FrameQueueProvider`] for testing the [`FrameQueue`] stage.
 ///
-/// [FrameQueue]: crate::stages::FrameQueue
+/// [`FrameQueue`]: crate::stages::FrameQueue
 #[derive(Debug, Default)]
 pub struct TestFrameQueueProvider {
     /// The data to return.
@@ -23,12 +23,12 @@ pub struct TestFrameQueueProvider {
 }
 
 impl TestFrameQueueProvider {
-    /// Creates a new [MockFrameQueueProvider] with the given data.
+    /// Creates a new [`MockFrameQueueProvider`] with the given data.
     pub const fn new(data: Vec<PipelineResult<Bytes>>) -> Self {
         Self { data, origin: None, reset: false }
     }
 
-    /// Sets the origin for the [MockFrameQueueProvider].
+    /// Sets the origin for the [`MockFrameQueueProvider`].
     pub const fn set_origin(&mut self, origin: BlockInfo) {
         self.origin = Some(origin);
     }

--- a/crates/protocol/derive/src/test_utils/frames.rs
+++ b/crates/protocol/derive/src/test_utils/frames.rs
@@ -9,7 +9,7 @@ use alloy_primitives::Bytes;
 use kona_genesis::RollupConfig;
 use kona_protocol::{BlockInfo, DERIVATION_VERSION_0, Frame};
 
-/// A [FrameQueue] builder.
+/// A [`FrameQueue`] builder.
 #[derive(Debug, Default)]
 pub struct FrameQueueBuilder {
     origin: Option<BlockInfo>,
@@ -29,7 +29,7 @@ fn encode_frames(frames: &[Frame]) -> Bytes {
 }
 
 impl FrameQueueBuilder {
-    /// Create a new [FrameQueueBuilder] instance.
+    /// Create a new [`FrameQueueBuilder`] instance.
     pub const fn new() -> Self {
         Self { origin: None, config: None, mock: None, expected_frames: vec![], expected_err: None }
     }
@@ -73,7 +73,7 @@ impl FrameQueueBuilder {
         self
     }
 
-    /// Build the [FrameQueue].
+    /// Build the [`FrameQueue`].
     pub fn build(self) -> FrameQueueAsserter {
         let mut mock = self.mock.unwrap_or_else(|| TestFrameQueueProvider::new(vec![]));
         if let Some(origin) = self.origin {
@@ -86,7 +86,7 @@ impl FrameQueueBuilder {
     }
 }
 
-/// The [FrameQueueAsserter] validates frame queue outputs.
+/// The [`FrameQueueAsserter`] validates frame queue outputs.
 #[derive(Debug)]
 pub struct FrameQueueAsserter {
     inner: FrameQueue<TestFrameQueueProvider>,
@@ -95,7 +95,7 @@ pub struct FrameQueueAsserter {
 }
 
 impl FrameQueueAsserter {
-    /// Create a new [FrameQueueAsserter] instance.
+    /// Create a new [`FrameQueueAsserter`] instance.
     pub const fn new(
         inner: FrameQueue<TestFrameQueueProvider>,
         expected_frames: Vec<Frame>,

--- a/crates/protocol/derive/src/test_utils/pipeline.rs
+++ b/crates/protocol/derive/src/test_utils/pipeline.rs
@@ -17,10 +17,10 @@ use crate::{
     test_utils::{TestAttributesBuilder, TestDAP},
 };
 
-/// A fully custom [NextAttributes].
+/// A fully custom [`NextAttributes`].
 #[derive(Default, Debug, Clone)]
 pub struct TestNextAttributes {
-    /// The next [OpAttributesWithParent] to return.
+    /// The next [`OpAttributesWithParent`] to return.
     pub next_attributes: Option<OpAttributesWithParent>,
 }
 
@@ -50,40 +50,40 @@ impl OriginAdvancer for TestNextAttributes {
 
 #[async_trait::async_trait]
 impl NextAttributes for TestNextAttributes {
-    /// Returns the next valid [OpAttributesWithParent].
+    /// Returns the next valid [`OpAttributesWithParent`].
     async fn next_attributes(&mut self, _: L2BlockInfo) -> PipelineResult<OpAttributesWithParent> {
         self.next_attributes.take().ok_or(PipelineError::Eof.temp())
     }
 }
 
-/// An [L1Traversal] using test providers and sources.
+/// An [`L1Traversal`] using test providers and sources.
 pub type TestL1Traversal = L1Traversal<TestChainProvider>;
 
-/// An [L1Retrieval] stage using test providers and sources.
+/// An [`L1Retrieval`] stage using test providers and sources.
 pub type TestL1Retrieval = L1Retrieval<TestDAP, TestL1Traversal>;
 
-/// A [FrameQueue] using test providers and sources.
+/// A [`FrameQueue`] using test providers and sources.
 pub type TestFrameQueue = FrameQueue<TestL1Retrieval>;
 
-/// A [ChannelBank] using test providers and sources.
+/// A [`ChannelBank`] using test providers and sources.
 pub type TestChannelProvider = ChannelProvider<TestFrameQueue>;
 
-/// A [ChannelReader] using test providers and sources.
+/// A [`ChannelReader`] using test providers and sources.
 pub type TestChannelReader = ChannelReader<TestChannelProvider>;
 
-/// A [BatchStream] using test providers and sources.
+/// A [`BatchStream`] using test providers and sources.
 pub type TestBatchStream = BatchStream<TestChannelReader, TestL2ChainProvider>;
 
-/// A [BatchQueue] using test providers and sources.
+/// A [`BatchQueue`] using test providers and sources.
 pub type TestBatchProvider = BatchProvider<TestBatchStream, TestL2ChainProvider>;
 
-/// An [AttributesQueue] using test providers and sources.
+/// An [`AttributesQueue`] using test providers and sources.
 pub type TestAttributesQueue = AttributesQueue<TestBatchProvider, TestAttributesBuilder>;
 
-/// A [DerivationPipeline] using test providers and sources.
+/// A [`DerivationPipeline`] using test providers and sources.
 pub type TestPipeline = DerivationPipeline<TestAttributesQueue, TestL2ChainProvider>;
 
-/// Constructs a [DerivationPipeline] using test providers and sources.
+/// Constructs a [`DerivationPipeline`] using test providers and sources.
 pub fn new_test_pipeline() -> TestPipeline {
     PipelineBuilder::new()
         .rollup_config(Arc::new(RollupConfig::default()))

--- a/crates/protocol/derive/src/test_utils/sys_config_fetcher.rs
+++ b/crates/protocol/derive/src/test_utils/sys_config_fetcher.rs
@@ -15,7 +15,7 @@ use thiserror::Error;
 /// A mock implementation of the `SystemConfigL2Fetcher` for testing.
 #[derive(Debug, Default)]
 pub struct TestSystemConfigL2Fetcher {
-    /// A map from [u64] block number to a [SystemConfig].
+    /// A map from [u64] block number to a [`SystemConfig`].
     pub system_configs: HashMap<u64, SystemConfig>,
 }
 
@@ -31,7 +31,7 @@ impl TestSystemConfigL2Fetcher {
     }
 }
 
-/// An error returned by the [TestSystemConfigL2Fetcher].
+/// An error returned by the [`TestSystemConfigL2Fetcher`].
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum TestSystemConfigL2FetcherError {
     /// The system config was not found.

--- a/crates/protocol/derive/src/traits/attributes.rs
+++ b/crates/protocol/derive/src/traits/attributes.rs
@@ -7,9 +7,9 @@ use async_trait::async_trait;
 use kona_protocol::{L2BlockInfo, OpAttributesWithParent, SingleBatch};
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 
-/// [AttributesProvider] is a trait abstraction that generalizes the [BatchQueue] stage.
+/// [`AttributesProvider`] is a trait abstraction that generalizes the [`BatchQueue`] stage.
 ///
-/// [BatchQueue]: crate::stages::BatchQueue
+/// [`BatchQueue`]: crate::stages::BatchQueue
 #[async_trait]
 pub trait AttributesProvider {
     /// Returns the next valid batch upon the given safe head.
@@ -19,25 +19,25 @@ pub trait AttributesProvider {
     fn is_last_in_span(&self) -> bool;
 }
 
-/// [NextAttributes] defines the interface for pulling attributes from
+/// [`NextAttributes`] defines the interface for pulling attributes from
 /// the top level `AttributesQueue` stage of the pipeline.
 #[async_trait]
 pub trait NextAttributes {
-    /// Returns the next [OpAttributesWithParent] from the current batch.
+    /// Returns the next [`OpAttributesWithParent`] from the current batch.
     async fn next_attributes(
         &mut self,
         parent: L2BlockInfo,
     ) -> PipelineResult<OpAttributesWithParent>;
 }
 
-/// The [AttributesBuilder] is responsible for preparing [OpPayloadAttributes]
+/// The [`AttributesBuilder`] is responsible for preparing [`OpPayloadAttributes`]
 /// that can be used to construct an L2 Block containing only deposits.
 #[async_trait]
 pub trait AttributesBuilder {
-    /// Prepares a template [OpPayloadAttributes] that is ready to be used to build an L2
+    /// Prepares a template [`OpPayloadAttributes`] that is ready to be used to build an L2
     /// block. The block will contain deposits only, on top of the given L2 parent, with the L1
     /// origin set to the given epoch.
-    /// By default, the [OpPayloadAttributes] template will have `no_tx_pool` set to true,
+    /// By default, the [`OpPayloadAttributes`] template will have `no_tx_pool` set to true,
     /// and no sequencer transactions. The caller has to modify the template to add transactions.
     /// This can be done by either setting the `no_tx_pool` to false as sequencer, or by appending
     /// batch transactions as the verifier.

--- a/crates/protocol/derive/src/traits/data_sources.rs
+++ b/crates/protocol/derive/src/traits/data_sources.rs
@@ -12,7 +12,7 @@ use kona_protocol::BlockInfo;
 /// The BlobProvider trait specifies the functionality of a data source that can provide blobs.
 #[async_trait]
 pub trait BlobProvider {
-    /// The error type for the [BlobProvider].
+    /// The error type for the [`BlobProvider`].
     type Error: Display + ToString + Into<PipelineErrorKind>;
 
     /// Fetches blobs for a given block ref and the blob hashes.
@@ -29,7 +29,7 @@ pub trait DataAvailabilityProvider {
     /// The item type of the data iterator.
     type Item: Send + Sync + Debug + Into<Bytes>;
 
-    /// Returns the next data for the given [BlockInfo], looking for transactions sent by the
+    /// Returns the next data for the given [`BlockInfo`], looking for transactions sent by the
     /// `batcher_addr`. Returns a `PipelineError::Eof` if there is no more data for the given
     /// block ref.
     async fn next(

--- a/crates/protocol/derive/src/traits/pipeline.rs
+++ b/crates/protocol/derive/src/traits/pipeline.rs
@@ -11,7 +11,7 @@ use crate::{errors::PipelineErrorKind, traits::OriginProvider, types::StepResult
 /// This trait defines the interface for interacting with the derivation pipeline.
 #[async_trait]
 pub trait Pipeline: OriginProvider + Iterator<Item = OpAttributesWithParent> {
-    /// Peeks at the next [OpAttributesWithParent] from the pipeline.
+    /// Peeks at the next [`OpAttributesWithParent`] from the pipeline.
     fn peek(&self) -> Option<&OpAttributesWithParent>;
 
     /// Attempts to progress the pipeline.
@@ -20,7 +20,7 @@ pub trait Pipeline: OriginProvider + Iterator<Item = OpAttributesWithParent> {
     /// Returns the rollup config.
     fn rollup_config(&self) -> &RollupConfig;
 
-    /// Returns the [SystemConfig] by L2 number.
+    /// Returns the [`SystemConfig`] by L2 number.
     async fn system_config_by_number(
         &mut self,
         number: u64,

--- a/crates/protocol/derive/src/traits/providers.rs
+++ b/crates/protocol/derive/src/traits/providers.rs
@@ -12,10 +12,10 @@ use kona_protocol::{BatchValidationProvider, BlockInfo};
 /// Describes the functionality of a data source that can provide information from the blockchain.
 #[async_trait]
 pub trait ChainProvider {
-    /// The error type for the [ChainProvider].
+    /// The error type for the [`ChainProvider`].
     type Error: Display + Into<PipelineErrorKind>;
 
-    /// Fetch the L1 [Header] for the given [B256] hash.
+    /// Fetch the L1 [`Header`] for the given [`B256`] hash.
     async fn header_by_hash(&mut self, hash: B256) -> Result<Header, Self::Error>;
 
     /// Returns the block at the given number, or an error if the block does not exist in the data
@@ -26,7 +26,7 @@ pub trait ChainProvider {
     /// exist in the data source.
     async fn receipts_by_hash(&mut self, hash: B256) -> Result<Vec<Receipt>, Self::Error>;
 
-    /// Returns the [BlockInfo] and list of [TxEnvelope]s from the given block hash.
+    /// Returns the [`BlockInfo`] and list of [`TxEnvelope`]s from the given block hash.
     async fn block_info_and_transactions_by_hash(
         &mut self,
         hash: B256,
@@ -36,10 +36,10 @@ pub trait ChainProvider {
 /// Describes the functionality of a data source that fetches safe blocks.
 #[async_trait]
 pub trait L2ChainProvider: BatchValidationProviderDerive {
-    /// The error type for the [L2ChainProvider].
+    /// The error type for the [`L2ChainProvider`].
     type Error: Display + Into<PipelineErrorKind>;
 
-    /// Returns the [SystemConfig] by L2 number.
+    /// Returns the [`SystemConfig`] by L2 number.
     async fn system_config_by_number(
         &mut self,
         number: u64,
@@ -47,8 +47,8 @@ pub trait L2ChainProvider: BatchValidationProviderDerive {
     ) -> Result<SystemConfig, <Self as L2ChainProvider>::Error>;
 }
 
-/// A super-trait for [BatchValidationProvider] that binds `Self::Error` to have a conversion into
-/// [PipelineErrorKind].
+/// A super-trait for [`BatchValidationProvider`] that binds `Self::Error` to have a conversion into
+/// [`PipelineErrorKind`].
 pub trait BatchValidationProviderDerive: BatchValidationProvider {}
 
 // Auto-implement the [BatchValidationProviderDerive] trait for all types that implement

--- a/crates/protocol/derive/src/traits/reset.rs
+++ b/crates/protocol/derive/src/traits/reset.rs
@@ -5,12 +5,12 @@ use async_trait::async_trait;
 use kona_genesis::SystemConfig;
 use kona_protocol::BlockInfo;
 
-/// Provides the [BlockInfo] and [SystemConfig] for the stack to reset the stages.
+/// Provides the [`BlockInfo`] and [`SystemConfig`] for the stack to reset the stages.
 #[async_trait]
 pub trait ResetProvider {
-    /// Returns the current [BlockInfo] for the pipeline to reset.
+    /// Returns the current [`BlockInfo`] for the pipeline to reset.
     async fn block_info(&self) -> BlockInfo;
 
-    /// Returns the current [SystemConfig] for the pipeline to reset.
+    /// Returns the current [`SystemConfig`] for the pipeline to reset.
     async fn system_config(&self) -> SystemConfig;
 }

--- a/crates/protocol/derive/src/traits/stages.rs
+++ b/crates/protocol/derive/src/traits/stages.rs
@@ -15,7 +15,7 @@ pub trait SignalReceiver {
 
 /// Provides a method for accessing the pipeline's current L1 origin.
 pub trait OriginProvider {
-    /// Returns the optional L1 [BlockInfo] origin.
+    /// Returns the optional L1 [`BlockInfo`] origin.
     fn origin(&self) -> Option<BlockInfo>;
 }
 

--- a/crates/protocol/derive/src/types/signals.rs
+++ b/crates/protocol/derive/src/types/signals.rs
@@ -33,7 +33,7 @@ impl core::fmt::Display for Signal {
 }
 
 impl Signal {
-    /// Sets the [SystemConfig] for the signal.
+    /// Sets the [`SystemConfig`] for the signal.
     pub const fn with_system_config(self, system_config: SystemConfig) -> Self {
         match self {
             Self::Reset(reset) => reset.with_system_config(system_config).signal(),
@@ -51,17 +51,17 @@ pub struct ResetSignal {
     pub l2_safe_head: L2BlockInfo,
     /// The L1 origin to reset to.
     pub l1_origin: BlockInfo,
-    /// The optional [SystemConfig] to reset with.
+    /// The optional [`SystemConfig`] to reset with.
     pub system_config: Option<SystemConfig>,
 }
 
 impl ResetSignal {
-    /// Creates a new [Signal::Reset] from the [ResetSignal].
+    /// Creates a new [Signal::Reset] from the [`ResetSignal`].
     pub const fn signal(self) -> Signal {
         Signal::Reset(self)
     }
 
-    /// Sets the [SystemConfig] for the signal.
+    /// Sets the [`SystemConfig`] for the signal.
     pub const fn with_system_config(self, system_config: SystemConfig) -> Self {
         Self { system_config: Some(system_config), ..self }
     }
@@ -74,17 +74,17 @@ pub struct ActivationSignal {
     pub l2_safe_head: L2BlockInfo,
     /// The L1 origin to reset to.
     pub l1_origin: BlockInfo,
-    /// The optional [SystemConfig] to reset with.
+    /// The optional [`SystemConfig`] to reset with.
     pub system_config: Option<SystemConfig>,
 }
 
 impl ActivationSignal {
-    /// Creates a new [Signal::Activation] from the [ActivationSignal].
+    /// Creates a new [Signal::Activation] from the [`ActivationSignal`].
     pub const fn signal(self) -> Signal {
         Signal::Activation(self)
     }
 
-    /// Sets the [SystemConfig] for the signal.
+    /// Sets the [`SystemConfig`] for the signal.
     pub const fn with_system_config(self, system_config: SystemConfig) -> Self {
         Self { system_config: Some(system_config), ..self }
     }


### PR DESCRIPTION
### Description

Teeny PR to fix code comments in `kona-derive` to use backticks.