### PR TITLE
chore(node/service): refactor node actor trait. take context out of the actor

### DIFF
--- a/crates/node/service/src/actors/engine/mod.rs
+++ b/crates/node/service/src/actors/engine/mod.rs
@@ -1,7 +1,7 @@
 //! The [`EngineActor`] and its components.
 
 mod actor;
-pub use actor::{EngineActor, EngineLauncher, InboundEngineMessage};
+pub use actor::{EngineActor, EngineContext, EngineLauncher, InboundEngineMessage};
 
 mod error;
 pub use error::EngineError;

--- a/crates/node/service/src/actors/mod.rs
+++ b/crates/node/service/src/actors/mod.rs
@@ -3,27 +3,32 @@
 //! [NodeActor]: super::NodeActor
 
 mod traits;
-pub use traits::NodeActor;
+pub use traits::{ActorContext, NodeActor};
 
 mod runtime;
-pub use runtime::{RuntimeActor, RuntimeLauncher};
+pub use runtime::{RuntimeActor, RuntimeContext, RuntimeLauncher};
 
 mod engine;
-pub use engine::{EngineActor, EngineError, EngineLauncher, InboundEngineMessage, L2Finalizer};
+pub use engine::{
+    EngineActor, EngineContext, EngineError, EngineLauncher, InboundEngineMessage, L2Finalizer,
+};
 
 mod supervisor;
 pub use supervisor::{
-    SupervisorActor, SupervisorActorError, SupervisorExt, SupervisorRpcServerExt,
+    SupervisorActor, SupervisorActorContext, SupervisorActorError, SupervisorExt,
+    SupervisorRpcServerExt,
 };
 
 mod rpc;
-pub use rpc::{RpcActor, RpcActorError};
+pub use rpc::{RpcActor, RpcActorError, RpcContext};
 
 mod derivation;
-pub use derivation::{DerivationActor, DerivationError, InboundDerivationMessage};
+pub use derivation::{
+    DerivationActor, DerivationContext, DerivationError, InboundDerivationMessage,
+};
 
 mod l1_watcher_rpc;
-pub use l1_watcher_rpc::{L1WatcherRpc, L1WatcherRpcError};
+pub use l1_watcher_rpc::{L1WatcherRpc, L1WatcherRpcContext, L1WatcherRpcError};
 
 mod network;
-pub use network::{NetworkActor, NetworkActorError};
+pub use network::{NetworkActor, NetworkActorError, NetworkContext};

--- a/crates/node/service/src/actors/supervisor/mod.rs
+++ b/crates/node/service/src/actors/supervisor/mod.rs
@@ -4,7 +4,7 @@ mod traits;
 pub use traits::SupervisorExt;
 
 mod actor;
-pub use actor::{SupervisorActor, SupervisorActorError};
+pub use actor::{SupervisorActor, SupervisorActorContext, SupervisorActorError};
 
 mod ext;
 pub use ext::SupervisorRpcServerExt;

--- a/crates/node/service/src/actors/traits.rs
+++ b/crates/node/service/src/actors/traits.rs
@@ -1,6 +1,13 @@
 //! [NodeActor] trait.
 
 use async_trait::async_trait;
+use tokio_util::sync::WaitForCancellationFuture;
+
+/// The communication context used by the actor.
+pub trait ActorContext: Send {
+    /// Returns a future that resolves when the actor is cancelled.
+    fn cancelled(&self) -> WaitForCancellationFuture<'_>;
+}
 
 /// The [NodeActor] is an actor-like service for the node.
 ///
@@ -12,7 +19,9 @@ use async_trait::async_trait;
 pub trait NodeActor {
     /// The error type for the actor.
     type Error: std::fmt::Debug;
+    /// The communication context used by the actor.
+    type Context: ActorContext;
 
     /// Starts the actor.
-    async fn start(self) -> Result<(), Self::Error>;
+    async fn start(self, context: Self::Context) -> Result<(), Self::Error>;
 }

