### PR TITLE
feat(node/service): Handle resets in `SequencerActor`

### DIFF
--- a/crates/node/service/src/service/core.rs
+++ b/crates/node/service/src/service/core.rs
@@ -191,7 +191,7 @@ pub trait RollupNodeService {
         };
 
         let derivation_context = DerivationContext {
-            reset_request_tx,
+            reset_request_tx: reset_request_tx.clone(),
             derived_attributes_tx: attributes_tx,
             cancellation: cancellation.clone(),
         };
@@ -204,6 +204,7 @@ pub trait RollupNodeService {
         };
 
         let sequencer_context = SequencerContext {
+            reset_request_tx,
             build_request_tx,
             gossip_payload_tx: unsafe_block_tx,
             cancellation: cancellation.clone(),


### PR DESCRIPTION
## Overview

Plumbs in the reset request channel from #2312 into the `SequencerActor`, and sends a reset request if there is a `Reset` error during attributes building.

closes #2305 