### PR TITLE
fix(node/service): invert the channel arrows in the rollup node service

### DIFF
--- a/crates/node/service/src/actors/engine/mod.rs
+++ b/crates/node/service/src/actors/engine/mod.rs
@@ -1,7 +1,7 @@
 //! The [`EngineActor`] and its components.
 
 mod actor;
-pub use actor::{EngineActor, EngineBuilder, EngineContext, EngineOutboundData};
+pub use actor::{EngineActor, EngineBuilder, EngineContext, EngineInboundData};
 
 mod error;
 pub use error::EngineError;

--- a/crates/node/service/src/actors/mod.rs
+++ b/crates/node/service/src/actors/mod.rs
@@ -6,39 +6,39 @@ mod traits;
 pub use traits::{CancellableContext, NodeActor};
 
 mod runtime;
-pub use runtime::{RuntimeActor, RuntimeContext, RuntimeOutboundData, RuntimeState};
+pub use runtime::{RuntimeActor, RuntimeContext, RuntimeState};
 
 mod engine;
 pub use engine::{
-    EngineActor, EngineBuilder, EngineContext, EngineError, EngineOutboundData, L2Finalizer,
+    EngineActor, EngineBuilder, EngineContext, EngineError, EngineInboundData, L2Finalizer,
 };
 
 mod supervisor;
 pub use supervisor::{
     SupervisorActor, SupervisorActorContext, SupervisorActorError, SupervisorExt,
-    SupervisorOutboundData, SupervisorRpcServerExt,
+    SupervisorInboundData, SupervisorRpcServerExt,
 };
 
 mod rpc;
-pub use rpc::{RpcActor, RpcActorError, RpcContext, RpcOutboundData};
+pub use rpc::{RpcActor, RpcActorError, RpcContext};
 
 mod derivation;
 pub use derivation::{
     DerivationActor, DerivationBuilder, DerivationContext, DerivationError,
-    DerivationOutboundChannels, DerivationState, InboundDerivationMessage, PipelineBuilder,
+    DerivationInboundChannels, DerivationState, InboundDerivationMessage, PipelineBuilder,
 };
 
 mod l1_watcher_rpc;
 pub use l1_watcher_rpc::{
-    L1WatcherRpc, L1WatcherRpcContext, L1WatcherRpcError, L1WatcherRpcOutboundChannels,
+    L1WatcherRpc, L1WatcherRpcContext, L1WatcherRpcError, L1WatcherRpcInboundChannels,
     L1WatcherRpcState,
 };
 
 mod network;
-pub use network::{NetworkActor, NetworkActorError, NetworkContext, NetworkOutboundData};
+pub use network::{NetworkActor, NetworkActorError, NetworkContext, NetworkInboundData};
 
 mod sequencer;
 pub use sequencer::{
     AttributesBuilderConfig, L1OriginSelector, L1OriginSelectorError, SequencerActor,
-    SequencerActorError, SequencerBuilder, SequencerContext, SequencerOutboundData,
+    SequencerActorError, SequencerBuilder, SequencerContext, SequencerInboundData,
 };

--- a/crates/node/service/src/actors/sequencer/mod.rs
+++ b/crates/node/service/src/actors/sequencer/mod.rs
@@ -6,5 +6,5 @@ pub use origin_selector::{L1OriginSelector, L1OriginSelectorError};
 mod actor;
 pub use actor::{
     AttributesBuilderConfig, SequencerActor, SequencerActorError, SequencerBuilder,
-    SequencerContext, SequencerOutboundData,
+    SequencerContext, SequencerInboundData,
 };

--- a/crates/node/service/src/actors/supervisor/mod.rs
+++ b/crates/node/service/src/actors/supervisor/mod.rs
@@ -5,7 +5,7 @@ pub use traits::SupervisorExt;
 
 mod actor;
 pub use actor::{
-    SupervisorActor, SupervisorActorContext, SupervisorActorError, SupervisorOutboundData,
+    SupervisorActor, SupervisorActorContext, SupervisorActorError, SupervisorInboundData,
 };
 
 mod ext;

