### PR TITLE
chore(workspace): Use `rustls` over `request`'s default TLS feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3519,6 +3519,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots 1.0.0",
 ]
 
 [[package]]
@@ -7363,6 +7364,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -7370,6 +7373,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -7377,6 +7381,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 1.0.0",
 ]
 
 [[package]]

--- a/crates/node/engine/Cargo.toml
+++ b/crates/node/engine/Cargo.toml
@@ -25,7 +25,7 @@ alloy-network.workspace = true
 alloy-network-primitives.workspace = true
 alloy-transport.workspace = true
 alloy-primitives.workspace = true
-alloy-provider = { workspace = true, features = ["ipc", "reqwest", "reqwest-default-tls", "engine-api"] }
+alloy-provider = { workspace = true, features = ["ipc", "reqwest", "reqwest-rustls-tls", "engine-api"] }
 alloy-rpc-client.workspace = true
 alloy-rpc-types-eth.workspace = true
 alloy-rpc-types-engine = { workspace = true, features = ["jwt", "serde"] }

--- a/crates/node/service/Cargo.toml
+++ b/crates/node/service/Cargo.toml
@@ -29,10 +29,10 @@ alloy-primitives.workspace = true
 alloy-rpc-client.workspace = true
 alloy-rpc-types-eth.workspace = true
 alloy-rpc-types-engine = { workspace = true, features = ["jwt", "serde"] }
-alloy-provider = { workspace = true, features = ["reqwest", "reqwest-default-tls", "hyper", "hyper-tls"] }
+alloy-provider = { workspace = true, features = ["reqwest", "reqwest-rustls-tls", "hyper", "hyper-tls"] }
 alloy-eips.workspace = true
 alloy-transport.workspace = true
-alloy-transport-http = { workspace = true, features = ["reqwest", "reqwest-default-tls", "hyper", "hyper-tls", "jwt-auth"] }
+alloy-transport-http = { workspace = true, features = ["reqwest", "reqwest-rustls-tls", "hyper", "hyper-tls", "jwt-auth"] }
 
 # op-alloy
 op-alloy-network.workspace = true

--- a/crates/node/sources/Cargo.toml
+++ b/crates/node/sources/Cargo.toml
@@ -23,7 +23,7 @@ kona-providers-alloy.workspace = true
 
 # Alloy
 alloy-eips.workspace = true
-alloy-provider = { workspace = true, features = ["reqwest", "reqwest-default-tls", "hyper", "hyper-tls"] }
+alloy-provider = { workspace = true, features = ["reqwest", "reqwest-rustls-tls", "hyper", "hyper-tls"] }
 alloy-transport.workspace = true
 alloy-primitives.workspace = true
 

--- a/crates/providers/providers-alloy/Cargo.toml
+++ b/crates/providers/providers-alloy/Cargo.toml
@@ -22,7 +22,7 @@ kona-derive.workspace = true
 alloy-serde.workspace = true
 alloy-eips = { workspace = true, features = ["kzg"] }
 alloy-transport.workspace = true
-alloy-transport-http = { workspace = true, features = ["reqwest", "reqwest-default-tls", "hyper", "hyper-tls", "jwt-auth"] }
+alloy-transport-http = { workspace = true, features = ["reqwest", "reqwest-rustls-tls", "hyper", "hyper-tls", "jwt-auth"] }
 alloy-consensus.workspace = true
 alloy-rpc-types-beacon.workspace = true
 alloy-rpc-types-engine.workspace = true

--- a/docker/apps/kona_app_generic.dockerfile
+++ b/docker/apps/kona_app_generic.dockerfile
@@ -87,6 +87,11 @@ SHELL ["/bin/bash", "-c"]
 ARG BIN_TARGET
 ARG BUILD_PROFILE
 
+# Install ca-certificates and libssl-dev for TLS support.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  ca-certificates \
+  libssl-dev
+
 # Copy in the binary from the build image.
 COPY --from=builder "app/target/${BUILD_PROFILE}/${BIN_TARGET}" "/usr/local/bin/${BIN_TARGET}"
 


### PR DESCRIPTION
## Overview

Uses `rustls` over `request-default-tls`.