--- a/crates/node/service/src/lib.rs
+++ b/crates/node/service/src/lib.rs
@@ -14,10 +14,12 @@ pub use service::{NodeMode, RollupNode, RollupNodeBuilder, RollupNodeError, Roll
 
 mod actors;
 pub use actors::{
-    DerivationActor, DerivationError, EngineActor, EngineError, EngineLauncher,
-    InboundDerivationMessage, InboundEngineMessage, L1WatcherRpc, L1WatcherRpcError, L2Finalizer,
-    NetworkActor, NetworkActorError, NodeActor, RpcActor, RpcActorError, RuntimeActor,
-    RuntimeLauncher, SupervisorActor, SupervisorActorError, SupervisorExt, SupervisorRpcServerExt,
+    ActorContext, DerivationActor, DerivationContext, DerivationError, EngineActor, EngineContext,
+    EngineError, EngineLauncher, InboundDerivationMessage, InboundEngineMessage, L1WatcherRpc,
+    L1WatcherRpcContext, L1WatcherRpcError, L2Finalizer, NetworkActor, NetworkActorError,
+    NetworkContext, NodeActor, RpcActor, RpcActorError, RpcContext, RuntimeActor, RuntimeContext,
+    RuntimeLauncher, SupervisorActor, SupervisorActorContext, SupervisorActorError, SupervisorExt,
+    SupervisorRpcServerExt,
 };
 
 mod metrics;

--- a/crates/node/service/src/service/core.rs
+++ b/crates/node/service/src/service/core.rs
@@ -73,8 +73,8 @@ pub trait RollupNodeService {
         finalized_updates: watch::Sender<Option<BlockInfo>>,
         block_signer_tx: mpsc::Sender<Address>,
         cancellation: CancellationToken,
-        l1_watcher_inbound_queries: Option<mpsc::Receiver<L1WatcherQueries>>,
-    ) -> Self::DataAvailabilityWatcher;
+        l1_watcher_inbound_queries: mpsc::Receiver<L1WatcherQueries>,
+    ) -> (Self::DataAvailabilityWatcher, <Self::DataAvailabilityWatcher as NodeActor>::Context);
 
     /// Creates a new instance of the [`Pipeline`] and initializes it. Returns the starting L2
     /// forkchoice state and the initialized derivation pipeline.
@@ -110,7 +110,7 @@ pub trait RollupNodeService {
         // Create a global cancellation token for graceful shutdown of tasks.
         let cancellation = CancellationToken::new();
 
-        // Create channels for communication between actors.
+        // Create context for communication between actors.
         let (sync_complete_tx, sync_complete_rx) = oneshot::channel();
         let (derived_payload_tx, derived_payload_rx) = mpsc::channel(16);
         let (runtime_config_tx, runtime_config_rx) = mpsc::channel(16);
@@ -130,7 +130,7 @@ pub trait RollupNodeService {
             finalized_updates_tx,
             block_signer_tx,
             cancellation.clone(),
-            Some(l1_watcher_queries_recv),
+            l1_watcher_queries_recv,
         );
 
         // Create the derivation actor.

--- a/crates/node/service/src/service/standard/node.rs
+++ b/crates/node/service/src/service/standard/node.rs
@@ -1,8 +1,8 @@
 //! Contains the [`RollupNode`] implementation.
 
 use crate::{
-    EngineLauncher, L1WatcherRpc, NodeMode, RollupNodeBuilder, RollupNodeError, RollupNodeService,
-    RuntimeLauncher, SupervisorRpcServerExt,
+    EngineLauncher, L1WatcherRpc, NodeActor, NodeMode, RollupNodeBuilder, RollupNodeError,
+    RollupNodeService, RuntimeLauncher, SupervisorRpcServerExt,
 };
 use alloy_primitives::Address;
 use alloy_provider::RootProvider;
@@ -80,8 +80,9 @@ impl RollupNodeService for RollupNode {
         finalized_updates: watch::Sender<Option<BlockInfo>>,
         block_signer_tx: mpsc::Sender<Address>,
         cancellation: CancellationToken,
-        l1_watcher_inbound_queries: Option<tokio::sync::mpsc::Receiver<L1WatcherQueries>>,
-    ) -> Self::DataAvailabilityWatcher {
+        l1_watcher_inbound_queries: mpsc::Receiver<L1WatcherQueries>,
+    ) -> (Self::DataAvailabilityWatcher, <Self::DataAvailabilityWatcher as NodeActor>::Context)
+    {
         L1WatcherRpc::new(
             self.config.clone(),
             self.l1_provider.clone(),

--- a/crates/node/service/src/service/util.rs
+++ b/crates/node/service/src/service/util.rs
@@ -14,9 +14,9 @@ macro_rules! spawn_and_wait {
 
         // Check if the actor is present, and spawn it if it is.
         $(
-            if let Some(actor) = $actor {
+            if let Some((actor, context)) = $actor {
                 task_handles.spawn(async move {
-                    if let Err(e) = actor.start().await {
+                    if let Err(e) = actor.start(context).await {
                         return Err(format!("{e:?}"));
                     }
                     Ok(())


### PR DESCRIPTION
## Description

First attempt to decouple channel handling from the individual actors. This PR merely refactors the `NodeActor` trait to add a `Context` associated type that gets passed to the `start` method in the trait.

I think from here we can make the structure simpler by:
- Refactoring the `process` private methods into separate methods. That should remove the extra arguments for the `EngineActor`
- Abstracting the actor building process behind the `new` methods of the individual actors. In particular, split up the context using inbound/outbound associated types and define channels inside the actor's `new` methods.