### PR TITLE
chore(node/service): refactor and simplify the `RollupNodeService` trait

### DIFF
--- a/crates/node/rpc/src/rollup.rs
+++ b/crates/node/rpc/src/rollup.rs
@@ -33,8 +33,11 @@ impl RollupRpc {
     pub const RPC_IDENT: &'static str = "rollup_rpc";
 
     /// Constructs a new [`RollupRpc`] given a sender channel.
-    pub const fn new(sender: EngineQuerySender, l1_watcher_sender: L1WatcherQuerySender) -> Self {
-        Self { engine_sender: sender, l1_watcher_sender }
+    pub const fn new(
+        engine_sender: EngineQuerySender,
+        l1_watcher_sender: L1WatcherQuerySender,
+    ) -> Self {
+        Self { engine_sender, l1_watcher_sender }
     }
 
     // Important note: we zero-out the fields that can't be derived yet to follow op-node's

--- a/crates/node/service/src/actors/engine/mod.rs
+++ b/crates/node/service/src/actors/engine/mod.rs
@@ -1,7 +1,10 @@
 //! The [`EngineActor`] and its components.
 
 mod actor;
-pub use actor::{EngineActor, EngineContext, EngineLauncher, InboundEngineMessage};
+pub use actor::{
+    EngineActor, EngineActorState, EngineContext, EngineLauncher, EngineOutboundData,
+    InboundEngineMessage,
+};
 
 mod error;
 pub use error::EngineError;

--- a/crates/node/service/src/actors/l1_watcher_rpc.rs
+++ b/crates/node/service/src/actors/l1_watcher_rpc.rs
@@ -1,7 +1,7 @@
 //! [`NodeActor`] implementation for an L1 chain watcher that polls for L1 block updates over HTTP
 //! RPC.
 
-use crate::{NodeActor, actors::ActorContext};
+use crate::{NodeActor, actors::CancellableContext};
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{Address, B256};
 use alloy_provider::{Provider, RootProvider};
@@ -29,29 +29,46 @@ use tokio_util::sync::{CancellationToken, WaitForCancellationFuture};
 /// An L1 chain watcher that checks for L1 block updates over RPC.
 #[derive(Debug)]
 pub struct L1WatcherRpc {
+    state: L1WatcherRpcState,
+    /// The latest L1 head block.
+    latest_head: watch::Sender<Option<BlockInfo>>,
+    /// The latest L1 finalized block.
+    latest_finalized: watch::Sender<Option<BlockInfo>>,
+    /// The block signer sender.
+    block_signer_sender: mpsc::Sender<Address>,
+}
+
+/// The configuration for the L1 watcher actor.
+#[derive(Debug)]
+pub struct L1WatcherRpcState {
     /// The [`RollupConfig`] to tell if ecotone is active.
     /// This is used to determine if the L1 watcher should check for unsafe block signer updates.
-    config: Arc<RollupConfig>,
+    pub rollup: Arc<RollupConfig>,
     /// The L1 provider.
-    l1_provider: RootProvider,
+    pub l1_provider: RootProvider,
+}
+
+/// The outbound channels for the L1 watcher actor.
+#[derive(Debug)]
+pub struct L1WatcherRpcOutboundChannels {
+    /// The latest L1 head block.
+    pub latest_head: watch::Receiver<Option<BlockInfo>>,
+    /// The latest L1 finalized block.
+    pub latest_finalized: watch::Receiver<Option<BlockInfo>>,
+    /// The block signer sender.
+    pub block_signer_sender: mpsc::Receiver<Address>,
 }
 
 /// The communication context used by the L1 watcher actor.
 #[derive(Debug)]
 pub struct L1WatcherRpcContext {
-    /// The block signer sender.
-    block_signer_sender: mpsc::Sender<Address>,
     /// The inbound queries to the L1 watcher.
-    inbound_queries: tokio::sync::mpsc::Receiver<L1WatcherQueries>,
-    /// The latest L1 head block.
-    latest_head: watch::Sender<Option<BlockInfo>>,
-    /// The latest L1 finalized block.
-    latest_finalized: watch::Sender<Option<BlockInfo>>,
+    pub inbound_queries: tokio::sync::mpsc::Receiver<L1WatcherQueries>,
     /// The cancellation token, shared between all tasks.
-    cancellation: CancellationToken,
+    pub cancellation: CancellationToken,
 }
 
-impl ActorContext for L1WatcherRpcContext {
+impl CancellableContext for L1WatcherRpcContext {
     fn cancelled(&self) -> WaitForCancellationFuture<'_> {
         self.cancellation.cancelled()
     }
@@ -59,29 +76,31 @@ impl ActorContext for L1WatcherRpcContext {
 
 impl L1WatcherRpc {
     /// Creates a new [`L1WatcherRpc`] instance.
-    pub const fn new(
-        config: Arc<RollupConfig>,
-        l1_provider: RootProvider,
-        head_updates: watch::Sender<Option<BlockInfo>>,
-        finalized_updates: watch::Sender<Option<BlockInfo>>,
-        block_signer_sender: mpsc::Sender<Address>,
-        cancellation: CancellationToken,
-        inbound_queries: mpsc::Receiver<L1WatcherQueries>,
-    ) -> (Self, L1WatcherRpcContext) {
-        let actor = Self { config, l1_provider };
-        let context = L1WatcherRpcContext {
-            block_signer_sender,
-            inbound_queries,
-            latest_head: head_updates,
-            latest_finalized: finalized_updates,
-            cancellation,
+    pub fn new(config: L1WatcherRpcState) -> (L1WatcherRpcOutboundChannels, Self) {
+        let (head_updates_tx, head_updates_rx) = watch::channel(None);
+        let (block_signer_tx, block_signer_rx) = mpsc::channel(16);
+        let (finalized_updates_tx, finalized_updates_rx) = watch::channel(None);
+
+        let actor = Self {
+            state: config,
+            latest_head: head_updates_tx,
+            latest_finalized: finalized_updates_tx,
+            block_signer_sender: block_signer_tx,
         };
-        (actor, context)
+        (
+            L1WatcherRpcOutboundChannels {
+                latest_head: head_updates_rx,
+                latest_finalized: finalized_updates_rx,
+                block_signer_sender: block_signer_rx,
+            },
+            actor,
+        )
     }
 
     /// Fetches logs for the given block hash.
     async fn fetch_logs(&self, block_hash: B256) -> Result<Vec<Log>, L1WatcherRpcError<BlockInfo>> {
         let logs = self
+            .state
             .l1_provider
             .get_logs(&alloy_rpc_types_eth::Filter::new().select(block_hash))
             .await?;
@@ -97,8 +116,8 @@ impl L1WatcherRpc {
     ) -> JoinHandle<()> {
         // Start the inbound query processor in a separate task to avoid blocking the main task.
         // We can cheaply clone the l1 provider here because it is an Arc.
-        let l1_provider = self.l1_provider.clone();
-        let rollup_config = self.config.clone();
+        let l1_provider = self.state.l1_provider.clone();
+        let rollup_config = self.state.rollup.clone();
 
         tokio::spawn(async move {
             while let Some(query) = inbound_queries.recv().await {
@@ -153,30 +172,33 @@ impl L1WatcherRpc {
 #[async_trait]
 impl NodeActor for L1WatcherRpc {
     type Error = L1WatcherRpcError<BlockInfo>;
-    type Context = L1WatcherRpcContext;
+    type InboundData = L1WatcherRpcContext;
+    type OutboundData = L1WatcherRpcOutboundChannels;
+    type State = L1WatcherRpcState;
+
+    fn build(config: Self::State) -> (Self::OutboundData, Self) {
+        Self::new(config)
+    }
 
     async fn start(
         mut self,
-        L1WatcherRpcContext {
-            inbound_queries,
-            latest_head,
-            latest_finalized,
-            block_signer_sender,
-            cancellation,
-        }: Self::Context,
+        L1WatcherRpcContext { inbound_queries, cancellation }: Self::InboundData,
     ) -> Result<(), Self::Error> {
-        let mut head_stream =
-            BlockStream::new(&self.l1_provider, BlockNumberOrTag::Latest, Duration::from_secs(13))
-                .into_stream();
+        let mut head_stream = BlockStream::new(
+            &self.state.l1_provider,
+            BlockNumberOrTag::Latest,
+            Duration::from_secs(13),
+        )
+        .into_stream();
         let mut finalized_stream = BlockStream::new(
-            &self.l1_provider,
+            &self.state.l1_provider,
             BlockNumberOrTag::Finalized,
             Duration::from_secs(60),
         )
         .into_stream();
 
         let inbound_query_processor =
-            self.start_query_processor(inbound_queries, latest_head.subscribe());
+            self.start_query_processor(inbound_queries, self.latest_head.subscribe());
 
         // Start the main processing loop.
         loop {
@@ -199,16 +221,16 @@ impl NodeActor for L1WatcherRpc {
                     }
                     Some(head_block_info) => {
                         // Send the head update event to all consumers.
-                        latest_head.send_replace(Some(head_block_info));
+                        self.latest_head.send_replace(Some(head_block_info));
 
                         // For each log, attempt to construct a `SystemConfigLog`.
                         // Build the `SystemConfigUpdate` from the log.
                         // If the update is an Unsafe block signer update, send the address
                         // to the block signer sender.
                         let logs = self.fetch_logs(head_block_info.hash).await?;
-                        let ecotone_active = self.config.is_ecotone_active(head_block_info.timestamp);
+                        let ecotone_active = self.state.rollup.is_ecotone_active(head_block_info.timestamp);
                         for log in logs {
-                            if log.address() != self.config.l1_system_config_address {
+                            if log.address() != self.state.rollup.l1_system_config_address {
                                 continue; // Skip logs not related to the system config.
                             }
 
@@ -218,7 +240,7 @@ impl NodeActor for L1WatcherRpc {
                                     target: "l1_watcher",
                                     "Unsafe block signer update: {unsafe_block_signer}"
                                 );
-                                if let Err(e) = block_signer_sender.send(unsafe_block_signer).await {
+                                if let Err(e) = self.block_signer_sender.send(unsafe_block_signer).await {
                                     error!(
                                         target: "l1_watcher",
                                         "Error sending unsafe block signer update: {e}"
@@ -233,7 +255,7 @@ impl NodeActor for L1WatcherRpc {
                         return Err(L1WatcherRpcError::StreamEnded);
                     }
                     Some(finalized_block_info) => {
-                        latest_finalized.send_replace(Some(finalized_block_info));
+                        self.latest_finalized.send_replace(Some(finalized_block_info));
                     }
                 }
             }

--- a/crates/node/service/src/actors/mod.rs
+++ b/crates/node/service/src/actors/mod.rs
@@ -3,20 +3,21 @@
 //! [NodeActor]: super::NodeActor
 
 mod traits;
-pub use traits::{ActorContext, NodeActor};
+pub use traits::{CancellableContext, NodeActor};
 
 mod runtime;
-pub use runtime::{RuntimeActor, RuntimeContext, RuntimeLauncher};
+pub use runtime::{RuntimeActor, RuntimeContext, RuntimeOutboundData, RuntimeState};
 
 mod engine;
 pub use engine::{
-    EngineActor, EngineContext, EngineError, EngineLauncher, InboundEngineMessage, L2Finalizer,
+    EngineActor, EngineActorState, EngineContext, EngineError, EngineLauncher, EngineOutboundData,
+    InboundEngineMessage, L2Finalizer,
 };
 
 mod supervisor;
 pub use supervisor::{
     SupervisorActor, SupervisorActorContext, SupervisorActorError, SupervisorExt,
-    SupervisorRpcServerExt,
+    SupervisorOutboundData, SupervisorRpcServerExt,
 };
 
 mod rpc;
@@ -24,11 +25,15 @@ pub use rpc::{RpcActor, RpcActorError, RpcContext};
 
 mod derivation;
 pub use derivation::{
-    DerivationActor, DerivationContext, DerivationError, InboundDerivationMessage,
+    DerivationActor, DerivationContext, DerivationError, DerivationOutboundChannels,
+    DerivationState, InboundDerivationMessage,
 };
 
 mod l1_watcher_rpc;
-pub use l1_watcher_rpc::{L1WatcherRpc, L1WatcherRpcContext, L1WatcherRpcError};
+pub use l1_watcher_rpc::{
+    L1WatcherRpc, L1WatcherRpcContext, L1WatcherRpcError, L1WatcherRpcOutboundChannels,
+    L1WatcherRpcState,
+};
 
 mod network;
-pub use network::{NetworkActor, NetworkActorError, NetworkContext};
+pub use network::{NetworkActor, NetworkActorError, NetworkContext, NetworkOutboundData};

--- a/crates/node/service/src/actors/runtime.rs
+++ b/crates/node/service/src/actors/runtime.rs
@@ -6,16 +6,16 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_util::sync::{CancellationToken, WaitForCancellationFuture};
 
-use crate::{NodeActor, actors::ActorContext};
+use crate::{NodeActor, actors::CancellableContext};
 
 /// The communication context used by the runtime actor.
 #[derive(Debug)]
 pub struct RuntimeContext {
-    runtime_config: mpsc::Sender<RuntimeConfig>,
-    cancellation: CancellationToken,
+    /// Cancels the runtime actor.
+    pub cancellation: CancellationToken,
 }
 
-impl ActorContext for RuntimeContext {
+impl CancellableContext for RuntimeContext {
     fn cancelled(&self) -> WaitForCancellationFuture<'_> {
         self.cancellation.cancelled()
     }
@@ -27,76 +27,52 @@ impl ActorContext for RuntimeContext {
 /// using the [`RuntimeLoader`].
 #[derive(Debug)]
 pub struct RuntimeActor {
+    state: RuntimeState,
+    runtime_config: mpsc::Sender<RuntimeConfig>,
+}
+
+/// The state of the runtime actor.
+#[derive(Debug, Clone)]
+pub struct RuntimeState {
     /// The [`RuntimeLoader`].
-    loader: RuntimeLoader,
+    pub loader: RuntimeLoader,
     /// The interval at which to load the runtime.
-    interval: Duration,
+    pub interval: Duration,
+}
+
+/// The outbound data for the runtime actor.
+#[derive(Debug)]
+pub struct RuntimeOutboundData {
+    /// The channel to send the [`RuntimeConfig`] to the engine actor.
+    pub runtime_config: mpsc::Receiver<RuntimeConfig>,
 }
 
 impl RuntimeActor {
     /// Constructs a new [`RuntimeActor`] from the given [`RuntimeLoader`].
-    pub const fn new(
-        loader: RuntimeLoader,
-        interval: Duration,
-        runtime_config: mpsc::Sender<RuntimeConfig>,
-        cancellation: CancellationToken,
-    ) -> (Self, RuntimeContext) {
-        let actor = Self { loader, interval };
-        let context = RuntimeContext { runtime_config, cancellation };
-        (actor, context)
-    }
-}
-
-/// The Runtime Launcher is a simple launcher for the [`RuntimeActor`].
-#[derive(Debug, Clone)]
-pub struct RuntimeLauncher {
-    /// The [`RuntimeLoader`].
-    loader: RuntimeLoader,
-    /// The interval at which to load the runtime.
-    interval: Option<Duration>,
-    /// The channel to send the [`RuntimeConfig`] to the engine actor.
-    tx: Option<mpsc::Sender<RuntimeConfig>>,
-    /// The cancellation token.
-    cancellation: Option<CancellationToken>,
-}
-
-impl RuntimeLauncher {
-    /// Constructs a new [`RuntimeLoader`] from the given runtime loading interval.
-    pub const fn new(loader: RuntimeLoader, interval: Option<Duration>) -> Self {
-        Self { loader, interval, tx: None, cancellation: None }
-    }
-
-    /// Sets the runtime config tx channel.
-    pub fn with_tx(self, tx: mpsc::Sender<RuntimeConfig>) -> Self {
-        Self { tx: Some(tx), ..self }
-    }
-
-    /// Sets the [`CancellationToken`] on the [`RuntimeLauncher`].
-    pub fn with_cancellation(self, cancellation: CancellationToken) -> Self {
-        Self { cancellation: Some(cancellation), ..self }
-    }
-
-    /// Launches the [`RuntimeActor`].
-    pub fn launch(self) -> Option<(RuntimeActor, RuntimeContext)> {
-        let cancellation = self.cancellation?;
-        let tx = self.tx?;
-        if self.interval.is_some() {
-            info!(target: "runtime", interval = ?self.interval, "Launched Runtime Actor");
-        }
-        self.interval.map(|i| RuntimeActor::new(self.loader, i, tx, cancellation))
+    pub fn new(state: RuntimeState) -> (RuntimeOutboundData, Self) {
+        let (runtime_config_tx, runtime_config_rx) = mpsc::channel(1024);
+        let outbound_data = RuntimeOutboundData { runtime_config: runtime_config_rx };
+        let actor = Self { state, runtime_config: runtime_config_tx };
+        (outbound_data, actor)
     }
 }
 
 #[async_trait]
 impl NodeActor for RuntimeActor {
     type Error = RuntimeLoaderError;
-    type Context = RuntimeContext;
+    type InboundData = RuntimeContext;
+    type OutboundData = RuntimeOutboundData;
+    type State = RuntimeState;
+
+    fn build(state: Self::State) -> (Self::OutboundData, Self) {
+        Self::new(state)
+    }
 
     async fn start(
         mut self,
-        RuntimeContext { runtime_config, cancellation }: Self::Context,
+        RuntimeContext { cancellation }: Self::InboundData,
     ) -> Result<(), Self::Error> {
-        let mut interval = tokio::time::interval(self.interval);
+        let mut interval = tokio::time::interval(self.state.interval);
         loop {
             tokio::select! {
                 _ = cancellation.cancelled() => {
@@ -104,9 +80,9 @@ impl NodeActor for RuntimeActor {
                     return Ok(());
                 }
                 _ = interval.tick() => {
-                    let config = self.loader.load_latest().await?;
+                    let config = self.state.loader.load_latest().await?;
                     debug!(target: "runtime", ?config, "Loaded latest runtime config");
-                    if let Err(e) = runtime_config.send(config).await {
+                    if let Err(e) = self.runtime_config.send(config).await {
                         error!(target: "runtime", ?e, "Failed to send runtime config to the engine actor");
                     }
                 }

--- a/crates/node/service/src/actors/supervisor/mod.rs
+++ b/crates/node/service/src/actors/supervisor/mod.rs
@@ -4,7 +4,9 @@ mod traits;
 pub use traits::SupervisorExt;
 
 mod actor;
-pub use actor::{SupervisorActor, SupervisorActorContext, SupervisorActorError};
+pub use actor::{
+    SupervisorActor, SupervisorActorContext, SupervisorActorError, SupervisorOutboundData,
+};
 
 mod ext;
 pub use ext::SupervisorRpcServerExt;

--- a/crates/node/service/src/actors/traits.rs
+++ b/crates/node/service/src/actors/traits.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use tokio_util::sync::WaitForCancellationFuture;
 
 /// The communication context used by the actor.
-pub trait ActorContext: Send {
+pub trait CancellableContext: Send {
     /// Returns a future that resolves when the actor is cancelled.
     fn cancelled(&self) -> WaitForCancellationFuture<'_>;
 }
@@ -16,12 +16,21 @@ pub trait ActorContext: Send {
 ///     - Perform background tasks.
 /// - Emit new events for other actors to process.
 #[async_trait]
-pub trait NodeActor {
+pub trait NodeActor: Send + 'static {
     /// The error type for the actor.
     type Error: std::fmt::Debug;
     /// The communication context used by the actor.
-    type Context: ActorContext;
+    /// These are the channels that the actor will use to receive messages from other actors.
+    type InboundData: CancellableContext;
+    /// The outbound communication channels used by the actor.
+    /// These are the channels that the actor will use to send messages to other actors.
+    type OutboundData: Sized;
+    /// The inner state for the actor.
+    type State;
+
+    /// Builds the actor.
+    fn build(initial_state: Self::State) -> (Self::OutboundData, Self);
 
     /// Starts the actor.
-    async fn start(self, context: Self::Context) -> Result<(), Self::Error>;
+    async fn start(self, inbound_context: Self::InboundData) -> Result<(), Self::Error>;
 }

--- a/crates/node/service/src/lib.rs
+++ b/crates/node/service/src/lib.rs
@@ -14,11 +14,14 @@ pub use service::{NodeMode, RollupNode, RollupNodeBuilder, RollupNodeError, Roll
 
 mod actors;
 pub use actors::{
-    ActorContext, DerivationActor, DerivationContext, DerivationError, EngineActor, EngineContext,
-    EngineError, EngineLauncher, InboundDerivationMessage, InboundEngineMessage, L1WatcherRpc,
-    L1WatcherRpcContext, L1WatcherRpcError, L2Finalizer, NetworkActor, NetworkActorError,
-    NetworkContext, NodeActor, RpcActor, RpcActorError, RpcContext, RuntimeActor, RuntimeContext,
-    RuntimeLauncher, SupervisorActor, SupervisorActorContext, SupervisorActorError, SupervisorExt,
+    CancellableContext, DerivationActor, DerivationContext, DerivationError,
+    DerivationOutboundChannels, DerivationState, EngineActor, EngineActorState, EngineContext,
+    EngineError, EngineLauncher, EngineOutboundData, InboundDerivationMessage,
+    InboundEngineMessage, L1WatcherRpc, L1WatcherRpcContext, L1WatcherRpcError,
+    L1WatcherRpcOutboundChannels, L1WatcherRpcState, L2Finalizer, NetworkActor, NetworkActorError,
+    NetworkContext, NetworkOutboundData, NodeActor, RpcActor, RpcActorError, RpcContext,
+    RuntimeActor, RuntimeContext, RuntimeOutboundData, RuntimeState, SupervisorActor,
+    SupervisorActorContext, SupervisorActorError, SupervisorExt, SupervisorOutboundData,
     SupervisorRpcServerExt,
 };
 

--- a/crates/node/service/src/service/standard/builder.rs
+++ b/crates/node/service/src/service/standard/builder.rs
@@ -1,6 +1,6 @@
 //! Contains the builder for the [`RollupNode`].
 
-use crate::{EngineLauncher, NodeMode, RollupNode, RuntimeLauncher};
+use crate::{EngineLauncher, NodeMode, RollupNode, actors::RuntimeState};
 use alloy_primitives::Bytes;
 use alloy_provider::RootProvider;
 use alloy_rpc_client::RpcClient;
@@ -145,10 +145,10 @@ impl RollupNodeBuilder {
             jwt_secret,
         };
 
-        let runtime_launcher = RuntimeLauncher::new(
-            kona_sources::RuntimeLoader::new(l1_rpc_url, rollup_config.clone()),
-            self.runtime_load_interval,
-        );
+        let runtime_launcher = self.runtime_load_interval.map(|load_interval| RuntimeState {
+            loader: kona_sources::RuntimeLoader::new(l1_rpc_url, rollup_config.clone()),
+            interval: load_interval,
+        });
         let supervisor_rpc = self.supervisor_rpc_config.unwrap_or_default();
 
         let p2p_config = self.p2p_config.expect("P2P config not set");


### PR DESCRIPTION
## Description

This PR builds up on the changes introduced by #2271 to simplify/unify further the structure of the node service crates. In particular this PR:

- Adds two associated types to the `NodeActor` trait. `OutboundData` and `State` which are used to specify a new build method for the actor that aims to replace single calls of the `new` methods. The build method has the following signature: 
```
fn build(initial_state: Self::State) -> (Self::OutboundData, Self);
```

- Takes out the output channels from the `ActorContext` back into the `Actor` struct. This allows to drastically reduce the number of arguments to provide to the `build` methods and remove the need to define channels inside the implementation of the `RollupNodeService` trait. Instead this is done inside the `NodeActor` themselves
- Add an associated type to the `RollupNodeService` for each actor and call the build methods from the associated types. That will make it much easier to have a modular architecture where we can easily swap out components if needed

## Follow-ups

Most of the heavy lifting is done in this PR, but I would like to do some quick follow-ups to refactor/simplify/improve the inner structure of actors even further.
We should also think about which types we want to expose to the public api and try to cut down the number of public exports in our libraries.