### PR TITLE
feat(node/test): add a way to retrieve RPC endpoints addresses from kurtosis services

### DIFF
--- a/tests/devnets/large-kona.yaml
+++ b/tests/devnets/large-kona.yaml
@@ -4,7 +4,6 @@
 optimism_package:
   faucet:
     enabled: true
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-faucet:develop
   chains:
     chain0:
     # Chain with more nodes

--- a/tests/devnets/simple-kona-geth.yaml
+++ b/tests/devnets/simple-kona-geth.yaml
@@ -4,7 +4,6 @@
 optimism_package:
   faucet:
     enabled: true
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-faucet:develop
   chains:
     chain0:
       # Chain with only two nodes

--- a/tests/devnets/simple-kona.yaml
+++ b/tests/devnets/simple-kona.yaml
@@ -4,7 +4,6 @@
 optimism_package:
   faucet:
     enabled: true
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-faucet:develop
   chains:
     chain0:
       # Chain with only two nodes

--- a/tests/devnets/simple-supervisor.yaml
+++ b/tests/devnets/simple-supervisor.yaml
@@ -1,7 +1,6 @@
 optimism_package:
   faucet:
     enabled: true
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-faucet:develop
   chains:
     chain1:
       participants:

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -13,6 +13,8 @@ require github.com/ethereum/go-ethereum v1.15.11
 
 require github.com/libp2p/go-libp2p v0.36.2
 
