### PR TITLE
feat(node/service): Prevent second reset on startup when sequencing

### DIFF
--- a/crates/node/service/src/actors/engine/actor.rs
+++ b/crates/node/service/src/actors/engine/actor.rs
@@ -330,6 +330,12 @@ impl EngineActorState {
                 return Ok(());
             };
 
+            // Only reset the engine if the sync state does not already know about a finalized
+            // block.
+            if self.engine.state().sync_state.finalized_head() != L2BlockInfo::default() {
+                return Ok(());
+            }
+
             // If the sync status is finished, we can reset the engine and start derivation.
             info!(target: "engine", "Performing initial engine reset");
             self.reset(derivation_signal_tx, engine_l2_safe_head_tx, finalizer).await?;


### PR DESCRIPTION
## Overview

Prevents the second reset that occurs when starting the node up in sequencing mode by disallowing the "execution layer sync finished" reset to trigger if the engine already knows of a finalized block.