--- a/crates/node/service/src/actors/traits.rs
+++ b/crates/node/service/src/actors/traits.rs
@@ -20,17 +20,17 @@ pub trait NodeActor: Send + 'static {
     /// The error type for the actor.
     type Error: std::fmt::Debug;
     /// The communication context used by the actor.
-    /// These are the channels that the actor will use to receive messages from other actors.
-    type InboundData: CancellableContext;
-    /// The outbound communication channels used by the actor.
     /// These are the channels that the actor will use to send messages to other actors.
-    type OutboundData: Sized;
+    type OutboundData: CancellableContext;
+    /// The inbound communication channels used by the actor.
+    /// These are the channels that the actor will use to receive messages from other actors.
+    type InboundData: Sized;
     /// The configuration needed to build the actor.
     type Builder;
 
     /// Builds the actor.
-    fn build(builder: Self::Builder) -> (Self::OutboundData, Self);
+    fn build(builder: Self::Builder) -> (Self::InboundData, Self);
 
     /// Starts the actor.
-    async fn start(self, inbound_context: Self::InboundData) -> Result<(), Self::Error>;
+    async fn start(self, inbound_context: Self::OutboundData) -> Result<(), Self::Error>;
 }

--- a/crates/node/service/src/lib.rs
+++ b/crates/node/service/src/lib.rs
@@ -15,15 +15,15 @@ pub use service::{InteropMode, NodeMode, RollupNode, RollupNodeBuilder, RollupNo
 mod actors;
 pub use actors::{
     AttributesBuilderConfig, CancellableContext, DerivationActor, DerivationBuilder,
-    DerivationContext, DerivationError, DerivationOutboundChannels, DerivationState, EngineActor,
-    EngineBuilder, EngineContext, EngineError, EngineOutboundData, InboundDerivationMessage,
+    DerivationContext, DerivationError, DerivationInboundChannels, DerivationState, EngineActor,
+    EngineBuilder, EngineContext, EngineError, EngineInboundData, InboundDerivationMessage,
     L1OriginSelector, L1OriginSelectorError, L1WatcherRpc, L1WatcherRpcContext, L1WatcherRpcError,
-    L1WatcherRpcOutboundChannels, L1WatcherRpcState, L2Finalizer, NetworkActor, NetworkActorError,
-    NetworkContext, NetworkOutboundData, NodeActor, PipelineBuilder, RpcActor, RpcActorError,
-    RpcContext, RpcOutboundData, RuntimeActor, RuntimeContext, RuntimeOutboundData, RuntimeState,
-    SequencerActor, SequencerActorError, SequencerBuilder, SequencerContext, SequencerOutboundData,
-    SupervisorActor, SupervisorActorContext, SupervisorActorError, SupervisorExt,
-    SupervisorOutboundData, SupervisorRpcServerExt,
+    L1WatcherRpcInboundChannels, L1WatcherRpcState, L2Finalizer, NetworkActor, NetworkActorError,
+    NetworkContext, NetworkInboundData, NodeActor, PipelineBuilder, RpcActor, RpcActorError,
+    RpcContext, RuntimeActor, RuntimeContext, RuntimeState, SequencerActor, SequencerActorError,
+    SequencerBuilder, SequencerContext, SequencerInboundData, SupervisorActor,
+    SupervisorActorContext, SupervisorActorError, SupervisorExt, SupervisorInboundData,
+    SupervisorRpcServerExt,
 };
 
 mod metrics;


### PR DESCRIPTION
## Description

This PR inverts the way actors build their channels. Instead of emitting a list of `OutboundData` (channels to send data to) and using `InboundData` (channels to receive data from) as `Context`, it rather emits `InboundData` and uses `OutboundData` as context. 
This allows to define data flows where several actors send to the same receiver (using `mpsc` channels for instance).