### PR TITLE
chore(node/service): remove process method from NodeActor trait

### DIFF
--- a/crates/node/service/src/actors/l1_watcher_rpc.rs
+++ b/crates/node/service/src/actors/l1_watcher_rpc.rs
@@ -143,7 +143,6 @@ impl L1WatcherRpc {
 
 #[async_trait]
 impl NodeActor for L1WatcherRpc {
-    type InboundEvent = ();
     type Error = L1WatcherRpcError<BlockInfo>;
 
     async fn start(mut self) -> Result<(), Self::Error> {
@@ -221,11 +220,6 @@ impl NodeActor for L1WatcherRpc {
                 }
             }
         }
-    }
-
-    async fn process(&mut self, _msg: Self::InboundEvent) -> Result<(), Self::Error> {
-        // The L1 watcher does not process any incoming messages.
-        Ok(())
     }
 }
 

--- a/crates/node/service/src/actors/network.rs
+++ b/crates/node/service/src/actors/network.rs
@@ -64,7 +64,6 @@ impl NetworkActor {
 
 #[async_trait]
 impl NodeActor for NetworkActor {
-    type InboundEvent = ();
     type Error = NetworkActorError;
 
     async fn start(mut self) -> Result<(), Self::Error> {
@@ -117,10 +116,6 @@ impl NodeActor for NetworkActor {
                 }
             }
         }
-    }
-
-    async fn process(&mut self, _: Self::InboundEvent) -> Result<(), Self::Error> {
-        Ok(())
     }
 }
 

--- a/crates/node/service/src/actors/rpc.rs
+++ b/crates/node/service/src/actors/rpc.rs
@@ -41,7 +41,6 @@ impl RpcActor {
 
 #[async_trait]
 impl NodeActor for RpcActor {
-    type InboundEvent = ();
     type Error = RpcActorError;
 
     async fn start(mut self) -> Result<(), Self::Error> {
@@ -80,9 +79,5 @@ impl NodeActor for RpcActor {
         // Stop the node if there has already been 3 rpc restarts.
         self.cancellation.cancel();
         return Err(RpcActorError::ServerStopped);
-    }
-
-    async fn process(&mut self, _: Self::InboundEvent) -> Result<(), Self::Error> {
-        Ok(())
     }
 }

--- a/crates/node/service/src/actors/runtime.rs
+++ b/crates/node/service/src/actors/runtime.rs
@@ -78,7 +78,6 @@ impl RuntimeLauncher {
 
 #[async_trait]
 impl NodeActor for RuntimeActor {
-    type InboundEvent = ();
     type Error = RuntimeLoaderError;
 
     async fn start(mut self) -> Result<(), Self::Error> {
@@ -98,10 +97,5 @@ impl NodeActor for RuntimeActor {
                 }
             }
         }
-    }
-
-    async fn process(&mut self, e: Self::InboundEvent) -> Result<(), Self::Error> {
-        trace!(target: "runtime", ?e, "Runtime Actor received unexpected inbound event. Ignoring.");
-        Ok(())
     }
 }

--- a/crates/node/service/src/actors/supervisor/actor.rs
+++ b/crates/node/service/src/actors/supervisor/actor.rs
@@ -47,7 +47,6 @@ impl<E> NodeActor for SupervisorActor<E>
 where
     E: SupervisorExt + Send + Sync,
 {
-    type InboundEvent = ();
     type Error = SupervisorActorError;
 
     async fn start(mut self) -> Result<(), Self::Error> {
@@ -74,11 +73,6 @@ where
                 },
             }
         }
-    }
-
-    async fn process(&mut self, _msg: Self::InboundEvent) -> Result<(), Self::Error> {
-        // The supervisor actor does not process any incoming messages.
-        Ok(())
     }
 }
 

--- a/crates/node/service/src/actors/traits.rs
+++ b/crates/node/service/src/actors/traits.rs
@@ -10,14 +10,9 @@ use async_trait::async_trait;
 /// - Emit new events for other actors to process.
 #[async_trait]
 pub trait NodeActor {
-    /// The event type received by the actor.
-    type InboundEvent;
     /// The error type for the actor.
     type Error: std::fmt::Debug;
 
     /// Starts the actor.
     async fn start(self) -> Result<(), Self::Error>;
-
-    /// Processes an incoming message.
-    async fn process(&mut self, msg: Self::InboundEvent) -> Result<(), Self::Error>;
 }


### PR DESCRIPTION
## Description

This PR removes the `process` method from `NodeActor` trait to simplify the structure of the `NodeActor`

Progress to #2176