### PR TITLE
chore(genesis): Remove Deprecated HardforkConfig Alias

### DIFF
--- a/crates/protocol/genesis/src/lib.rs
+++ b/crates/protocol/genesis/src/lib.rs
@@ -48,10 +48,6 @@ pub use system::{
     SystemConfigUpdateKind, UnsafeBlockSignerUpdateError,
 };
 
-/// An alias for the hardfork configuration.
-#[deprecated(note = "Use `HardForkConfig` instead")]
-pub type HardForkConfiguration = HardForkConfig;
-
 mod chain;
 pub use chain::{
     AddressList, AltDAConfig, BASE_MAINNET_CHAIN_ID, BASE_SEPOLIA_CHAIN_ID, ChainConfig,


### PR DESCRIPTION
### Description

Very small PR to remove the deprecated alias to the `HardforkConfig`.