### PR TITLE
feat(supervisor/syncnode): Observe `ManagedModeApiClient` RPC calls

### DIFF
--- a/crates/supervisor/core/src/syncnode/metrics.rs
+++ b/crates/supervisor/core/src/syncnode/metrics.rs
@@ -77,7 +77,7 @@ impl Metrics {
     }
 }
 
-/// See [`observe_rpc_call`](crate::rpc::observe_rpc_call).
+/// See [`observe_rpc_call`](crate::observe_rpc_call).
 #[macro_export]
 macro_rules! observe_rpc_call_managed_mode {
     ($method_name:expr, $block:expr) => {{

--- a/crates/supervisor/core/src/syncnode/metrics.rs
+++ b/crates/supervisor/core/src/syncnode/metrics.rs
@@ -1,4 +1,4 @@
-//! Metrics for the Supervisor RPC service.
+//! Metrics for the Managed Mode RPC client.
 
 /// Container for metrics.
 #[derive(Debug, Clone)]

--- a/crates/supervisor/core/src/syncnode/metrics.rs
+++ b/crates/supervisor/core/src/syncnode/metrics.rs
@@ -1,0 +1,97 @@
+//! Metrics for the Supervisor RPC service.
+
+/// Container for metrics.
+#[derive(Debug, Clone)]
+pub(super) struct Metrics;
+
+impl Metrics {
+    // --- Metric Names ---
+    /// Identifier for the counter of successful RPC requests. Labels: `method`.
+    pub(crate) const MANAGED_MODE_RPC_REQUESTS_SUCCESS_TOTAL: &'static str =
+        "managed_mode_rpc_requests_success_total";
+    /// Identifier for the counter of failed RPC requests. Labels: `method`.
+    pub(crate) const MANAGED_MODE_RPC_REQUESTS_ERROR_TOTAL: &'static str =
+        "managed_mode_rpc_requests_error_total";
+    /// Identifier for the histogram of RPC request durations. Labels: `method`.
+    pub(crate) const MANAGED_MODE_RPC_REQUEST_DURATION_SECONDS: &'static str =
+        "managed_mode_rpc_request_duration_seconds";
+
+    // --- RPC Method Names (for zeroing) ---
+    /// Lists all managed mode RPC methods here to ensure they are pre-registered.
+    const RPC_METHODS: [&'static str; 5] = [
+        "fetch_receipts",
+        "output_v0_at_timestamp",
+        "pending_output_v0_at_timestamp",
+        "l2_block_ref_by_timestamp",
+        "provide_l1",
+    ];
+
+    /// Initializes metrics for the Supervisor RPC service.
+    ///
+    /// This does two things:
+    /// * Describes various metrics.
+    /// * Initializes metrics with their labels to 0 so they can be queried immediately.
+    pub(crate) fn init() {
+        Self::describe();
+        Self::zero();
+    }
+
+    /// Describes metrics used in the Supervisor RPC service.
+    fn describe() {
+        metrics::describe_counter!(
+            Self::MANAGED_MODE_RPC_REQUESTS_SUCCESS_TOTAL,
+            metrics::Unit::Count,
+            "Total number of successful RPC requests processed by the managed mode client"
+        );
+        metrics::describe_counter!(
+            Self::MANAGED_MODE_RPC_REQUESTS_ERROR_TOTAL,
+            metrics::Unit::Count,
+            "Total number of failed RPC requests processed by the managed mode client"
+        );
+        metrics::describe_histogram!(
+            Self::MANAGED_MODE_RPC_REQUEST_DURATION_SECONDS,
+            metrics::Unit::Seconds,
+            "Duration of RPC requests processed by the managed mode client"
+        );
+    }
+
+    /// Initializes metrics with their labels to `0` so they appear in Prometheus from the start.
+    fn zero() {
+        for method_name in Self::RPC_METHODS.iter() {
+            metrics::counter!(
+                Self::MANAGED_MODE_RPC_REQUESTS_SUCCESS_TOTAL,
+                "method" => *method_name
+            )
+            .increment(0);
+            metrics::counter!(
+                Self::MANAGED_MODE_RPC_REQUESTS_ERROR_TOTAL,
+                "method" => *method_name
+            )
+            .increment(0);
+            metrics::histogram!(
+                Self::MANAGED_MODE_RPC_REQUEST_DURATION_SECONDS,
+                "method" => *method_name
+            )
+            .record(0.0); // Record a zero value to ensure the label combination is present
+        }
+    }
+}
+
+/// See [`observe_rpc_call`](crate::rpc::observe_rpc_call).
+#[macro_export]
+macro_rules! observe_rpc_call_managed_mode {
+    ($method_name:expr, $block:expr) => {{
+        let start_time = std::time::Instant::now();
+        let result = $block; // Execute the provided code block
+        let duration = start_time.elapsed().as_secs_f64();
+
+        if result.is_ok() {
+            metrics::counter!($crate::syncnode::metrics::Metrics::MANAGED_MODE_RPC_REQUESTS_SUCCESS_TOTAL, "method" => $method_name).increment(1);
+        } else {
+            metrics::counter!($crate::syncnode::metrics::Metrics::MANAGED_MODE_RPC_REQUESTS_ERROR_TOTAL, "method" => $method_name).increment(1);
+        }
+
+        metrics::histogram!($crate::syncnode::metrics::Metrics::MANAGED_MODE_RPC_REQUEST_DURATION_SECONDS, "method" => $method_name).record(duration);
+        result
+    }};
+}

--- a/crates/supervisor/core/src/syncnode/mod.rs
+++ b/crates/supervisor/core/src/syncnode/mod.rs
@@ -12,3 +12,5 @@ mod traits;
 pub use traits::{ManagedNodeApiProvider, ManagedNodeProvider, NodeSubscriber, ReceiptProvider};
 
 pub use task::ManagedEventTask;
+
+pub(crate) mod metrics;

--- a/crates/supervisor/core/src/syncnode/node.rs
+++ b/crates/supervisor/core/src/syncnode/node.rs
@@ -280,15 +280,12 @@ where
 {
     async fn fetch_receipts(&self, block_hash: B256) -> Result<Receipts, ManagedNodeError> {
         let client = self.get_ws_client().await?;
-        observe_rpc_call_managed_mode!(
+        let receipts = observe_rpc_call_managed_mode!(
             "fetch_receipts",
-            async {
-                let receipts =
-                    ManagedModeApiClient::fetch_receipts(client.as_ref(), block_hash).await?;
-                Ok(receipts)
-            }
-            .await
-        )
+            ManagedModeApiClient::fetch_receipts(client.as_ref(), block_hash).await
+        )?;
+
+        Ok(receipts)
     }
 }
 
@@ -299,16 +296,12 @@ where
 {
     async fn output_v0_at_timestamp(&self, timestamp: u64) -> Result<OutputV0, ManagedNodeError> {
         let client = self.get_ws_client().await?;
-        observe_rpc_call_managed_mode!(
+        let output_v0 = observe_rpc_call_managed_mode!(
             "output_v0_at_timestamp",
-            async {
-                let output_v0 =
-                    ManagedModeApiClient::output_v0_at_timestamp(client.as_ref(), timestamp)
-                        .await?;
-                Ok(output_v0)
-            }
-            .await
-        )
+            ManagedModeApiClient::output_v0_at_timestamp(client.as_ref(), timestamp).await
+        )?;
+
+        Ok(output_v0)
     }
 
     async fn pending_output_v0_at_timestamp(
@@ -316,18 +309,12 @@ where
         timestamp: u64,
     ) -> Result<OutputV0, ManagedNodeError> {
         let client = self.get_ws_client().await?;
-        observe_rpc_call_managed_mode!(
+        let output_v0 = observe_rpc_call_managed_mode!(
             "pending_output_v0_at_timestamp",
-            async {
-                let output_v0 = ManagedModeApiClient::pending_output_v0_at_timestamp(
-                    client.as_ref(),
-                    timestamp,
-                )
-                .await?;
-                Ok(output_v0)
-            }
-            .await
-        )
+            ManagedModeApiClient::pending_output_v0_at_timestamp(client.as_ref(), timestamp,).await
+        )?;
+
+        Ok(output_v0)
     }
 
     async fn l2_block_ref_by_timestamp(
@@ -335,16 +322,12 @@ where
         timestamp: u64,
     ) -> Result<BlockInfo, ManagedNodeError> {
         let client = self.get_ws_client().await?;
-        observe_rpc_call_managed_mode!(
+        let block_info = observe_rpc_call_managed_mode!(
             "fetch_receipts",
-            async {
-                let block_info =
-                    ManagedModeApiClient::l2_block_ref_by_timestamp(client.as_ref(), timestamp)
-                        .await?;
-                Ok(block_info)
-            }
-            .await
-        )
+            ManagedModeApiClient::l2_block_ref_by_timestamp(client.as_ref(), timestamp).await
+        )?;
+
+        Ok(block_info)
     }
 }
 

--- a/crates/supervisor/core/src/syncnode/task.rs
+++ b/crates/supervisor/core/src/syncnode/task.rs
@@ -30,7 +30,7 @@ where
     DB: LogStorageReader + DerivationStorageReader + HeadRefStorageReader + Send + Sync + 'static,
 {
     /// Creates a new [`ManagedEventTask`] instance.
-    pub fn new(
+    pub const fn new(
         l1_provider: RootProvider<Ethereum>,
         db_provider: Arc<DB>,
         event_tx: mpsc::Sender<ChainEvent>,

--- a/crates/supervisor/core/src/syncnode/task.rs
+++ b/crates/supervisor/core/src/syncnode/task.rs
@@ -36,8 +36,6 @@ where
         event_tx: mpsc::Sender<ChainEvent>,
         client: Arc<WsClient>,
     ) -> Self {
-        Metrics::init();
-
         Self { l1_provider, db_provider, event_tx, client: Some(client) }
     }
 

--- a/crates/supervisor/core/src/syncnode/task.rs
+++ b/crates/supervisor/core/src/syncnode/task.rs
@@ -1,4 +1,4 @@
-use super::{ManagedEventTaskError, metrics::Metrics};
+use super::ManagedEventTaskError;
 use crate::{event::ChainEvent, observe_rpc_call_managed_mode};
 use alloy_eips::BlockNumberOrTag;
 use alloy_network::Ethereum;


### PR DESCRIPTION
Closes https://github.com/op-rs/kona/issues/2088

Implement RPC metrics for `ManagedModeApiClient` RPC calls