### PR TITLE
chore(node/engine): cleanup engine tasks errors. refactors the engine build task to reuse the insert task

### DIFF
--- a/crates/node/engine/src/lib.rs
+++ b/crates/node/engine/src/lib.rs
@@ -12,8 +12,9 @@ extern crate tracing;
 mod task_queue;
 pub use task_queue::{
     BuildTask, BuildTaskError, ConsolidateTask, ConsolidateTaskError, Engine, EngineResetError,
-    EngineTask, EngineTaskError, EngineTaskExt, FinalizeTask, FinalizeTaskError, ForkchoiceTask,
-    ForkchoiceTaskError, InsertUnsafeTask, InsertUnsafeTaskError,
+    EngineTask, EngineTaskError, EngineTaskErrorSeverity, EngineTaskErrors, EngineTaskExt,
+    FinalizeTask, FinalizeTaskError, ForkchoiceTask, ForkchoiceTaskError, InsertTask,
+    InsertTaskError,
 };
 
 mod attributes;

--- a/crates/node/engine/src/task_queue/tasks/consolidate/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/consolidate/task.rs
@@ -1,8 +1,8 @@
 //! A task to consolidate the engine state.
 
 use crate::{
-    BuildTask, ConsolidateTaskError, EngineClient, EngineState, EngineTaskError, EngineTaskExt,
-    ForkchoiceTask, Metrics, state::EngineSyncStateUpdate,
+    BuildTask, ConsolidateTaskError, EngineClient, EngineState, EngineTaskExt, ForkchoiceTask,
+    Metrics, state::EngineSyncStateUpdate,
 };
 use async_trait::async_trait;
 use kona_genesis::RollupConfig;
