### PR TITLE
feat(kona/logs): add logging format options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4246,6 +4246,7 @@ dependencies = [
  "libc",
  "libp2p",
  "metrics-exporter-prometheus",
+ "serde",
  "thiserror 2.0.12",
  "tracing",
  "tracing-subscriber 0.3.19",

--- a/bin/host/src/bin/host.rs
+++ b/bin/host/src/bin/host.rs
@@ -6,7 +6,7 @@
 
 use anyhow::Result;
 use clap::{ArgAction, Parser, Subcommand};
-use kona_cli::{cli_styles, init_tracing_subscriber};
+use kona_cli::{LogFormat, cli_styles, init_tracing_subscriber};
 use serde::Serialize;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
@@ -28,6 +28,9 @@ pub struct HostCli {
     /// By default, the verbosity level is set to 3 (info level).
     #[arg(long, short, default_value = "3", action = ArgAction::Count)]
     pub v: u8,
+    /// The format of the logs. One of: full, json, pretty, compact.
+    #[arg(long = "logs.format", short = 'f', default_value = "full")]
+    pub logs_format: LogFormat,
     /// Host mode
     #[command(subcommand)]
     pub mode: HostMode,
@@ -48,7 +51,7 @@ pub enum HostMode {
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
     let cfg = HostCli::parse();
-    init_tracing_subscriber(cfg.v, None::<EnvFilter>)?;
+    init_tracing_subscriber(cfg.v, None::<EnvFilter>, cfg.logs_format)?;
 
     match cfg.mode {
         #[cfg(feature = "single")]

--- a/crates/utilities/cli/Cargo.toml
+++ b/crates/utilities/cli/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 tracing.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
+serde.workspace = true
 tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
 metrics-exporter-prometheus = { workspace = true, features = ["http-listener"] }
 anyhow = { version = "1.0.98", default-features = false }

--- a/crates/utilities/cli/Cargo.toml
+++ b/crates/utilities/cli/Cargo.toml
@@ -13,9 +13,9 @@ workspace = true
 
 [dependencies]
 tracing.workspace = true
+serde = { workspace = true, features = ["derive"]}
 clap = { workspace = true, features = ["derive", "env"] }
-serde.workspace = true
-tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
+tracing-subscriber = { workspace = true, features = ["fmt", "env-filter", "json"] }
 metrics-exporter-prometheus = { workspace = true, features = ["http-listener"] }
 anyhow = { version = "1.0.98", default-features = false }
 

--- a/crates/utilities/cli/src/lib.rs
+++ b/crates/utilities/cli/src/lib.rs
@@ -18,7 +18,7 @@ pub mod backtrace;
 pub mod log;
 
 mod tracing;
-pub use tracing::{init_test_tracing, init_tracing_subscriber};
+pub use tracing::{LogFormat, init_test_tracing, init_tracing_subscriber};
 
 mod prometheus;
 pub use prometheus::init_prometheus_server;

--- a/crates/utilities/cli/src/log.rs
+++ b/crates/utilities/cli/src/log.rs
@@ -3,7 +3,7 @@
 use clap::{ArgAction, Args};
 use tracing_subscriber::EnvFilter;
 
-use crate::init_tracing_subscriber;
+use crate::{init_tracing_subscriber, tracing::LogFormat};
 
 /// Global configuration arguments.
 #[derive(Args, Debug, Default, Clone)]
@@ -16,15 +16,25 @@ pub struct LogArgs {
         short,
         global = true,
         default_value = "3",
+        env = "KONA_NODE_LOG_LEVEL",
         action = ArgAction::Count,
     )]
     pub v: u8,
+    /// The format of the logs. One of: full, json, pretty, compact.
+    #[arg(
+        long = "logs.format",
+        short = 'f',
+        global = true,
+        default_value = "full",
+        env = "KONA_NODE_LOG_FORMAT"
+    )]
+    pub logs_format: LogFormat,
 }
 
 impl LogArgs {
     /// Initializes the telemetry stack.
     pub fn init_tracing(&self, filter: Option<EnvFilter>) -> anyhow::Result<()> {
-        Ok(init_tracing_subscriber(self.v, filter)?)
+        Ok(init_tracing_subscriber(self.v, filter, self.logs_format)?)
     }
 }
 

