### PR TITLE
chore(deps): update rocksdb dep to fix build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,7 +1515,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -2327,7 +2327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.104",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3943,15 +3943,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -5198,7 +5189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.2",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5596,9 +5587,8 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.17.1+9.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b7869a512ae9982f4d46ba482c2a304f1efd80c6412a3d4bf57bb79a619679f"
+version = "0.17.2+9.10.0"
+source = "git+https://github.com/rust-rocksdb/rust-rocksdb?rev=7da6d11e669e1467d919764e446b82edeebb00c0#7da6d11e669e1467d919764e446b82edeebb00c0"
 dependencies = [
  "bindgen 0.69.5",
  "bzip2-sys",
@@ -8027,8 +8017,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec73b20525cb235bad420f911473b69f9fe27cc856c5461bccd7e4af037f43"
+source = "git+https://github.com/rust-rocksdb/rust-rocksdb?rev=7da6d11e669e1467d919764e446b82edeebb00c0#7da6d11e669e1467d919764e446b82edeebb00c0"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -252,7 +252,7 @@ serde = { version = "1.0.219", default-features = false }
 serde_json = { version = "1.0.140", default-features = false }
 
 # K/V database
-rocksdb = { version = "0.23.0", default-features = false }
+rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb", rev = "7da6d11e669e1467d919764e446b82edeebb00c0", default-features = false }
 
 # Cryptography
 sha2 = { version = "0.10.9", default-features = false }


### PR DESCRIPTION
The kona repo failed to build due to a rocksdb C issue on my system.

This PR updates the dep, to support cstdint / GCC 15 / newer C toolchain, by including the rocksdb build fix (git rev, unfortunately no newer tagged releases to update to): https://github.com/rust-rocksdb/rust-rocksdb/pull/1007

For anyone else running into toolchain issues, as work-around, building also works like this, without the dep fix:
```
export CXXFLAGS="-include cstdint"
cargo b
```
Documenting it here for anyone else running into it...
