### PR TITLE
chore(bin/node): Improve error verbosity for runtime loader failure

### DIFF
--- a/bin/node/src/flags/p2p.rs
+++ b/bin/node/src/flags/p2p.rs
@@ -320,10 +320,9 @@ impl P2PArgs {
         // First attempt to load the unsafe block signer from the runtime loader.
         if let Some(url) = l1_rpc {
             let mut loader = RuntimeLoader::new(url, Arc::new(config.clone()));
-            let runtime = loader
-                .load_latest()
-                .await
-                .map_err(|e| anyhow::anyhow!("Failed to load runtime: {}", e))?;
+            let runtime = loader.load_latest().await.map_err(|e| {
+                anyhow::anyhow!("Failed to load runtime: {} {:?}", e, std::error::Error::source(&e))
+            })?;
             return Ok(runtime.unsafe_block_signer_address);
         }
 


### PR DESCRIPTION
## Overview

Includes the source of the error when a failure happens during initial runtime configuration loading.