### PR TITLE
feat(node/sequencer): move node mode from rollup node service trait to engine actor.

### DIFF
--- a/crates/node/service/src/service/core.rs
+++ b/crates/node/service/src/service/core.rs
@@ -128,12 +128,10 @@ pub trait RollupNodeService {
         let cancellation = CancellationToken::new();
 
         // Create the DA watcher actor.
-        let da_watcher_builder = self.da_watcher_builder();
         let (L1WatcherRpcInboundChannels { inbound_queries: da_watcher_rpc }, da_watcher) =
-            Self::DataAvailabilityWatcher::build(da_watcher_builder);
+            Self::DataAvailabilityWatcher::build(self.da_watcher_builder());
 
         // Create the derivation actor.
-        let derivation_builder = self.derivation_builder();
         let (
             DerivationInboundChannels {
                 derivation_signal_tx,
@@ -142,7 +140,7 @@ pub trait RollupNodeService {
                 el_sync_complete_tx,
             },
             derivation,
-        ) = Self::DerivationActor::build(derivation_builder);
+        ) = Self::DerivationActor::build(self.derivation_builder());
 
         // TODO: get the supervisor ext.
         // TODO: use the supervisor ext to create the supervisor actor.
@@ -155,7 +153,6 @@ pub trait RollupNodeService {
         let (_, runtime) = self.runtime_builder().map(Self::RuntimeActor::build).unzip();
 
         // Create the engine actor.
-        let engine_builder = self.engine_builder();
         let (
             EngineInboundData {
                 build_request_tx,
@@ -167,48 +164,20 @@ pub trait RollupNodeService {
                 finalized_l1_block_tx,
             },
             engine,
-        ) = Self::EngineActor::build(engine_builder);
+        ) = Self::EngineActor::build(self.engine_builder());
 
         // Create the p2p actor.
-        let driver = self.network_builder();
         let (NetworkInboundData { signer, rpc: network_rpc }, network) =
-            Self::NetworkActor::build(driver);
+            Self::NetworkActor::build(self.network_builder());
 
         // Create the RPC server actor.
-        let rpc_builder = self.rpc_builder();
-        let (_, rpc) = rpc_builder.map(Self::RpcActor::build).unzip();
+        let (_, rpc) = self.rpc_builder().map(Self::RpcActor::build).unzip();
 
-        let network_context =
-            NetworkContext { blocks: unsafe_block_tx.clone(), cancellation: cancellation.clone() };
-
-        let (_, sequencer) = Self::SequencerActor::build(self.sequencer_builder());
-
-        let da_watcher_context = L1WatcherRpcContext {
-            latest_head: l1_head_updates_tx,
-            latest_finalized: finalized_l1_block_tx,
-            block_signer_sender: signer,
-            cancellation: cancellation.clone(),
-        };
-
-        let derivation_context = DerivationContext {
-            reset_request_tx: reset_request_tx.clone(),
-            derived_attributes_tx: attributes_tx,
-            cancellation: cancellation.clone(),
-        };
-
-        let engine_context = EngineContext {
-            engine_l2_safe_head_tx,
-            sync_complete_tx: el_sync_complete_tx,
-            derivation_signal_tx,
-            cancellation: cancellation.clone(),
-        };
-
-        let sequencer_context = SequencerContext {
-            reset_request_tx,
-            build_request_tx,
-            gossip_payload_tx: unsafe_block_tx,
-            cancellation: cancellation.clone(),
-        };
+        let (_, sequencer) = self
+            .mode()
+            .is_sequencer()
+            .then_some(Self::SequencerActor::build(self.sequencer_builder()))
+            .unzip();
 
         spawn_and_wait!(
             cancellation,
@@ -226,11 +195,45 @@ pub trait RollupNodeService {
                         engine_query: engine_rpc,
                     }
                 )),
-                Some((network, network_context)),
-                Some((da_watcher, da_watcher_context)),
-                Some((derivation, derivation_context)),
-                Some((engine, engine_context)),
-                self.mode().is_sequencer().then_some((sequencer, sequencer_context))
+                sequencer.map(|s| (
+                    s,
+                    SequencerContext {
+                        reset_request_tx: reset_request_tx.clone(),
+                        build_request_tx: build_request_tx.expect(
+                            "`build_request_tx` not set while in sequencer mode. This should never happen.",
+                        ),
+                        gossip_payload_tx: unsafe_block_tx.clone(),
+                        cancellation: cancellation.clone(),
+                    })
+                ),
+                Some((
+                    network,
+                    NetworkContext { blocks: unsafe_block_tx, cancellation: cancellation.clone() }
+                )),
+                Some((
+                    da_watcher,
+                    L1WatcherRpcContext {
+                        latest_head: l1_head_updates_tx,
+                        latest_finalized: finalized_l1_block_tx,
+                        block_signer_sender: signer,
+                        cancellation: cancellation.clone(),
+                    })
+                ),
+                Some((
+                    derivation,
+                    DerivationContext {
+                        reset_request_tx: reset_request_tx.clone(),
+                        derived_attributes_tx: attributes_tx,
+                        cancellation: cancellation.clone(),
+                })),
+                Some((engine,
+                    EngineContext {
+                        engine_l2_safe_head_tx,
+                        sync_complete_tx: el_sync_complete_tx,
+                        derivation_signal_tx,
+                        cancellation: cancellation.clone(),
+                    })
+                ),
             ]
         );
         Ok(())

