### PR TITLE
chore: fix 404 URL

### DIFF
--- a/book/src/examples/new-l1-block-info-tx-hardfork.md
+++ b/book/src/examples/new-l1-block-info-tx-hardfork.md
@@ -105,7 +105,7 @@ Some new error variants to the [`BlockInfoError`][bie] are needed as well.
 [pr-diff]: https://github.com/alloy-rs/op-alloy/pull/130/files
 [decode-calldata]: https://docs.rs/kona-protocol/latest/kona_protocol/enum.L1BlockInfoTx.html#method.decode_calldata
 [try-new]: https://docs.rs/kona-protocol/latest/kona_protocol/enum.L1BlockInfoTx.html#method.try_new
-[ecotone]: https://github.com/op-rs/kona/blob/main/crates/protocol/src/info/ecotone.rs
+[ecotone]: https://github.com/op-rs/kona/blob/main/crates/protocol/protocol/src/info/ecotone.rs
 [info-mod]: https://github.com/op-rs/kona/blob/main/crates/protocol/src/info/mod.rs
 [genesis]: https://docs.rs/kona-genesis/latest/kona_genesis/index.html
 [rc]: https://docs.rs/kona-genesis/latest/kona_genesis/struct.RollupConfig.html


### PR DESCRIPTION
fix 404 URL  for `book/src/examples/new-l1-block-info-tx-hardfork.md`.