### PR TITLE
feat(node/engine): remove temporary error variant. avoid cloning payloads when possible

### DIFF
--- a/crates/node/engine/src/task_queue/core.rs
+++ b/crates/node/engine/src/task_queue/core.rs
@@ -132,15 +132,11 @@ impl Engine {
     /// the error is returned.
     pub async fn drain(&mut self) -> Result<(), EngineTaskErrors> {
         // Drain tasks in order of priority, halting on errors for a retry to be attempted.
-        while let Some(task) = self.tasks.peek() {
-            // Execute the task
+        while let Some(task) = self.tasks.pop() {
             task.execute(&mut self.state).await?;
 
             // Update the state and notify the engine actor.
             self.state_sender.send_replace(self.state);
-
-            // Pop the task from the queue now that it's been executed.
-            self.tasks.pop();
         }
 
         Ok(())

--- a/crates/node/engine/src/task_queue/tasks/build/error.rs
+++ b/crates/node/engine/src/task_queue/tasks/build/error.rs
@@ -14,15 +14,9 @@ use tokio::sync::mpsc;
 /// An error that occurs when running the [crate::ForkchoiceTask].
 #[derive(Debug, Error)]
 pub enum BuildTaskError {
-    /// The forkchoice update is not needed.
-    #[error("No forkchoice update needed")]
-    NoForkchoiceUpdateNeeded,
-    /// The engine is syncing.
-    #[error("Attempting to update forkchoice state while EL syncing")]
-    EngineSyncing,
-    /// Missing payload ID.
-    #[error("Missing payload ID")]
-    MissingPayloadId,
+    /// Failed to insert the payload into the engine.
+    #[error("Failed to insert the payload into the engine")]
+    InsertPayloadFailed,
     /// The initial forkchoice update call to the engine api failed.
     #[error(transparent)]
     ForkchoiceUpdateFailed(#[from] ForkchoiceTaskError),
@@ -64,12 +58,10 @@ impl EngineTaskError for BuildTaskError {
         match self {
             Self::ForkchoiceUpdateFailed(inner) => inner.severity(),
             Self::PayloadInsertionFailed(inner) => inner.severity(),
-            Self::NoForkchoiceUpdateNeeded => EngineTaskErrorSeverity::Temporary,
-            Self::EngineSyncing => EngineTaskErrorSeverity::Temporary,
-            Self::GetPayloadFailed(_) => EngineTaskErrorSeverity::Temporary,
-            Self::NewPayloadFailed(_) => EngineTaskErrorSeverity::Temporary,
+            Self::GetPayloadFailed(_) => EngineTaskErrorSeverity::Reset,
+            Self::NewPayloadFailed(_) => EngineTaskErrorSeverity::Reset,
             Self::HoloceneInvalidFlush => EngineTaskErrorSeverity::Flush,
-            Self::MissingPayloadId => EngineTaskErrorSeverity::Critical,
+            Self::InsertPayloadFailed => EngineTaskErrorSeverity::Critical,
             Self::UnexpectedPayloadStatus(_) => EngineTaskErrorSeverity::Critical,
             Self::DepositOnlyPayloadReattemptFailed => EngineTaskErrorSeverity::Critical,
             Self::DepositOnlyPayloadFailed => EngineTaskErrorSeverity::Critical,

--- a/crates/node/engine/src/task_queue/tasks/consolidate/error.rs
+++ b/crates/node/engine/src/task_queue/tasks/consolidate/error.rs
@@ -27,7 +27,7 @@ impl EngineTaskError for ConsolidateTaskError {
     fn severity(&self) -> EngineTaskErrorSeverity {
         match self {
             Self::MissingUnsafeL2Block(_) => EngineTaskErrorSeverity::Reset,
-            Self::FailedToFetchUnsafeL2Block => EngineTaskErrorSeverity::Temporary,
+            Self::FailedToFetchUnsafeL2Block => EngineTaskErrorSeverity::Drop,
             Self::BuildTaskFailed(inner) => inner.severity(),
             Self::ForkchoiceUpdateFailed(inner) => inner.severity(),
         }

--- a/crates/node/engine/src/task_queue/tasks/finalize/error.rs
+++ b/crates/node/engine/src/task_queue/tasks/finalize/error.rs
@@ -35,7 +35,7 @@ impl EngineTaskError for FinalizeTaskError {
             Self::BlockNotSafe => EngineTaskErrorSeverity::Critical,
             Self::BlockNotFound(_) => EngineTaskErrorSeverity::Critical,
             Self::FromBlock(_) => EngineTaskErrorSeverity::Critical,
-            Self::TransportError(_) => EngineTaskErrorSeverity::Temporary,
+            Self::TransportError(_) => EngineTaskErrorSeverity::Drop,
             Self::ForkchoiceUpdateFailed(inner) => inner.severity(),
         }
     }

--- a/crates/node/engine/src/task_queue/tasks/finalize/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/finalize/task.rs
@@ -12,7 +12,7 @@ use std::{sync::Arc, time::Instant};
 
 /// The [`FinalizeTask`] fetches the [`L2BlockInfo`] at `block_number`, updates the [`EngineState`],
 /// and dispatches a forkchoice update to finalize the block.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct FinalizeTask {
     /// The engine client.
     pub client: Arc<EngineClient>,
@@ -35,7 +35,7 @@ impl EngineTaskExt for FinalizeTask {
 
     type Error = FinalizeTaskError;
 
-    async fn execute(&self, state: &mut EngineState) -> Result<(), FinalizeTaskError> {
+    async fn execute(self, state: &mut EngineState) -> Result<(), FinalizeTaskError> {
         // Sanity check that the block that is being finalized is at least safe.
         if state.sync_state.safe_head().block_info.number < self.block_number {
             return Err(FinalizeTaskError::BlockNotSafe);
@@ -58,8 +58,8 @@ impl EngineTaskExt for FinalizeTask {
         // Dispatch a forkchoice update.
         let fcu_start = Instant::now();
         ForkchoiceTask::new(
-            self.client.clone(),
-            self.cfg.clone(),
+            self.client,
+            self.cfg,
             EngineSyncStateUpdate { finalized_head: Some(block_info), ..Default::default() },
             None,
         )

--- a/crates/node/engine/src/task_queue/tasks/forkchoice/error.rs
+++ b/crates/node/engine/src/task_queue/tasks/forkchoice/error.rs
@@ -34,9 +34,9 @@ pub enum ForkchoiceTaskError {
 impl EngineTaskError for ForkchoiceTaskError {
     fn severity(&self) -> EngineTaskErrorSeverity {
         match self {
-            Self::NoForkchoiceUpdateNeeded => EngineTaskErrorSeverity::Temporary,
-            Self::EngineSyncing => EngineTaskErrorSeverity::Temporary,
-            Self::ForkchoiceUpdateFailed(_) => EngineTaskErrorSeverity::Temporary,
+            Self::NoForkchoiceUpdateNeeded => EngineTaskErrorSeverity::Drop,
+            Self::EngineSyncing => EngineTaskErrorSeverity::Drop,
+            Self::ForkchoiceUpdateFailed(_) => EngineTaskErrorSeverity::Drop,
             Self::FinalizedAheadOfUnsafe(_, _) => EngineTaskErrorSeverity::Critical,
             Self::UnexpectedPayloadStatus(_) => EngineTaskErrorSeverity::Critical,
             Self::InvalidForkchoiceState => EngineTaskErrorSeverity::Reset,

--- a/crates/node/engine/src/task_queue/tasks/forkchoice/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/forkchoice/task.rs
@@ -15,7 +15,7 @@ use tokio::time::Instant;
 
 /// The [`ForkchoiceTask`] executes an `engine_forkchoiceUpdated` call with the current
 /// [`EngineState`]'s forkchoice, and no payload attributes.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ForkchoiceTask {
     /// The engine client.
     pub client: Arc<EngineClient>,
@@ -81,7 +81,7 @@ impl EngineTaskExt for ForkchoiceTask {
     type Output = Option<PayloadId>;
     type Error = ForkchoiceTaskError;
 
-    async fn execute(&self, state: &mut EngineState) -> Result<Self::Output, ForkchoiceTaskError> {
+    async fn execute(self, state: &mut EngineState) -> Result<Self::Output, ForkchoiceTaskError> {
         // Apply the sync state update to the engine state.
         let new_sync_state = state.sync_state.apply_update(self.state_update);
 
@@ -118,8 +118,7 @@ impl EngineTaskExt for ForkchoiceTask {
             self.envelope.as_ref().map(|p| p.inner.payload_attributes.timestamp).unwrap_or(0),
         );
 
-        // TODO(@theochap, `<https://github.com/op-rs/kona/issues/2387>`): we should avoid cloning the payload attributes here.
-        let payload_attributes = self.envelope.as_ref().map(|p| p.inner()).cloned();
+        let payload_attributes = self.envelope.map(|p| p.inner);
 
         // Send the forkchoice update through the input.
         let forkchoice = new_sync_state.create_forkchoice_state();

--- a/crates/node/engine/src/task_queue/tasks/insert/error.rs
+++ b/crates/node/engine/src/task_queue/tasks/insert/error.rs
@@ -39,7 +39,7 @@ impl EngineTaskError for InsertTaskError {
     fn severity(&self) -> EngineTaskErrorSeverity {
         match self {
             Self::FromBlockError(_) => EngineTaskErrorSeverity::Critical,
-            Self::InsertFailed(_) => EngineTaskErrorSeverity::Temporary,
+            Self::InsertFailed(_) => EngineTaskErrorSeverity::Drop,
             Self::UnexpectedPayloadStatus(_) => EngineTaskErrorSeverity::Critical,
             Self::L2BlockInfoConstruction(_) => EngineTaskErrorSeverity::Critical,
             Self::InconsistentForkchoiceState => EngineTaskErrorSeverity::Reset,

--- a/crates/protocol/protocol/src/attributes.rs
+++ b/crates/protocol/protocol/src/attributes.rs
@@ -70,15 +70,15 @@ impl OpAttributesWithParent {
     }
 
     /// Converts the [`OpAttributesWithParent`] into a deposits-only payload.
-    pub fn as_deposits_only(&self) -> Self {
+    pub fn as_deposits_only(self) -> Self {
         Self {
             inner: OpPayloadAttributes {
-                transactions: self.inner.transactions.as_ref().map(|txs| {
+                transactions: self.inner.transactions.map(|txs| {
                     txs.iter()
                         .map(|_| alloy_primitives::Bytes::from(vec![OpTxType::Deposit as u8]))
                         .collect()
                 }),
-                ..self.inner.clone()
+                ..self.inner
             },
             parent: self.parent,
             l1_origin: self.l1_origin,


### PR DESCRIPTION
## Description

This PR replaces the `Temporary` error variant with a `Drop` variant inside the `Engine`. It unifies the way we propagate errors inside the engine, and in particular it postpones the error handling until they get propagated to the actor level. This makes the data flows in the engine more explicit

Close #2403 #2387
