### PR TITLE
chore(supervisor): op-node devnet version

### DIFF
--- a/tests/devnets/simple-supervisor.yaml
+++ b/tests/devnets/simple-supervisor.yaml
@@ -9,7 +9,7 @@ optimism_package:
             type: op-geth
           cl:
             type: op-node
-            image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:develop
+            image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.3
             log_level: debug
       network_params:
         network: "kurtosis"
@@ -32,7 +32,7 @@ optimism_package:
             type: op-geth
           cl:
             type: op-node
-            image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:develop
+            image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.3
             log_level: debug
       network_params:
         network: "kurtosis"


### PR DESCRIPTION
`op-node` spec is being updated and we need to stick to the versioned release to make sure to avoid compatibility issues in future.