### PR TITLE
feat(node/service): use drop guards to ensure actors are cancelled properly

### DIFF
--- a/crates/node/service/src/actors/engine/actor.rs
+++ b/crates/node/service/src/actors/engine/actor.rs
@@ -210,7 +210,6 @@ impl EngineActorState {
         derivation_signal_tx: &mpsc::Sender<Signal>,
         engine_l2_safe_head_tx: &watch::Sender<L2BlockInfo>,
         finalizer: &mut L2Finalizer,
-        cancellation: &CancellationToken,
     ) -> Result<(), EngineError> {
         // Reset the engine.
         let (l2_safe_head, l1_origin, system_config) =
@@ -222,7 +221,6 @@ impl EngineActorState {
             Ok(_) => debug!(target: "engine", "Sent reset signal to derivation actor"),
             Err(err) => {
                 error!(target: "engine", ?err, "Failed to send reset signal to the derivation actor");
-                cancellation.cancel();
                 return Err(EngineError::ChannelClosed);
             }
         }
@@ -243,7 +241,6 @@ impl EngineActorState {
         sync_complete_tx: &mut Option<oneshot::Sender<()>>,
         engine_l2_safe_head_tx: &watch::Sender<L2BlockInfo>,
         finalizer: &mut L2Finalizer,
-        cancellation: &CancellationToken,
     ) -> Result<(), EngineError> {
         match self.engine.drain().await {
             Ok(_) => {
@@ -251,8 +248,7 @@ impl EngineActorState {
             }
             Err(EngineTaskError::Reset(err)) => {
                 warn!(target: "engine", ?err, "Received reset request");
-                self.reset(derivation_signal_tx, engine_l2_safe_head_tx, finalizer, cancellation)
-                    .await?;
+                self.reset(derivation_signal_tx, engine_l2_safe_head_tx, finalizer).await?;
             }
             Err(EngineTaskError::Flush(err)) => {
                 // This error is encountered when the payload is marked INVALID
@@ -266,14 +262,12 @@ impl EngineActorState {
                     }
                     Err(err) => {
                         error!(target: "engine", ?err, "Failed to send flush signal to the derivation actor.");
-                        cancellation.cancel();
                         return Err(EngineError::ChannelClosed);
                     }
                 }
             }
             Err(err @ EngineTaskError::Critical(_)) => {
                 error!(target: "engine", ?err, "Critical error draining engine tasks");
-                cancellation.cancel();
                 return Err(err.into());
             }
             Err(EngineTaskError::Temporary(err)) => {
@@ -287,7 +281,6 @@ impl EngineActorState {
             engine_l2_safe_head_tx,
             sync_complete_tx,
             finalizer,
-            cancellation,
         )
         .await?;
 
@@ -301,7 +294,6 @@ impl EngineActorState {
         engine_l2_safe_head_tx: &watch::Sender<L2BlockInfo>,
         sync_complete_tx: &mut Option<oneshot::Sender<()>>,
         finalizer: &mut L2Finalizer,
-        cancellation: &CancellationToken,
     ) -> Result<(), EngineError> {
         if self.engine.state().el_sync_finished {
             let Some(sync_complete_tx) = std::mem::take(sync_complete_tx) else {
@@ -310,8 +302,7 @@ impl EngineActorState {
 
             // If the sync status is finished, we can reset the engine and start derivation.
             info!(target: "engine", "Performing initial engine reset");
-            self.reset(derivation_signal_tx, engine_l2_safe_head_tx, finalizer, cancellation)
-                .await?;
+            self.reset(derivation_signal_tx, engine_l2_safe_head_tx, finalizer).await?;
             sync_complete_tx.send(()).ok();
         }
 
@@ -387,7 +378,6 @@ impl NodeActor for EngineActor {
                     &mut sync_complete_tx,
                     &engine_l2_safe_head_tx,
                     &mut self.finalizer,
-                    &cancellation,
                 )
                 .await?;
 
@@ -409,7 +399,7 @@ impl NodeActor for EngineActor {
                     }
                     warn!(target: "engine", "Received reset request");
                     state
-                        .reset(&derivation_signal_tx, &engine_l2_safe_head_tx, &mut self.finalizer, &cancellation)
+                        .reset(&derivation_signal_tx, &engine_l2_safe_head_tx, &mut self.finalizer)
                         .await?;
                 }
                 unsafe_block = self.unsafe_block_rx.recv() => {

--- a/crates/node/service/src/actors/runtime.rs
+++ b/crates/node/service/src/actors/runtime.rs
@@ -64,6 +64,7 @@ impl NodeActor for RuntimeActor {
         RuntimeContext { cancellation, runtime_config_tx }: Self::OutboundData,
     ) -> Result<(), Self::Error> {
         let mut interval = tokio::time::interval(self.state.interval);
+
         loop {
             tokio::select! {
                 _ = cancellation.cancelled() => {

--- a/crates/node/service/src/actors/supervisor/actor.rs
+++ b/crates/node/service/src/actors/supervisor/actor.rs
@@ -81,6 +81,7 @@ where
         SupervisorActorContext { engine_control, cancellation }: Self::OutboundData,
     ) -> Result<(), Self::Error> {
         let mut control_events = Box::pin(self.supervisor_ext.subscribe_control_events());
+
         loop {
             tokio::select! {
                 _ = cancellation.cancelled() => {

--- a/crates/node/service/src/service/util.rs
+++ b/crates/node/service/src/service/util.rs
@@ -15,7 +15,16 @@ macro_rules! spawn_and_wait {
         // Check if the actor is present, and spawn it if it is.
         $(
             if let Some((actor, context)) = $actor {
+                let cancellation = $cancellation.clone();
                 task_handles.spawn(async move {
+                    // This guard ensures that the cancellation token is cancelled when the actor is
+                    // dropped. This ensures that the actor is properly shut down.
+                    // Note the underscore prefix: this is to signal that we don't use the guard anywhere, but
+                    // *the compiler shouldn't optimize it away*.
+                    // Note that using a simple `_` would not work here because it gets optimized away in
+                    // release mode.
+                    let _guard = cancellation.drop_guard();
+
                     if let Err(e) = actor.start(context).await {
                         return Err(format!("{e:?}"));
                     }


### PR DESCRIPTION
## Description

This PR adds drop guards to every actor to ensure they're all cancelled whenever any actor drops.