--- a/crates/node/service/src/service/standard/builder.rs
+++ b/crates/node/service/src/service/standard/builder.rs
@@ -150,6 +150,7 @@ impl RollupNodeBuilder {
             l1_rpc_url: l1_rpc_url.clone(),
             engine_url: self.l2_engine_rpc_url.expect("missing l2 engine rpc url"),
             jwt_secret,
+            mode: self.mode,
         };
 
         let runtime_builder = self.runtime_load_interval.map(|load_interval| RuntimeState {
@@ -165,7 +166,6 @@ impl RollupNodeBuilder {
         };
 
         RollupNode {
-            mode: self.mode,
             config: rollup_config,
             interop_mode,
             l1_provider,

--- a/crates/node/service/src/service/standard/node.rs
+++ b/crates/node/service/src/service/standard/node.rs
@@ -24,8 +24,6 @@ use kona_rpc::{RpcBuilder, SupervisorRpcConfig, SupervisorRpcServer};
 pub struct RollupNode {
     /// The rollup configuration.
     pub(crate) config: Arc<RollupConfig>,
-    /// The mode of operation for the node.
-    pub(crate) mode: NodeMode,
     /// The interop mode for the node.
     pub(crate) interop_mode: InteropMode,
     /// The L1 EL provider.
@@ -72,7 +70,7 @@ impl RollupNodeService for RollupNode {
     type NetworkActor = NetworkActor;
 
     fn mode(&self) -> NodeMode {
-        self.mode
+        self.engine_builder.mode
     }
 
     fn da_watcher_builder(&self) -> L1WatcherRpcState {

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -15,6 +15,8 @@ require github.com/libp2p/go-libp2p v0.36.2
 
 require github.com/kurtosis-tech/kurtosis/api/golang v1.8.2-0.20250602144112-2b7d06430e48 
 
+require golang.org/x/sync v0.14.0
+
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/BurntSushi/toml v1.5.0 // indirect
@@ -262,7 +264,6 @@ require (
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c // indirect
 	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/net v0.36.0 // indirect
-	golang.org/x/sync v0.14.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/term v0.29.0 // indirect
 	golang.org/x/text v0.25.0 // indirect


### PR DESCRIPTION
## Description

Small PR to move the node mode parameter from the `RollupNodeService` trait to the `EngineActor`. This also improves the safety of the engine select statement branch for incoming block building requests by being able to catch communication drops from the sequencer engine.