### PR TITLE
chore(hardforks): Code Comment References

### DIFF
--- a/crates/protocol/hardforks/src/ecotone.rs
+++ b/crates/protocol/hardforks/src/ecotone.rs
@@ -1,4 +1,4 @@
-//! Module containing a [TxDeposit] builder for the Ecotone network upgrade transactions.
+//! Module containing a [`TxDeposit`] builder for the Ecotone network upgrade transactions.
 
 use alloc::{string::String, vec::Vec};
 use alloy_eips::eip2718::Encodable2718;
@@ -108,7 +108,7 @@ impl Ecotone {
             .into()
     }
 
-    /// Returns the list of [TxDeposit]s for the Ecotone network upgrade.
+    /// Returns the list of [`TxDeposit`]s for the Ecotone network upgrade.
     pub fn deposits() -> impl Iterator<Item = TxDeposit> {
         ([
             // Deploy the L1 Block contract for Ecotone.

--- a/crates/protocol/hardforks/src/fjord.rs
+++ b/crates/protocol/hardforks/src/fjord.rs
@@ -1,4 +1,4 @@
-//! Module containing a [TxDeposit] builder for the Fjord network upgrade transactions.
+//! Module containing a [`TxDeposit`] builder for the Fjord network upgrade transactions.
 
 use alloc::{string::String, vec::Vec};
 use alloy_eips::eip2718::Encodable2718;
@@ -63,7 +63,7 @@ impl Fjord {
             .into()
     }
 
-    /// Returns the list of [TxDeposit]s for the Fjord network upgrade.
+    /// Returns the list of [`TxDeposit`]s for the Fjord network upgrade.
     pub fn deposits() -> impl Iterator<Item = TxDeposit> {
         ([
             // Deploys the Fjord Gas Price Oracle contract.

--- a/crates/protocol/hardforks/src/forks.rs
+++ b/crates/protocol/hardforks/src/forks.rs
@@ -6,7 +6,7 @@ use crate::{Ecotone, Fjord, Interop, Isthmus};
 ///
 /// This type is used to encapsulate hardfork transactions.
 /// It exposes methods that return hardfork upgrade transactions
-/// as [alloy_primitives::Bytes].
+/// as [`alloy_primitives::Bytes`].
 ///
 /// # Example
 ///

--- a/crates/protocol/hardforks/src/interop.rs
+++ b/crates/protocol/hardforks/src/interop.rs
@@ -1,4 +1,4 @@
-//! Module containing a [TxDeposit] builder for the Interop network upgrade transactions.
+//! Module containing a [`TxDeposit`] builder for the Interop network upgrade transactions.
 //!
 //! Interop network upgrade transactions are defined in the [OP Stack Specs][specs].
 //!

--- a/crates/protocol/hardforks/src/isthmus.rs
+++ b/crates/protocol/hardforks/src/isthmus.rs
@@ -1,4 +1,4 @@
-//! Module containing a [TxDeposit] builder for the Isthmus network upgrade transactions.
+//! Module containing a [`TxDeposit`] builder for the Isthmus network upgrade transactions.
 //!
 //! Isthmus network upgrade transactions are defined in the [OP Stack Specs][specs].
 //!
@@ -145,7 +145,7 @@ impl Isthmus {
             .into()
     }
 
-    /// Returns the list of [TxDeposit]s for the network upgrade.
+    /// Returns the list of [`TxDeposit`]s for the network upgrade.
     pub fn deposits() -> impl Iterator<Item = TxDeposit> {
         ([
             TxDeposit {

--- a/crates/protocol/hardforks/src/traits.rs
+++ b/crates/protocol/hardforks/src/traits.rs
@@ -4,6 +4,6 @@ use alloy_primitives::Bytes;
 
 /// The trait abstraction for a Hardfork.
 pub trait Hardfork {
-    /// Returns the hardfork upgrade transactions as [Bytes].
+    /// Returns the hardfork upgrade transactions as [`Bytes`].
     fn txs(&self) -> impl Iterator<Item = Bytes> + '_;
 }


### PR DESCRIPTION
### Description

Properly use backtick code comment references in `kona-hardforks`.