+require github.com/kurtosis-tech/kurtosis/api/golang v1.8.2-0.20250602144112-2b7d06430e48 
+
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/BurntSushi/toml v1.5.0 // indirect
@@ -123,7 +125,6 @@ require (
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/kurtosis-tech/kurtosis-portal/api/golang v0.0.0-20230818182330-1a86869414d2 // indirect
-	github.com/kurtosis-tech/kurtosis/api/golang v1.8.2-0.20250602144112-2b7d06430e48 // indirect
 	github.com/kurtosis-tech/kurtosis/contexts-config-store v0.0.0-20230818184218-f4e3e773463b // indirect
 	github.com/kurtosis-tech/kurtosis/grpc-file-transfer/golang v0.0.0-20230803130419-099ee7a4e3dc // indirect
 	github.com/kurtosis-tech/kurtosis/path-compression v0.0.0-20250108161014-0819b8ca912f // indirect

--- a/tests/node-devstack/cpu_monitor_test.go
+++ b/tests/node-devstack/cpu_monitor_test.go
@@ -1,0 +1,73 @@
+package nodedevstack
+
+import (
+	"context"
+	"math"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/kurtosis-tech/kurtosis/api/golang/engine/lib/kurtosis_context"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	MAX_CPU_USAGE = 30
+)
+
+// GetCPUStats executes shell commands to get CPU usage statistics from a service
+func GetCPUStats(t devtest.T, ctx context.Context, serviceName string) {
+
+	kurtosisCtx, err := kurtosis_context.NewKurtosisContextFromLocalEngine()
+	require.NoError(t, err, "failed to create kurtosis context")
+
+	enclaves, err := kurtosisCtx.GetEnclaves(ctx)
+	require.NoError(t, err, "failed to get enclaves")
+
+	for enclave := range enclaves.GetEnclavesByName() {
+		enclaveCtx, err := kurtosisCtx.GetEnclaveContext(ctx, enclave)
+		require.NoError(t, err, "failed to get enclave context: %s", enclave)
+
+		serviceCtx, err := enclaveCtx.GetServiceContext(serviceName)
+		require.NoError(t, err, "failed to get service context: %s", serviceName)
+
+		// CPU monitoring commands that work well in Linux containers. Gets the CPU usage percentage of the kona-node binary that runs in the service.
+		cpuUsageCommand := []string{
+			"sh", "-c", "ps aux | grep " + serviceName + " | head -1 | awk '{print $3}'",
+		}
+
+		exitCode, logs, err := serviceCtx.ExecCommand(cpuUsageCommand)
+
+		require.NoError(t, err, "failed to execute command %s: %s", cpuUsageCommand, logs)
+
+		trimmedLogs := strings.TrimSpace(logs)
+		cpuUsageFloat, err := strconv.ParseFloat(trimmedLogs, 64)
+		cpuUsage := int(math.Trunc(cpuUsageFloat))
+
+		require.NoError(t, err, "failed to convert logs to int: %s", trimmedLogs)
+
+		require.Equal(t, exitCode, int32(0), "exitCode: ", exitCode)
+		require.LessOrEqual(t, cpuUsage, MAX_CPU_USAGE, "CPU usage is too high: %s, max allowed: %s", cpuUsage, MAX_CPU_USAGE)
+	}
+}
+
+// Ensure that the CPU usage for a kona-node is less than the max allowed.
+func TestKurtosisCPUMonitor(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	out := NewMixedOpKona(t)
+
+	out.T.Gate().LessOrEqual(len(out.L2CLKonaNodes), 1, "expected at most one kona-node")
+
+	opNode := out.L2CLOpNodes[0]
+	konaNode := out.L2CLKonaNodes[0]
+
+	// Wait for a few blocks to be produced before checking the CPU usage.
+	dsl.CheckAll(t, konaNode.ReachedFn(types.LocalUnsafe, 40, 40), opNode.ReachedFn(types.LocalUnsafe, 40, 40))
+
+	ctx := context.Background()
+
+	GetCPUStats(t, ctx, konaNode.Escape().ID().Key())
+}

--- a/tests/node-devstack/mixed_preset.go
+++ b/tests/node-devstack/mixed_preset.go
@@ -20,8 +20,8 @@ import (
 type L2NodeKind string
 
 const (
-	OpNode   L2NodeKind = "op-node"
-	KonaNode L2NodeKind = "kona-node"
+	OpNode   L2NodeKind = "optimism"
+	KonaNode L2NodeKind = "kona"
 )
 
 type MixedOpKonaPreset struct {
@@ -140,9 +140,6 @@ func NewMixedOpKona(t devtest.T) *MixedOpKonaPreset {
 		Wallet:        dsl.NewHDWallet(t, devkeys.TestMnemonic, 30),
 		Faucet:        dsl.NewFaucet(l2Net.Faucet(match.Assume(t, match.FirstFaucet))),
 	}
-	out.FaucetL1 = dsl.NewFaucet(out.L1Network.Escape().Faucet(match.Assume(t, match.FirstFaucet)))
-	out.FunderL1 = dsl.NewFunder(out.Wallet, out.FaucetL1, out.L1EL)
-	out.Funder = dsl.NewFunder(out.Wallet, out.Faucet, out.L2ELOpNodes[0])
 	return out
 }
 

--- a/tests/node-devstack/p2p_test.go
+++ b/tests/node-devstack/p2p_test.go
@@ -33,7 +33,7 @@ func checkPeerStats(t devtest.T, node *dsl.L2CLNode, minConnected uint, minTable
 	require.NoError(t, err, "failed to get peer stats for %s", nodeName)
 
 	require.GreaterOrEqual(t, peerStats.Connected, minConnected, fmt.Sprintf("%s has no connected peers", nodeName))
-	require.Greater(t, peerStats.Table, minTable, fmt.Sprintf("%s has no peers in the discovery table", nodeName))
+	require.GreaterOrEqual(t, peerStats.Table, minTable, fmt.Sprintf("%s has no peers in the discovery table", nodeName))
 	require.GreaterOrEqual(t, peerStats.BlocksTopic, minBlocksTopic, fmt.Sprintf("%s has no peers in the blocks topic", nodeName))
 	require.GreaterOrEqual(t, peerStats.BlocksTopicV2, minBlocksTopic, fmt.Sprintf("%s has no peers in the blocks topic v2", nodeName))
 	require.GreaterOrEqual(t, peerStats.BlocksTopicV3, minBlocksTopic, fmt.Sprintf("%s has no peers in the blocks topic v3", nodeName))

--- a/tests/node-devstack/rpc_endpoints_test.go
+++ b/tests/node-devstack/rpc_endpoints_test.go
@@ -1,0 +1,77 @@
+package nodedevstack
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/kurtosis-tech/kurtosis/api/golang/engine/lib/kurtosis_context"
+	"github.com/stretchr/testify/require"
+)
+
+// GetCPUStats executes shell commands to get CPU usage statistics from a service
+func rpcEndpoint(ctx context.Context, serviceName string) (string, error) {
+	kurtosisCtx, err := kurtosis_context.NewKurtosisContextFromLocalEngine()
+	if err != nil {
+		return "", err
+	}
+
+	enclaves, err := kurtosisCtx.GetEnclaves(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	for enclave := range enclaves.GetEnclavesByName() {
+		enclaveCtx, err := kurtosisCtx.GetEnclaveContext(ctx, enclave)
+		if err != nil {
+			return "", err
+		}
+
+		serviceCtx, err := enclaveCtx.GetServiceContext(serviceName)
+		if err != nil {
+			return "", err
+		}
+
+		publicPorts := serviceCtx.GetPublicPorts()
+
+		// Get the port for the RPC endpoint
+		rpcPort, ok := publicPorts["rpc"]
+		if !ok {
+			return "", fmt.Errorf("rpc port not found")
+		}
+
+		// Get the RPC endpoint
+		applicationProtocol := rpcPort.GetMaybeApplicationProtocol()
+		if applicationProtocol == "" {
+			applicationProtocol = "http"
+		}
+
+		publicIPAddress := serviceCtx.GetMaybePublicIPAddress()
+		if publicIPAddress == "" {
+			return "", fmt.Errorf("public IP address not found")
+		}
+
+		return fmt.Sprintf("%s://%s:%d", applicationProtocol, publicIPAddress, rpcPort.GetNumber()), nil
+	}
+
+	return "", fmt.Errorf("no enclaves found")
+}
+
+func GetNodeRPCEndpoint(ctx context.Context, node *dsl.L2CLNode) (string, error) {
+	return rpcEndpoint(ctx, node.Escape().ID().Key())
+}
+
+func TestRPCEndpoints(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+
+	out := NewMixedOpKona(t)
+
+	for _, node := range out.L2CLKonaNodes {
+		endpoint, err := GetNodeRPCEndpoint(t.Ctx(), &node)
+		require.NoError(t, err, "failed to get RPC endpoint for node %s", node.Escape().ID().Key())
+
+		t.Logf("RPC endpoint for node %s: %s", node.Escape().ID().Key(), endpoint)
+	}
+}


### PR DESCRIPTION
## Description

Adds a simple RPC endpoint retriever from kurtosis services. This will allow us to finally deprecate the devnet-sdk by migrating the remaining tests using the RPC endpoint provider to the devstack.