--- a/crates/utilities/cli/src/tracing.rs
+++ b/crates/utilities/cli/src/tracing.rs
@@ -1,7 +1,26 @@
 //! [tracing_subscriber] utilities.
 
-use tracing::{Level, subscriber::SetGlobalDefaultError};
+use serde::{Deserialize, Serialize};
+use tracing::{level_filters::LevelFilter, subscriber::SetGlobalDefaultError};
 use tracing_subscriber::EnvFilter;
+
+/// The format of the logs.
+#[derive(
+    Default, Debug, Clone, Copy, PartialEq, Eq, Hash, clap::ValueEnum, Serialize, Deserialize,
+)]
+#[serde(rename_all = "lowercase")]
+#[clap(rename_all = "lowercase")]
+pub enum LogFormat {
+    /// Full format (default).
+    #[default]
+    Full,
+    /// JSON format.
+    Json,
+    /// Pretty format.
+    Pretty,
+    /// Compact format.
+    Compact,
+}
 
 /// Initializes the tracing subscriber
 ///
@@ -14,22 +33,43 @@ use tracing_subscriber::EnvFilter;
 pub fn init_tracing_subscriber(
     verbosity_level: u8,
     env_filter: Option<impl Into<EnvFilter>>,
+    log_format: LogFormat,
 ) -> Result<(), SetGlobalDefaultError> {
-    if verbosity_level == 0 {
-        return Ok(());
-    }
-
     let level = match verbosity_level {
-        1 => Level::ERROR,
-        2 => Level::WARN,
-        3 => Level::INFO,
-        4 => Level::DEBUG,
-        _ => Level::TRACE,
+        0 => LevelFilter::OFF,
+        1 => LevelFilter::ERROR,
+        2 => LevelFilter::WARN,
+        3 => LevelFilter::INFO,
+        4 => LevelFilter::DEBUG,
+        _ => LevelFilter::TRACE,
     };
     let filter = env_filter.map(|e| e.into()).unwrap_or(EnvFilter::from_default_env());
     let filter = filter.add_directive(level.into());
-    let subscriber = tracing_subscriber::fmt().with_max_level(level);
-    tracing::subscriber::set_global_default(subscriber.with_env_filter(filter).finish())
+
+    match log_format {
+        LogFormat::Full => {
+            let subscriber =
+                tracing_subscriber::fmt().with_max_level(level).with_env_filter(filter);
+            tracing::subscriber::set_global_default(subscriber.finish())?;
+        }
+        LogFormat::Json => {
+            let subscriber =
+                tracing_subscriber::fmt().json().with_max_level(level).with_env_filter(filter);
+            tracing::subscriber::set_global_default(subscriber.finish())?;
+        }
+        LogFormat::Pretty => {
+            let subscriber =
+                tracing_subscriber::fmt().pretty().with_max_level(level).with_env_filter(filter);
+            tracing::subscriber::set_global_default(subscriber.finish())?;
+        }
+        LogFormat::Compact => {
+            let subscriber =
+                tracing_subscriber::fmt().compact().with_max_level(level).with_env_filter(filter);
+            tracing::subscriber::set_global_default(subscriber.finish())?;
+        }
+    };
+
+    Ok(())
 }
 
 /// This provides function for init tracing in testing