@@ -38,7 +38,10 @@ impl ConsolidateTask {
 
     /// Executes a new [`BuildTask`].
     /// This is used when the [`ConsolidateTask`] fails to consolidate the engine state.
-    async fn execute_build_task(&self, state: &mut EngineState) -> Result<(), EngineTaskError> {
+    async fn execute_build_task(
+        &self,
+        state: &mut EngineState,
+    ) -> Result<(), ConsolidateTaskError> {
         let build_task = BuildTask::new(
             self.client.clone(),
             self.cfg.clone(),
@@ -46,11 +49,11 @@ impl ConsolidateTask {
             self.is_attributes_derived,
             None,
         );
-        build_task.execute(state).await
+        Ok(build_task.execute(state).await?)
     }
 
     /// Attempts consolidation on the engine state.
-    pub async fn consolidate(&self, state: &mut EngineState) -> Result<(), EngineTaskError> {
+    pub async fn consolidate(&self, state: &mut EngineState) -> Result<(), ConsolidateTaskError> {
         let global_start = Instant::now();
 
         // Fetch the unsafe l2 block after the attributes parent.
@@ -60,11 +63,11 @@ impl ConsolidateTask {
             Ok(Some(block)) => block,
             Ok(None) => {
                 warn!(target: "engine", "Received `None` block for {}", block_num);
-                return Err(ConsolidateTaskError::MissingUnsafeL2Block(block_num).into());
+                return Err(ConsolidateTaskError::MissingUnsafeL2Block(block_num));
             }
             Err(_) => {
                 warn!(target: "engine", "Failed to fetch unsafe l2 block for consolidation");
-                return Err(ConsolidateTaskError::FailedToFetchUnsafeL2Block.into());
+                return Err(ConsolidateTaskError::FailedToFetchUnsafeL2Block);
             }
         };
         let block_fetch_duration = fetch_start.elapsed();
@@ -162,7 +165,9 @@ impl ConsolidateTask {
 impl EngineTaskExt for ConsolidateTask {
     type Output = ();
 
-    async fn execute(&self, state: &mut EngineState) -> Result<(), EngineTaskError> {
+    type Error = ConsolidateTaskError;
+
+    async fn execute(&self, state: &mut EngineState) -> Result<(), ConsolidateTaskError> {
         // Skip to building the payload attributes if consolidation is not needed.
         if state.sync_state.safe_head().block_info.number <
             state.sync_state.unsafe_head().block_info.number

--- a/crates/node/engine/src/task_queue/tasks/finalize/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/finalize/task.rs
@@ -1,8 +1,8 @@
 //! A task for finalizing an L2 block.
 
 use crate::{
-    EngineClient, EngineState, EngineTaskError, EngineTaskExt, FinalizeTaskError, ForkchoiceTask,
-    Metrics, state::EngineSyncStateUpdate,
+    EngineClient, EngineState, EngineTaskExt, FinalizeTaskError, ForkchoiceTask, Metrics,
+    state::EngineSyncStateUpdate,
 };
 use alloy_provider::Provider;
 use async_trait::async_trait;
@@ -33,10 +33,12 @@ impl FinalizeTask {
 impl EngineTaskExt for FinalizeTask {
     type Output = ();
 
-    async fn execute(&self, state: &mut EngineState) -> Result<(), EngineTaskError> {
+    type Error = FinalizeTaskError;
+
+    async fn execute(&self, state: &mut EngineState) -> Result<(), FinalizeTaskError> {
         // Sanity check that the block that is being finalized is at least safe.
         if state.sync_state.safe_head().block_info.number < self.block_number {
-            return Err(FinalizeTaskError::BlockNotSafe.into());
+            return Err(FinalizeTaskError::BlockNotSafe);
         }
 
         let block_fetch_start = Instant::now();

--- a/crates/node/engine/src/task_queue/tasks/forkchoice/error.rs
+++ b/crates/node/engine/src/task_queue/tasks/forkchoice/error.rs
@@ -1,6 +1,6 @@
 //! Contains error types for the [crate::ForkchoiceTask].
 
-use crate::EngineTaskError;
+use crate::{EngineTaskError, task_queue::tasks::task::EngineTaskErrorSeverity};
 use alloy_rpc_types_engine::PayloadStatusEnum;
 use alloy_transport::{RpcError, TransportErrorKind};
 use thiserror::Error;
@@ -31,16 +31,16 @@ pub enum ForkchoiceTaskError {
     UnexpectedPayloadStatus(PayloadStatusEnum),
 }
 
-impl From<ForkchoiceTaskError> for EngineTaskError {
-    fn from(value: ForkchoiceTaskError) -> Self {
-        match value {
-            ForkchoiceTaskError::NoForkchoiceUpdateNeeded => Self::Temporary(Box::new(value)),
-            ForkchoiceTaskError::EngineSyncing => Self::Temporary(Box::new(value)),
-            ForkchoiceTaskError::ForkchoiceUpdateFailed(_) => Self::Temporary(Box::new(value)),
-            ForkchoiceTaskError::FinalizedAheadOfUnsafe(_, _) => Self::Critical(Box::new(value)),
-            ForkchoiceTaskError::UnexpectedPayloadStatus(_) => Self::Critical(Box::new(value)),
-            ForkchoiceTaskError::InvalidForkchoiceState => Self::Reset(Box::new(value)),
-            ForkchoiceTaskError::InvalidPayloadStatus(_) => Self::Reset(Box::new(value)),
+impl EngineTaskError for ForkchoiceTaskError {
+    fn severity(&self) -> EngineTaskErrorSeverity {
+        match self {
+            Self::NoForkchoiceUpdateNeeded => EngineTaskErrorSeverity::Temporary,
+            Self::EngineSyncing => EngineTaskErrorSeverity::Temporary,
+            Self::ForkchoiceUpdateFailed(_) => EngineTaskErrorSeverity::Temporary,
+            Self::FinalizedAheadOfUnsafe(_, _) => EngineTaskErrorSeverity::Critical,
+            Self::UnexpectedPayloadStatus(_) => EngineTaskErrorSeverity::Critical,
+            Self::InvalidForkchoiceState => EngineTaskErrorSeverity::Reset,
+            Self::InvalidPayloadStatus(_) => EngineTaskErrorSeverity::Reset,
         }
     }
 }

--- a/crates/node/engine/src/task_queue/tasks/insert/error.rs
+++ b/crates/node/engine/src/task_queue/tasks/insert/error.rs
@@ -1,18 +1,20 @@
-//! Contains the error types for the [InsertUnsafeTask].
+//! Contains the error types for the [InsertTask].
 //!
-//! [InsertUnsafeTask]: crate::InsertUnsafeTask
+//! [InsertTask]: crate::InsertTask
 
-use crate::EngineTaskError;
+use crate::{
+    EngineTaskError, ForkchoiceTaskError, task_queue::tasks::task::EngineTaskErrorSeverity,
+};
 use alloy_rpc_types_engine::PayloadStatusEnum;
 use alloy_transport::{RpcError, TransportErrorKind};
 use kona_protocol::FromBlockError;
 use op_alloy_rpc_types_engine::OpPayloadError;
 
-/// An error that occurs when running the [InsertUnsafeTask].
+/// An error that occurs when running the [InsertTask].
 ///
-/// [InsertUnsafeTask]: crate::InsertUnsafeTask
+/// [InsertTask]: crate::InsertTask
 #[derive(Debug, thiserror::Error)]
-pub enum InsertUnsafeTaskError {
+pub enum InsertTaskError {
     /// Error converting a payload into a block.
     #[error(transparent)]
     FromBlockError(#[from] OpPayloadError),
@@ -28,16 +30,20 @@ pub enum InsertUnsafeTaskError {
     /// Error converting the payload + chain genesis into an L2 block info.
     #[error(transparent)]
     L2BlockInfoConstruction(#[from] FromBlockError),
+    /// The forkchoice update call to consolidate the block into the engine state failed.
+    #[error(transparent)]
+    ForkchoiceUpdateFailed(#[from] ForkchoiceTaskError),
 }
 
-impl From<InsertUnsafeTaskError> for EngineTaskError {
-    fn from(value: InsertUnsafeTaskError) -> Self {
-        match value {
-            InsertUnsafeTaskError::FromBlockError(_) => Self::Critical(Box::new(value)),
-            InsertUnsafeTaskError::InsertFailed(_) => Self::Temporary(Box::new(value)),
-            InsertUnsafeTaskError::UnexpectedPayloadStatus(_) => Self::Critical(Box::new(value)),
-            InsertUnsafeTaskError::L2BlockInfoConstruction(_) => Self::Critical(Box::new(value)),
-            InsertUnsafeTaskError::InconsistentForkchoiceState => Self::Reset(Box::new(value)),
+impl EngineTaskError for InsertTaskError {
+    fn severity(&self) -> EngineTaskErrorSeverity {
+        match self {
+            Self::FromBlockError(_) => EngineTaskErrorSeverity::Critical,
+            Self::InsertFailed(_) => EngineTaskErrorSeverity::Temporary,
+            Self::UnexpectedPayloadStatus(_) => EngineTaskErrorSeverity::Critical,
+            Self::L2BlockInfoConstruction(_) => EngineTaskErrorSeverity::Critical,
+            Self::InconsistentForkchoiceState => EngineTaskErrorSeverity::Reset,
+            Self::ForkchoiceUpdateFailed(inner) => inner.severity(),
         }
     }
 }

--- a/crates/node/engine/src/task_queue/tasks/insert/mod.rs
+++ b/crates/node/engine/src/task_queue/tasks/insert/mod.rs
@@ -1,7 +1,7 @@
 //! Task to insert an unsafe payload into the execution engine.
 
 mod task;
-pub use task::InsertUnsafeTask;
+pub use task::InsertTask;
 
 mod error;
-pub use error::InsertUnsafeTaskError;
+pub use error::InsertTaskError;

--- a/crates/node/engine/src/task_queue/tasks/mod.rs
+++ b/crates/node/engine/src/task_queue/tasks/mod.rs
@@ -1,13 +1,15 @@
 //! Tasks to update the engine state.
 
 mod task;
-pub use task::{EngineTask, EngineTaskError, EngineTaskExt};
+pub use task::{
+    EngineTask, EngineTaskError, EngineTaskErrorSeverity, EngineTaskErrors, EngineTaskExt,
+};
 
 mod forkchoice;
 pub use forkchoice::{ForkchoiceTask, ForkchoiceTaskError};
 
 mod insert;
-pub use insert::{InsertUnsafeTask, InsertUnsafeTaskError};
+pub use insert::{InsertTask, InsertTaskError};
 
 mod build;
 pub use build::{BuildTask, BuildTaskError};

--- a/crates/node/service/src/actors/engine/error.rs
+++ b/crates/node/service/src/actors/engine/error.rs
@@ -2,7 +2,7 @@
 //!
 //! [`EngineActor`]: super::EngineActor
 
-use kona_engine::{EngineResetError, EngineTaskError};
+use kona_engine::{EngineResetError, EngineTaskErrors};
 
 /// An error from the [`EngineActor`].
 ///
@@ -17,5 +17,5 @@ pub enum EngineError {
     EngineReset(#[from] EngineResetError),
     /// Engine task error.
     #[error(transparent)]
-    EngineTask(#[from] EngineTaskError),
+    EngineTask(#[from] EngineTaskErrors),
 }


### PR DESCRIPTION
## Description

This PR does the following cleanups to the engine tasks:

- Use explicit error types instead of `dyn Box<...>` for the `EngineTaskError`. The goal of this is twofold:
   - Improve the composability of engine tasks (and be able to do some control flow when an engine task emits an error)
   - Allows explicit testing of the error cases (in the future when we'll add tests for the engine tasks)
- Refactors the build task in the engine to reuse the `InsertUnsafe` task logic. This task is now called `InsertTask` to also encapsulate the case where we insert a derived block.

Close #2390. Progress towards #2389