### PR TITLE
chore(node/rpc): remove rpc disabled field in rpc builder

### DIFF
--- a/bin/node/src/flags/rpc.rs
+++ b/bin/node/src/flags/rpc.rs
@@ -44,15 +44,18 @@ impl Default for RpcArgs {
     }
 }
 
-impl From<RpcArgs> for RpcBuilder {
+impl From<RpcArgs> for Option<RpcBuilder> {
     fn from(args: RpcArgs) -> Self {
-        Self {
-            disabled: args.rpc_disabled,
-            no_restart: args.no_restart,
-            socket: SocketAddr::from((args.listen_addr, args.listen_port)),
-            enable_admin: args.enable_admin,
-            admin_persistence: args.admin_persistence.clone(),
-            ws_enabled: args.ws_enabled,
+        if args.rpc_disabled {
+            None
+        } else {
+            Some(RpcBuilder {
+                no_restart: args.no_restart,
+                socket: SocketAddr::from((args.listen_addr, args.listen_port)),
+                enable_admin: args.enable_admin,
+                admin_persistence: args.admin_persistence.clone(),
+                ws_enabled: args.ws_enabled,
+            })
         }
     }
 }

--- a/crates/node/rpc/src/config.rs
+++ b/crates/node/rpc/src/config.rs
@@ -5,8 +5,6 @@ use std::{net::SocketAddr, path::PathBuf};
 /// The RPC configuration.
 #[derive(Debug, Clone)]
 pub struct RpcBuilder {
-    /// Disable the rpc server.
-    pub disabled: bool,
     /// Prevent the rpc server from being restarted.
     pub no_restart: bool,
     /// The RPC socket address.

--- a/crates/node/service/src/service/core.rs
+++ b/crates/node/service/src/service/core.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 use async_trait::async_trait;
 use kona_derive::{AttributesBuilder, Pipeline, SignalReceiver};
-use kona_rpc::RpcBuilder;
 use std::fmt::Display;
 use tokio_util::sync::CancellationToken;
 
@@ -93,7 +92,7 @@ pub trait RollupNodeService {
         >;
 
     /// The type of rpc actor to use for the service.
-    type RpcActor: NodeActor<Error: Display, OutboundData = RpcContext, InboundData = (), Builder = RpcBuilder>;
+    type RpcActor: NodeActor<Error: Display, OutboundData = RpcContext, InboundData = ()>;
 
     /// The mode of operation for the node.
     fn mode(&self) -> NodeMode;

--- a/crates/node/service/src/service/standard/builder.rs
+++ b/crates/node/service/src/service/standard/builder.rs
@@ -101,8 +101,8 @@ impl RollupNodeBuilder {
     }
 
     /// Sets the [`RpcBuilder`] on the [`RollupNodeBuilder`].
-    pub fn with_rpc_config(self, rpc_config: RpcBuilder) -> Self {
-        Self { rpc_config: Some(rpc_config), ..self }
+    pub fn with_rpc_config(self, rpc_config: Option<RpcBuilder>) -> Self {
+        Self { rpc_config, ..self }
     }
 
     /// Sets the runtime load interval on the [`RollupNodeBuilder`].


### PR DESCRIPTION
## Description

A simple PR that removes the `rpc_disabled` field inside the `RpcBuilder`. This field was redundant since the `RpcBuilder` is now provided as an `Option` inside the `RollupNodeService`