### PR TITLE
fix(bin/node): Fix `SUPERVISOR_PORT` envvar typo

### DIFF
--- a/bin/node/src/flags/supervisor.rs
+++ b/bin/node/src/flags/supervisor.rs
@@ -30,7 +30,7 @@ pub struct SupervisorArgs {
     pub ip_address: IpAddr,
 
     /// TCP port to serve the supervisor rpc. Any available system port if set to 0.
-    #[arg(long = "supervisor.port", default_value = "9333", env = "KONA_NODE_SEQUENCER_PORT")]
+    #[arg(long = "supervisor.port", default_value = "9333", env = "KONA_NODE_SUPERVISOR_PORT")]
     pub port: u16,
 
     /// JWT secret for supervisor websocket authentication

--- a/book/src/node/cli.md
+++ b/book/src/node/cli.md
@@ -12,7 +12,7 @@ This document lists all CLI flags for the `kona-node node` subcommand, grouped b
 | RPC WebSocket   | 9545         | (same as HTTP, enabled with `--rpc.ws-enabled`) |
 | P2P TCP         | 9222         | `--p2p.listen.tcp` / `KONA_NODE_P2P_LISTEN_TCP_PORT` |
 | P2P UDP         | 9223         | `--p2p.listen.udp` / `KONA_NODE_P2P_LISTEN_UDP_PORT` |
-| Supervisor RPC  | 9333         | `--supervisor.port` / `KONA_NODE_SEQUENCER_PORT`     |
+| Supervisor RPC  | 9333         | `--supervisor.port` / `KONA_NODE_SUPERVISOR_PORT`     |
 | Conductor RPC   | 8547         | `--conductor.rpc` / `KONA_NODE_CONDUCTOR_RPC`        |
 
 ---


### PR DESCRIPTION
## Overview

Fixes the `KONA_NODE_SUPERVISOR_PORT` environment variable.