### PR TITLE
feat(node/engine): refactor engine tasks. fix sequencer startup logic

### DIFF
--- a/crates/node/engine/src/lib.rs
+++ b/crates/node/engine/src/lib.rs
@@ -26,7 +26,7 @@ mod versions;
 pub use versions::{EngineForkchoiceVersion, EngineGetPayloadVersion, EngineNewPayloadVersion};
 
 mod state;
-pub use state::EngineState;
+pub use state::{EngineState, EngineSyncState, EngineSyncStateUpdate};
 
 mod kinds;
 pub use kinds::EngineKind;

--- a/crates/node/engine/src/state/mod.rs
+++ b/crates/node/engine/src/state/mod.rs
@@ -1,4 +1,4 @@
 //! Engine State
 
 mod core;
-pub use core::EngineState;
+pub use core::{EngineState, EngineSyncState, EngineSyncStateUpdate};

--- a/crates/node/engine/src/task_queue/tasks/build/error.rs
+++ b/crates/node/engine/src/task_queue/tasks/build/error.rs
@@ -17,9 +17,6 @@ pub enum BuildTaskError {
     /// The engine is syncing.
     #[error("Attempting to update forkchoice state while EL syncing")]
     EngineSyncing,
-    /// The forkchoice update call to the engine api failed.
-    #[error(transparent)]
-    ForkchoiceUpdateFailed(RpcError<TransportErrorKind>),
     /// Missing payload ID.
     #[error("Missing payload ID")]
     MissingPayloadId,
@@ -32,12 +29,6 @@ pub enum BuildTaskError {
     /// The new payload call to the engine api failed.
     #[error(transparent)]
     NewPayloadFailed(RpcError<TransportErrorKind>),
-    /// The forkchoice state is invalid.
-    #[error("Invalid forkchoice state")]
-    InvalidForkchoiceState,
-    /// The finalized head is behind the unsafe head.
-    #[error("Invalid forkchoice state: unsafe head {0} is ahead of finalized head {1}")]
-    FinalizedAheadOfUnsafe(u64, u64),
     /// A deposit-only payload failed to import.
     #[error("Deposit-only payload failed to import")]
     DepositOnlyPayloadFailed,
@@ -64,15 +55,12 @@ impl From<BuildTaskError> for EngineTaskError {
         match value {
             BuildTaskError::NoForkchoiceUpdateNeeded => Self::Temporary(Box::new(value)),
             BuildTaskError::EngineSyncing => Self::Temporary(Box::new(value)),
-            BuildTaskError::ForkchoiceUpdateFailed(_) => Self::Temporary(Box::new(value)),
-            BuildTaskError::MissingPayloadId => Self::Temporary(Box::new(value)),
-            BuildTaskError::UnexpectedPayloadStatus(_) => Self::Temporary(Box::new(value)),
             BuildTaskError::GetPayloadFailed(_) => Self::Temporary(Box::new(value)),
             BuildTaskError::NewPayloadFailed(_) => Self::Temporary(Box::new(value)),
-            BuildTaskError::InvalidForkchoiceState => Self::Reset(Box::new(value)),
             BuildTaskError::HoloceneInvalidFlush => Self::Flush(Box::new(value)),
+            BuildTaskError::MissingPayloadId => Self::Critical(Box::new(value)),
+            BuildTaskError::UnexpectedPayloadStatus(_) => Self::Critical(Box::new(value)),
             BuildTaskError::DepositOnlyPayloadReattemptFailed => Self::Critical(Box::new(value)),
-            BuildTaskError::FinalizedAheadOfUnsafe(_, _) => Self::Critical(Box::new(value)),
             BuildTaskError::DepositOnlyPayloadFailed => Self::Critical(Box::new(value)),
             BuildTaskError::FromBlock(_) => Self::Critical(Box::new(value)),
             BuildTaskError::MpscSend(_) => Self::Critical(Box::new(value)),

--- a/crates/node/engine/src/task_queue/tasks/build/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/build/task.rs
@@ -2,12 +2,12 @@
 
 use super::BuildTaskError;
 use crate::{
-    EngineClient, EngineForkchoiceVersion, EngineGetPayloadVersion, EngineState, EngineTaskError,
-    EngineTaskExt, ForkchoiceTask, Metrics,
+    EngineClient, EngineGetPayloadVersion, EngineState, EngineTaskError, EngineTaskExt,
+    ForkchoiceTask, Metrics, state::EngineSyncStateUpdate,
 };
 use alloy_provider::ext::EngineApi;
 use alloy_rpc_types_engine::{
-    ExecutionPayloadFieldV2, ExecutionPayloadInputV2, ForkchoiceState, PayloadId, PayloadStatusEnum,
+    ExecutionPayloadFieldV2, ExecutionPayloadInputV2, PayloadId, PayloadStatusEnum,
 };
 use alloy_transport::RpcError;
 use async_trait::async_trait;
@@ -44,96 +44,6 @@ impl BuildTask {
         payload_tx: Option<mpsc::Sender<OpExecutionPayloadEnvelope>>,
     ) -> Self {
         Self { engine, cfg, attributes, is_attributes_derived, payload_tx }
-    }
-
-    /// Starts the block building process by sending an initial `engine_forkchoiceUpdate` call with
-    /// the payload attributes to build.
-    ///
-    /// ## Observed [PayloadStatusEnum] Variants
-    /// The `engine_forkchoiceUpdate` payload statuses that this function observes are below. Any
-    /// other [PayloadStatusEnum] variant is considered a failure.
-    ///
-    /// ### Success (`VALID`)
-    /// If the build is successful, the [PayloadId] is returned for sealing and the external
-    /// actor is notified of the successful forkchoice update.
-    ///
-    /// ### Failure (`INVALID`)
-    /// If the forkchoice update fails, the external actor is notified of the failure.
-    ///
-    /// ### Syncing (`SYNCING`)
-    /// If the EL is syncing, the payload attributes are buffered and the function returns early.
-    /// This is a temporary state, and the function should be called again later.
-    async fn start_build(
-        &self,
-        engine_client: &EngineClient,
-        forkchoice: ForkchoiceState,
-        attributes_envelope: OpAttributesWithParent,
-    ) -> Result<PayloadId, BuildTaskError> {
-        debug!(
-            target: "engine_builder",
-            txs = attributes_envelope.inner().transactions.as_ref().map_or(0, |txs| txs.len()),
-            "Starting new build job"
-        );
-
-        let forkchoice_version = EngineForkchoiceVersion::from_cfg(
-            &self.cfg,
-            attributes_envelope.inner().payload_attributes.timestamp,
-        );
-        debug!(target: "engine_builder", ?forkchoice_version, "Forkchoice version");
-        let update = match forkchoice_version {
-            EngineForkchoiceVersion::V3 => {
-                engine_client
-                    .fork_choice_updated_v3(forkchoice, Some(attributes_envelope.inner))
-                    .await
-            }
-            EngineForkchoiceVersion::V2 => {
-                engine_client
-                    .fork_choice_updated_v2(forkchoice, Some(attributes_envelope.inner))
-                    .await
-            }
-            EngineForkchoiceVersion::V1 => {
-                engine_client
-                    .fork_choice_updated_v1(
-                        forkchoice,
-                        Some(attributes_envelope.inner.payload_attributes),
-                    )
-                    .await
-            }
-        }
-        .map_err(|e| {
-            error!(target: "engine_builder", "Forkchoice update failed: {}", e);
-            BuildTaskError::ForkchoiceUpdateFailed(e)
-        })?;
-
-        match update.payload_status.status {
-            PayloadStatusEnum::Valid => {
-                debug!(
-                    target: "engine_builder",
-                    unsafe_hash = forkchoice.head_block_hash.to_string(),
-                    safe_hash = forkchoice.safe_block_hash.to_string(),
-                    finalized_hash = forkchoice.finalized_block_hash.to_string(),
-                    "Forkchoice update with attributes successful"
-                );
-            }
-            PayloadStatusEnum::Invalid { validation_error } => {
-                error!(target: "engine_builder", "Forkchoice update failed: {}", validation_error);
-                return Err(BuildTaskError::ForkchoiceUpdateFailed(RpcError::local_usage_str(
-                    &validation_error,
-                )));
-            }
-            PayloadStatusEnum::Syncing => {
-                warn!(target: "engine_builder", "Forkchoice update failed temporarily: EL is syncing");
-                return Err(BuildTaskError::EngineSyncing);
-            }
-            s => {
-                // Other codes are never returned by `engine_forkchoiceUpdate`
-                return Err(BuildTaskError::UnexpectedPayloadStatus(s));
-            }
-        }
-
-        // Fetch the payload ID from the FCU. If no payload ID was returned, something went wrong -
-        // the block building job on the EL should have been initiated.
-        update.payload_id.ok_or(BuildTaskError::MissingPayloadId)
     }
 
     /// Fetches the execution payload from the EL and imports it into the engine via
@@ -311,27 +221,30 @@ impl BuildTask {
 
 #[async_trait]
 impl EngineTaskExt for BuildTask {
-    async fn execute(&self, state: &mut EngineState) -> Result<(), EngineTaskError> {
-        // Sanity check if the head is behind the finalized head. If it is, this is a critical
-        // error.
-        if state.unsafe_head().block_info.number < state.finalized_head().block_info.number {
-            return Err(BuildTaskError::FinalizedAheadOfUnsafe(
-                state.unsafe_head().block_info.number,
-                state.finalized_head().block_info.number,
-            )
-            .into());
-        }
+    type Output = ();
 
-        // Send the forkchoice update through the input, with the current engine state and the
-        // payload attributes for the block building job.
-        let mut forkchoice = state.create_forkchoice_state();
-        forkchoice.head_block_hash = self.attributes.parent.block_info.hash;
+    async fn execute(&self, state: &mut EngineState) -> Result<(), EngineTaskError> {
+        debug!(
+            target: "engine_builder",
+            txs = self.attributes.inner().transactions.as_ref().map_or(0, |txs| txs.len()),
+            "Starting new build job"
+        );
 
         // Start the build by sending an FCU call with the current forkchoice and the input
         // payload attributes.
         let fcu_start_time = Instant::now();
-        let payload_id =
-            self.start_build(&self.engine, forkchoice, self.attributes.clone()).await?;
+        let payload_id = ForkchoiceTask::new(
+            self.engine.clone(),
+            self.cfg.clone(),
+            EngineSyncStateUpdate {
+                unsafe_head: Some(self.attributes.parent),
+                ..Default::default()
+            },
+            Some(self.attributes.clone()),
+        )
+        .execute(state)
+        .await?
+        .ok_or(BuildTaskError::MissingPayloadId)?;
         let fcu_duration = fcu_start_time.elapsed();
 
         // Fetch the payload from the EL and import it into the engine.
@@ -347,16 +260,21 @@ impl EngineTaskExt for BuildTask {
             .await?;
         let block_import_duration = block_import_start_time.elapsed();
 
-        // Update the engine state.
-        state.set_unsafe_head(new_block_ref);
-        state.set_cross_unsafe_head(new_block_ref);
-        if self.is_attributes_derived {
-            state.set_local_safe_head(new_block_ref);
-            state.set_safe_head(new_block_ref);
-        }
-
         // Send a FCU to canonicalize the imported block.
-        ForkchoiceTask::new(Arc::clone(&self.engine)).execute(state).await?;
+        ForkchoiceTask::new(
+            Arc::clone(&self.engine),
+            self.cfg.clone(),
+            EngineSyncStateUpdate {
+                unsafe_head: Some(new_block_ref),
+                cross_unsafe_head: Some(new_block_ref),
+                local_safe_head: self.is_attributes_derived.then_some(new_block_ref),
+                safe_head: self.is_attributes_derived.then_some(new_block_ref),
+                ..Default::default()
+            },
+            None,
+        )
+        .execute(state)
+        .await?;
 
         // If a channel was provided, send the built payload envelope to it.
         if let Some(tx) = &self.payload_tx {

--- a/crates/node/engine/src/task_queue/tasks/forkchoice/error.rs
+++ b/crates/node/engine/src/task_queue/tasks/forkchoice/error.rs
@@ -1,6 +1,7 @@
 //! Contains error types for the [crate::ForkchoiceTask].
 
 use crate::EngineTaskError;
+use alloy_rpc_types_engine::PayloadStatusEnum;
 use alloy_transport::{RpcError, TransportErrorKind};
 use thiserror::Error;
 
@@ -22,6 +23,12 @@ pub enum ForkchoiceTaskError {
     /// The forkchoice state is invalid.
     #[error("Invalid forkchoice state")]
     InvalidForkchoiceState,
+    /// The payload status is invalid.
+    #[error("Invalid payload status: {0}")]
+    InvalidPayloadStatus(String),
+    /// The payload status is unexpected.
+    #[error("Unexpected payload status: {0}")]
+    UnexpectedPayloadStatus(PayloadStatusEnum),
 }
 
 impl From<ForkchoiceTaskError> for EngineTaskError {
@@ -31,7 +38,9 @@ impl From<ForkchoiceTaskError> for EngineTaskError {
             ForkchoiceTaskError::EngineSyncing => Self::Temporary(Box::new(value)),
             ForkchoiceTaskError::ForkchoiceUpdateFailed(_) => Self::Temporary(Box::new(value)),
             ForkchoiceTaskError::FinalizedAheadOfUnsafe(_, _) => Self::Critical(Box::new(value)),
+            ForkchoiceTaskError::UnexpectedPayloadStatus(_) => Self::Critical(Box::new(value)),
             ForkchoiceTaskError::InvalidForkchoiceState => Self::Reset(Box::new(value)),
+            ForkchoiceTaskError::InvalidPayloadStatus(_) => Self::Reset(Box::new(value)),
         }
     }
 }

--- a/crates/node/engine/src/task_queue/tasks/forkchoice/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/forkchoice/task.rs
@@ -1,12 +1,17 @@
 //! A task for the `engine_forkchoiceUpdated` method, with no attributes.
 
 use crate::{
-    EngineClient, EngineState, EngineTaskError, EngineTaskExt, ForkchoiceTaskError, Metrics,
+    EngineClient, EngineForkchoiceVersion, EngineState, EngineTaskError, EngineTaskExt,
+    ForkchoiceTaskError, Metrics, state::EngineSyncStateUpdate,
 };
-use alloy_rpc_types_engine::INVALID_FORK_CHOICE_STATE_ERROR;
+use alloy_provider::ext::EngineApi;
+use alloy_rpc_types_engine::{INVALID_FORK_CHOICE_STATE_ERROR, PayloadId, PayloadStatusEnum};
 use async_trait::async_trait;
+use kona_genesis::RollupConfig;
+use kona_protocol::OpAttributesWithParent;
 use op_alloy_provider::ext::engine::OpEngineApi;
 use std::sync::Arc;
+use tokio::time::Instant;
 
 /// The [`ForkchoiceTask`] executes an `engine_forkchoiceUpdated` call with the current
 /// [`EngineState`]'s forkchoice, and no payload attributes.
@@ -14,59 +19,158 @@ use std::sync::Arc;
 pub struct ForkchoiceTask {
     /// The engine client.
     pub client: Arc<EngineClient>,
+    /// The rollup config.
+    pub rollup: Arc<RollupConfig>,
+    /// Optional payload attributes to be used for the forkchoice update.
+    pub envelope: Option<OpAttributesWithParent>,
+    /// The sync state update to apply to the engine state.
+    pub state_update: EngineSyncStateUpdate,
 }
 
 impl ForkchoiceTask {
     /// Creates a new [`ForkchoiceTask`].
-    pub const fn new(client: Arc<EngineClient>) -> Self {
-        Self { client }
+    pub const fn new(
+        client: Arc<EngineClient>,
+        rollup: Arc<RollupConfig>,
+        state_update: EngineSyncStateUpdate,
+        payload_attributes: Option<OpAttributesWithParent>,
+    ) -> Self {
+        Self { client, rollup, envelope: payload_attributes, state_update }
+    }
+
+    /// Checks the response of the `engine_forkchoiceUpdated` call, and updates the sync status if
+    /// necessary.
+    fn check_forkchoice_updated_status(
+        state: &mut EngineState,
+        status: &PayloadStatusEnum,
+    ) -> Result<(), ForkchoiceTaskError> {
+        match status {
+            PayloadStatusEnum::Valid => {
+                if !state.el_sync_finished {
+                    info!(
+                        target: "engine",
+                        "Finished execution layer sync."
+                    );
+                    state.el_sync_finished = true;
+                }
+
+                debug!(
+                    target: "engine_builder",
+                    "Forkchoice update with attributes successful"
+                );
+                Ok(())
+            }
+            PayloadStatusEnum::Syncing => {
+                warn!(target: "engine_builder", "Forkchoice update failed temporarily: EL is syncing");
+                Err(ForkchoiceTaskError::EngineSyncing)
+            }
+            PayloadStatusEnum::Invalid { validation_error } => {
+                error!(target: "engine_builder", "Forkchoice update failed: {}", validation_error);
+                Err(ForkchoiceTaskError::InvalidPayloadStatus(validation_error.clone()))
+            }
+            s => {
+                // Other codes are never returned by `engine_forkchoiceUpdate`
+                Err(ForkchoiceTaskError::UnexpectedPayloadStatus(s.clone()))
+            }
+        }
     }
 }
 
 #[async_trait]
 impl EngineTaskExt for ForkchoiceTask {
-    async fn execute(&self, state: &mut EngineState) -> Result<(), EngineTaskError> {
+    type Output = Option<PayloadId>;
+
+    async fn execute(&self, state: &mut EngineState) -> Result<Self::Output, EngineTaskError> {
+        // Apply the sync state update to the engine state.
+        let new_sync_state = state.sync_state.apply_update(self.state_update);
+
         // Check if a forkchoice update is not needed, return early.
-        if !state.forkchoice_update_needed {
+        // A forkchoice update is not needed if...
+        // 1. The engine state is not default (initial forkchoice state has been emitted), and
+        // 2. The new sync state is the same as the current sync state (no changes to the sync
+        //    state).
+        if state.sync_state != Default::default() &&
+            state.sync_state == new_sync_state &&
+            self.envelope.is_none()
+        {
             return Err(ForkchoiceTaskError::NoForkchoiceUpdateNeeded.into());
         }
 
-        // If the engine is syncing, log a warning. We can still attempt to apply the
-        // forkchoice update.
-        if !state.el_sync_finished {
-            warn!(target: "engine", "Attempting to update forkchoice state while EL syncing");
-        }
-
         // Check if the head is behind the finalized head.
-        if state.unsafe_head().block_info.number < state.finalized_head().block_info.number {
+        if new_sync_state.unsafe_head().block_info.number <
+            new_sync_state.finalized_head().block_info.number
+        {
             return Err(ForkchoiceTaskError::FinalizedAheadOfUnsafe(
-                state.unsafe_head().block_info.number,
-                state.finalized_head().block_info.number,
+                new_sync_state.unsafe_head().block_info.number,
+                new_sync_state.finalized_head().block_info.number,
             )
             .into());
         }
 
+        let fcu_time_start = Instant::now();
+
+        // Determine the forkchoice version to use.
+        // Note that if the envelope is not provided, we use the forkchoice version from the
+        // timestamp zero. The version number in `fork_choice_updated_v*`
+        // methods only matters for the payload attributes.
+        let version = EngineForkchoiceVersion::from_cfg(
+            &self.rollup,
+            self.envelope.as_ref().map(|p| p.inner.payload_attributes.timestamp).unwrap_or(0),
+        );
+
+        // TODO(@theochap, `<https://github.com/op-rs/kona/issues/2387>`): we should avoid cloning the payload attributes here.
+        let payload_attributes = self.envelope.as_ref().map(|p| p.inner()).cloned();
+
         // Send the forkchoice update through the input.
-        let forkchoice = state.create_forkchoice_state();
+        let forkchoice = new_sync_state.create_forkchoice_state();
 
         // Handle the forkchoice update result.
-        if let Err(e) = self.client.fork_choice_updated_v3(forkchoice, None).await {
-            let e = e
-                .as_error_resp()
+        let response = match version {
+            EngineForkchoiceVersion::V1 => {
+                self.client
+                    .fork_choice_updated_v1(
+                        forkchoice,
+                        payload_attributes.map(|p| p.payload_attributes),
+                    )
+                    .await
+            }
+            EngineForkchoiceVersion::V2 => {
+                self.client.fork_choice_updated_v2(forkchoice, payload_attributes).await
+            }
+            EngineForkchoiceVersion::V3 => {
+                self.client.fork_choice_updated_v3(forkchoice, payload_attributes).await
+            }
+        };
+
+        let valid_response = response.map_err(|e| {
+            // Fatal forkchoice update error.
+            e.as_error_resp()
                 .and_then(|e| {
                     (e.code == INVALID_FORK_CHOICE_STATE_ERROR as i64)
                         .then_some(ForkchoiceTaskError::InvalidForkchoiceState)
                 })
-                .unwrap_or_else(|| ForkchoiceTaskError::ForkchoiceUpdateFailed(e));
+                .unwrap_or_else(|| ForkchoiceTaskError::ForkchoiceUpdateFailed(e))
+        })?;
 
-            return Err(e.into());
-        }
+        // Unexpected forkchoice payload status.
+        // We may be able to recover from this by resetting the engine.
+        Self::check_forkchoice_updated_status(state, &valid_response.payload_status.status)?;
 
-        state.forkchoice_update_needed = false;
+        // Apply the new sync state to the engine state.
+        state.sync_state = new_sync_state;
 
         // Update metrics.
         kona_macros::inc!(counter, Metrics::ENGINE_TASK_COUNT, Metrics::FORKCHOICE_TASK_LABEL);
 
-        Ok(())
+        let fcu_duration = fcu_time_start.elapsed();
+        info!(
+            target: "engine",
+            fcu_duration = ?fcu_duration,
+            forkchoice = ?forkchoice,
+            response = ?valid_response,
+            "Forkchoice updated"
+        );
+
+        Ok(valid_response.payload_id)
     }
 }

--- a/crates/node/engine/src/task_queue/tasks/insert/error.rs
+++ b/crates/node/engine/src/task_queue/tasks/insert/error.rs
@@ -13,18 +13,12 @@ use op_alloy_rpc_types_engine::OpPayloadError;
 /// [InsertUnsafeTask]: crate::InsertUnsafeTask
 #[derive(Debug, thiserror::Error)]
 pub enum InsertUnsafeTaskError {
-    /// Could not fetch the finalized L2 block.
-    #[error("Could not fetch the finalized L2 block")]
-    FinalizedBlockFetch,
     /// Error converting a payload into a block.
     #[error(transparent)]
     FromBlockError(#[from] OpPayloadError),
     /// Failed to insert new payload.
     #[error("Failed to insert new payload: {0}")]
     InsertFailed(RpcError<TransportErrorKind>),
-    /// Failed to update the forkchoice.
-    #[error("Failed to update the forkchoice: {0}")]
-    ForkchoiceUpdateFailed(RpcError<TransportErrorKind>),
     /// Unexpected payload status
     #[error("Unexpected payload status: {0}")]
     UnexpectedPayloadStatus(PayloadStatusEnum),
@@ -39,11 +33,9 @@ pub enum InsertUnsafeTaskError {
 impl From<InsertUnsafeTaskError> for EngineTaskError {
     fn from(value: InsertUnsafeTaskError) -> Self {
         match value {
-            InsertUnsafeTaskError::FinalizedBlockFetch => Self::Temporary(Box::new(value)),
             InsertUnsafeTaskError::FromBlockError(_) => Self::Critical(Box::new(value)),
             InsertUnsafeTaskError::InsertFailed(_) => Self::Temporary(Box::new(value)),
-            InsertUnsafeTaskError::ForkchoiceUpdateFailed(_) => Self::Temporary(Box::new(value)),
-            InsertUnsafeTaskError::UnexpectedPayloadStatus(_) => Self::Temporary(Box::new(value)),
+            InsertUnsafeTaskError::UnexpectedPayloadStatus(_) => Self::Critical(Box::new(value)),
             InsertUnsafeTaskError::L2BlockInfoConstruction(_) => Self::Critical(Box::new(value)),
             InsertUnsafeTaskError::InconsistentForkchoiceState => Self::Reset(Box::new(value)),
         }

--- a/crates/node/rpc/src/rollup.rs
+++ b/crates/node/rpc/src/rollup.rs
@@ -52,11 +52,11 @@ impl RollupRpc {
             head_l1: l1_sync_status.head_l1.unwrap_or_default(),
             safe_l1: l1_sync_status.safe_l1.unwrap_or_default(),
             finalized_l1: l1_sync_status.finalized_l1.unwrap_or_default(),
-            unsafe_l2: l2_sync_status.unsafe_head(),
-            cross_unsafe_l2: l2_sync_status.cross_unsafe_head(),
-            local_safe_l2: l2_sync_status.local_safe_head(),
-            safe_l2: l2_sync_status.safe_head(),
-            finalized_l2: l2_sync_status.finalized_head(),
+            unsafe_l2: l2_sync_status.sync_state.unsafe_head(),
+            cross_unsafe_l2: l2_sync_status.sync_state.cross_unsafe_head(),
+            local_safe_l2: l2_sync_status.sync_state.local_safe_head(),
+            safe_l2: l2_sync_status.sync_state.safe_head(),
+            finalized_l2: l2_sync_status.sync_state.finalized_head(),
         }
     }
 }

--- a/crates/node/rpc/src/ws.rs
+++ b/crates/node/rpc/src/ws.rs
@@ -64,16 +64,16 @@ impl WsServer for WsRPC {
 
         let mut subscription = self.engine_state_watcher().await?;
 
-        let mut current_safe_head = subscription.borrow().safe_head();
+        let mut current_safe_head = subscription.borrow().sync_state.safe_head();
 
         Self::send_state_update(&sink, current_safe_head).await?;
 
         while let Ok(new_state) = subscription
-            .wait_for(|state| state.safe_head() != current_safe_head)
+            .wait_for(|state| state.sync_state.safe_head() != current_safe_head)
             .await
             .map(|state| *state)
         {
-            current_safe_head = new_state.safe_head();
+            current_safe_head = new_state.sync_state.safe_head();
             Self::send_state_update(&sink, current_safe_head).await?;
         }
 
@@ -86,16 +86,16 @@ impl WsServer for WsRPC {
 
         let mut subscription = self.engine_state_watcher().await?;
 
-        let mut current_finalized_head = subscription.borrow().finalized_head();
+        let mut current_finalized_head = subscription.borrow().sync_state.finalized_head();
 
         Self::send_state_update(&sink, current_finalized_head).await?;
 
         while let Ok(new_state) = subscription
-            .wait_for(|state| state.finalized_head() != current_finalized_head)
+            .wait_for(|state| state.sync_state.finalized_head() != current_finalized_head)
             .await
             .map(|state| *state)
         {
-            current_finalized_head = new_state.finalized_head();
+            current_finalized_head = new_state.sync_state.finalized_head();
             Self::send_state_update(&sink, current_finalized_head).await?;
         }
 
@@ -108,16 +108,16 @@ impl WsServer for WsRPC {
 
         let mut subscription = self.engine_state_watcher().await?;
 
-        let mut current_unsafe_head = subscription.borrow().unsafe_head();
+        let mut current_unsafe_head = subscription.borrow().sync_state.unsafe_head();
 
         Self::send_state_update(&sink, current_unsafe_head).await?;
 
         while let Ok(new_state) = subscription
-            .wait_for(|state| state.unsafe_head() != current_unsafe_head)
+            .wait_for(|state| state.sync_state.unsafe_head() != current_unsafe_head)
             .await
             .map(|state| *state)
         {
-            current_unsafe_head = new_state.unsafe_head();
+            current_unsafe_head = new_state.sync_state.unsafe_head();
             Self::send_state_update(&sink, current_unsafe_head).await?;
         }
 

--- a/crates/node/service/src/actors/engine/actor.rs
+++ b/crates/node/service/src/actors/engine/actor.rs
@@ -132,7 +132,7 @@ impl EngineBuilder {
 #[derive(Debug)]
 pub(super) struct EngineActorState {
     /// The [`RollupConfig`] used to build tasks.
-    rollup: Arc<RollupConfig>,
+    pub(super) rollup: Arc<RollupConfig>,
     /// An [`EngineClient`] used for creating engine tasks.
     pub(super) client: Arc<EngineClient>,
     /// The [`Engine`] task queue.
@@ -236,7 +236,7 @@ impl EngineActorState {
     ) -> Result<(), EngineError> {
         // Reset the engine.
         let (l2_safe_head, l1_origin, system_config) =
-            self.engine.reset(self.client.clone(), &self.rollup).await?;
+            self.engine.reset(self.client.clone(), self.rollup.clone()).await?;
 
         // Signal the derivation actor to reset.
         let signal = ResetSignal { l2_safe_head, l1_origin, system_config: Some(system_config) };
@@ -334,7 +334,7 @@ impl EngineActorState {
 
     /// Attempts to update the safe head via the watch channel.
     fn maybe_update_safe_head(&self, engine_l2_safe_head_tx: &watch::Sender<L2BlockInfo>) {
-        let state_safe_head = self.engine.state().safe_head();
+        let state_safe_head = self.engine.state().sync_state.safe_head();
         let update = |head: &mut L2BlockInfo| {
             if head != &state_safe_head {
                 *head = state_safe_head;

--- a/crates/node/service/src/actors/engine/finalizer.rs
+++ b/crates/node/service/src/actors/engine/finalizer.rs
@@ -70,6 +70,7 @@ impl L2Finalizer {
         if let Some((_, highest_safe_number)) = highest_safe {
             let task = EngineTask::Finalize(FinalizeTask::new(
                 engine_state.client.clone(),
+                engine_state.rollup.clone(),
                 *highest_safe_number,
             ));
             engine_state.engine.enqueue(task);

--- a/crates/protocol/protocol/src/block.rs
+++ b/crates/protocol/protocol/src/block.rs
@@ -106,6 +106,13 @@ pub struct L2BlockInfo {
     pub seq_num: u64,
 }
 
+impl L2BlockInfo {
+    /// Returns the block hash.
+    pub const fn hash(&self) -> B256 {
+        self.block_info.hash
+    }
+}
+
 #[cfg(feature = "arbitrary")]
 impl arbitrary::Arbitrary<'_> for L2BlockInfo {
     fn arbitrary(g: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {


### PR DESCRIPTION
## Description

This PR refactors the core logic of the engine task handler. In particular, it moves duplicate code from the build and the insert unsafe tasks to the forkchoice task.

Changes:
- Add an associated `Output` type for the `EngineTaskExt` trait which allows the implementors of this trait to be composed. In particular, the `ForkchoiceTask` may returns the payload id that was inserted in the EL, which can be used by the `BuildTask` to consolidate the payload into the engine state.
- Allows the `ForkchoiceTask` to directly insert newly built payload attributes into the EL (by adding an `Option<OpAttributeWithParent>` argument to the `ForkchoiceTask`). This allows to refactors both calls to the `FCU` inside the `BuildTask` using the `ForkchoiceTask` and avoids manually handling the forkchoice updates
- Moves the `PayloadStatus` verification logic to the `ForkchoiceTask` to avoid having to perform the same logic in both the `BuildTask` and the `InsertUnsafeTask`, which allows to fix the sequencer kickstart issue described in #2372 

Close #2372 

## Potential follow-ups

- Remove the clones inside the engine tasks
- Refactor the `new_payload` logic into an engine task to remove duplicate code in the `InsertUnsafe` and `Build`Tasks