### PR TITLE
chore(derive): Globalize Derivation Crate Imports

### DIFF
--- a/crates/protocol/derive/src/attributes/stateful.rs
+++ b/crates/protocol/derive/src/attributes/stateful.rs
@@ -1,9 +1,8 @@
 //! The [`AttributesBuilder`] and it's default implementation.
 
 use crate::{
-    errors::{BuilderError, PipelineEncodingError, PipelineError, PipelineErrorKind},
-    traits::{AttributesBuilder, ChainProvider, L2ChainProvider},
-    types::PipelineResult,
+    AttributesBuilder, BuilderError, ChainProvider, L2ChainProvider, PipelineEncodingError,
+    PipelineError, PipelineErrorKind, PipelineResult,
 };
 use alloc::{boxed::Box, fmt::Debug, string::ToString, sync::Arc, vec, vec::Vec};
 use alloy_consensus::{Eip658Value, Receipt};

--- a/crates/protocol/derive/src/errors/sources.rs
+++ b/crates/protocol/derive/src/errors/sources.rs
@@ -1,6 +1,6 @@
 //! Error types for sources.
 
-use super::{PipelineError, PipelineErrorKind};
+use crate::{PipelineError, PipelineErrorKind};
 use alloc::string::{String, ToString};
 use thiserror::Error;
 

--- a/crates/protocol/derive/src/pipeline/core.rs
+++ b/crates/protocol/derive/src/pipeline/core.rs
@@ -1,11 +1,9 @@
 //! Contains the core derivation pipeline.
 
 use crate::{
-    errors::{PipelineError, PipelineErrorKind},
-    traits::{
-        L2ChainProvider, NextAttributes, OriginAdvancer, OriginProvider, Pipeline, SignalReceiver,
-    },
-    types::{ActivationSignal, PipelineResult, ResetSignal, Signal, StepResult},
+    ActivationSignal, L2ChainProvider, NextAttributes, OriginAdvancer, OriginProvider, Pipeline,
+    PipelineError, PipelineErrorKind, PipelineResult, ResetSignal, Signal, SignalReceiver,
+    StepResult,
 };
 use alloc::{boxed::Box, collections::VecDeque, sync::Arc};
 use async_trait::async_trait;

--- a/crates/protocol/derive/src/sources/blob_data.rs
+++ b/crates/protocol/derive/src/sources/blob_data.rs
@@ -1,6 +1,6 @@
 //! Contains the `BlobData` struct.
 
-use crate::errors::BlobDecodingError;
+use crate::BlobDecodingError;
 use alloc::{boxed::Box, vec};
 use alloy_eips::eip4844::{BYTES_PER_BLOB, Blob, VERSIONED_HASH_VERSION_KZG};
 use alloy_primitives::Bytes;

--- a/crates/protocol/derive/src/sources/calldata.rs
+++ b/crates/protocol/derive/src/sources/calldata.rs
@@ -1,10 +1,6 @@
 //! CallData Source
 
-use crate::{
-    errors::PipelineError,
-    traits::{ChainProvider, DataAvailabilityProvider},
-    types::PipelineResult,
-};
+use crate::{ChainProvider, DataAvailabilityProvider, PipelineError, PipelineResult};
 use alloc::{boxed::Box, collections::VecDeque};
 use alloy_consensus::{Transaction, TxEnvelope, transaction::SignerRecoverable};
 use alloy_primitives::{Address, Bytes};

--- a/crates/protocol/derive/src/traits/attributes.rs
+++ b/crates/protocol/derive/src/traits/attributes.rs
@@ -1,6 +1,6 @@
 //! Contains traits for working with payload attributes and their providers.
 
-use crate::types::PipelineResult;
+use crate::PipelineResult;
 use alloc::boxed::Box;
 use alloy_eips::BlockNumHash;
 use async_trait::async_trait;

--- a/crates/protocol/derive/src/traits/data_sources.rs
+++ b/crates/protocol/derive/src/traits/data_sources.rs
@@ -1,7 +1,7 @@
 //! Contains traits that describe the functionality of various data sources used in the derivation
 //! pipeline's stages.
 
-use crate::{errors::PipelineErrorKind, types::PipelineResult};
+use crate::{PipelineErrorKind, PipelineResult};
 use alloc::{boxed::Box, fmt::Debug, string::ToString, vec::Vec};
 use alloy_eips::eip4844::{Blob, IndexedBlobHash};
 use alloy_primitives::{Address, Bytes};

--- a/crates/protocol/derive/src/traits/pipeline.rs
+++ b/crates/protocol/derive/src/traits/pipeline.rs
@@ -6,7 +6,7 @@ use core::iter::Iterator;
 use kona_genesis::{RollupConfig, SystemConfig};
 use kona_protocol::{L2BlockInfo, OpAttributesWithParent};
 
-use crate::{errors::PipelineErrorKind, traits::OriginProvider, types::StepResult};
+use crate::{OriginProvider, PipelineErrorKind, StepResult};
 
 /// This trait defines the interface for interacting with the derivation pipeline.
 #[async_trait]

--- a/crates/protocol/derive/src/traits/providers.rs
+++ b/crates/protocol/derive/src/traits/providers.rs
@@ -1,6 +1,6 @@
 //! Chain providers for the derivation pipeline.
 
-use crate::errors::PipelineErrorKind;
+use crate::PipelineErrorKind;
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use alloy_consensus::{Header, Receipt, TxEnvelope};
 use alloy_primitives::B256;

--- a/crates/protocol/derive/src/traits/stages.rs
+++ b/crates/protocol/derive/src/traits/stages.rs
@@ -4,7 +4,7 @@ use alloc::boxed::Box;
 use async_trait::async_trait;
 use kona_protocol::BlockInfo;
 
-use crate::types::{PipelineResult, Signal};
+use crate::{PipelineResult, Signal};
 
 /// Providers a way for the pipeline to accept a signal from the driver.
 #[async_trait]

--- a/crates/protocol/derive/src/types/results.rs
+++ b/crates/protocol/derive/src/types/results.rs
@@ -1,6 +1,6 @@
 //! Result types for the `kona-derive` pipeline.
 
-use crate::errors::PipelineErrorKind;
+use crate::PipelineErrorKind;
 
 /// A result type for the derivation pipeline stages.
 pub type PipelineResult<T> = Result<T, PipelineErrorKind>;


### PR DESCRIPTION
### Description

Cleans up `kona-derive` crate imports to use the global crate import, removing private module identifiers.