@@ -39,5 +79,5 @@ pub fn init_tracing_subscriber(
 /// - `init_tracing_subscriber`: Initializes the tracing subscriber with a specified verbosity level
 ///   and optional environment filter.
 pub fn init_test_tracing() {
-    let _ = init_tracing_subscriber(4, None::<EnvFilter>);
+    let _ = init_tracing_subscriber(4, None::<EnvFilter>, LogFormat::Full);
 }

--- a/examples/discovery/src/main.rs
+++ b/examples/discovery/src/main.rs
@@ -19,7 +19,7 @@
 
 use clap::{ArgAction, Parser};
 use discv5::enr::CombinedKey;
-use kona_cli::init_tracing_subscriber;
+use kona_cli::{LogFormat, init_tracing_subscriber};
 use kona_p2p::{Discv5Builder, LocalNode};
 use std::net::{IpAddr, Ipv4Addr};
 
@@ -32,6 +32,9 @@ pub struct DiscCommand {
     /// By default, the verbosity level is set to 3 (info level).
     #[arg(long, short, default_value = "3", action = ArgAction::Count)]
     pub v: u8,
+    /// The format of the logs. One of: full, json, pretty, compact.
+    #[arg(long = "logs.format", short = 'f', default_value = "full")]
+    pub logs_format: LogFormat,
     /// The L2 chain ID to use.
     #[arg(long, short = 'c', default_value = "10", help = "The L2 chain ID to use")]
     pub l2_chain_id: u64,
@@ -48,7 +51,7 @@ impl DiscCommand {
     pub async fn run(self) -> anyhow::Result<()> {
         let filter = tracing_subscriber::EnvFilter::from_default_env()
             .add_directive("discv5=error".parse()?);
-        init_tracing_subscriber(self.v, Some(filter))?;
+        init_tracing_subscriber(self.v, Some(filter), self.logs_format)?;
 
         let CombinedKey::Secp256k1(secret_key) = CombinedKey::generate_secp256k1() else {
             unreachable!()

--- a/examples/execution-fixture/src/main.rs
+++ b/examples/execution-fixture/src/main.rs
@@ -18,7 +18,7 @@
 
 use anyhow::{Result, anyhow};
 use clap::{ArgAction, Parser};
-use kona_cli::init_tracing_subscriber;
+use kona_cli::{LogFormat, init_tracing_subscriber};
 use kona_executor::test_utils::ExecutorTestFixtureCreator;
 use std::path::PathBuf;
 use tracing::info;
@@ -34,6 +34,9 @@ pub struct ExecutionFixtureCommand {
     /// By default, the verbosity level is set to 3 (info level).
     #[arg(long, short, default_value = "3", action = ArgAction::Count)]
     pub v: u8,
+    /// The format of the logs. One of: full, json, pretty, compact.
+    #[arg(long = "logs.format", short = 'f', default_value = "full")]
+    pub logs_format: LogFormat,
     /// The L2 archive EL to use.
     #[arg(long, short = 'r')]
     pub l2_rpc: Url,
@@ -48,7 +51,7 @@ pub struct ExecutionFixtureCommand {
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = ExecutionFixtureCommand::parse();
-    init_tracing_subscriber(cli.v, None::<EnvFilter>)?;
+    init_tracing_subscriber(cli.v, None::<EnvFilter>, cli.logs_format)?;
 
     let output_dir = if let Some(output_dir) = cli.output_dir {
         output_dir

--- a/examples/gossip/src/main.rs
+++ b/examples/gossip/src/main.rs
@@ -19,7 +19,7 @@
 
 use clap::{ArgAction, Parser};
 use discv5::enr::CombinedKey;
-use kona_cli::init_tracing_subscriber;
+use kona_cli::{LogFormat, init_tracing_subscriber};
 use kona_node_service::{NetworkActor, NetworkConfig, NetworkContext, NodeActor};
 use kona_p2p::LocalNode;
 use kona_registry::ROLLUP_CONFIGS;
@@ -40,6 +40,9 @@ pub struct GossipCommand {
     /// By default, the verbosity level is set to 3 (info level).
     #[arg(long, short, default_value = "3", action = ArgAction::Count)]
     pub v: u8,
+    /// The format of the logs. One of: full, json, pretty, compact.
+    #[arg(long = "logs.format", short = 'f', default_value = "full")]
+    pub logs_format: LogFormat,
     /// The L2 chain ID to use.
     #[arg(long, short = 'c', default_value = "10", help = "The L2 chain ID to use")]
     pub l2_chain_id: u64,
@@ -57,7 +60,7 @@ pub struct GossipCommand {
 impl GossipCommand {
     /// Run the gossip subcommand.
     pub async fn run(self) -> anyhow::Result<()> {
-        init_tracing_subscriber(self.v, None::<EnvFilter>)?;
+        init_tracing_subscriber(self.v, None::<EnvFilter>, self.logs_format)?;
 
         let rollup_config = ROLLUP_CONFIGS
             .get(&self.l2_chain_id)


### PR DESCRIPTION
## Description

This PR adds options for logging format to kona's tracing utilities and propagates them to the CLI.

Logging options:
- json
- full (default)
- compact
- pretty

Tested inside kurtosis