### PR TITLE
fix(docs): Callouts and Doc Links

### DIFF
--- a/docs/docs/pages/sdk/examples/batch-to-frames.mdx
+++ b/docs/docs/pages/sdk/examples/batch-to-frames.mdx
@@ -1,25 +1,21 @@
-import { Callout } from 'vocs/components'
-
 # Transform a Batch into Frames
 
-<Callout type="info">
-
+:::info
 This example performs the reverse transformation as the [frames-to-batch][frames-to-batch] example.
-
-</Callout>
-
-<Callout type="danger">
-
-Steps and handling of types with respect to chain tip, ordering of frames, re-orgs, and
-more are not covered by this example. This example solely demonstrates the most trivial
-way to transform an individual [`Batch`][batch] into [`Frame`][frame]s.
-
-</Callout>
+:::
 
 This example walks through transforming a [`Batch`][batch] into [`Frame`][frame]s.
 
 Effectively, this example demonstrates the _encoding_ process from an L2 batch into the
 serialized bytes that are posted to the data availability layer.
+
+:::danger
+Steps and handling of types with respect to chain tip, ordering of frames, re-orgs, and
+more are not covered by this example. This example solely demonstrates the most trivial
+way to transform an individual [`Batch`][batch] into [`Frame`][frame]s.
+:::
+
+
 
 ## Walkthrough
 
@@ -34,13 +30,11 @@ using the [`Batch::encode()`][encode-batch] method. The output bytes
 need to then be compressed prior to adding them to the
 [`ChannelOut`][channel-out].
 
-<Callout type="info">
-
+:::info
 The [`ChannelOut`][channel-out] type also provides a method for adding
 the [`Batch`][batch] itself, handling encoding and compression, but
 this method is not available yet.
-
-</Callout>
+:::
 
 Once compressed using the [`compress_brotli`][compress-brotli] method, the
 compressed bytes can be added to a newly constructed [`ChannelOut`][channel-out].
@@ -173,8 +167,28 @@ fn main() {
 }
 ```
 
+[frame]: https://docs.rs/kona-protocol/latest/kona_protocol/struct.Frame.html
+[batch]: https://docs.rs/kona-protocol/latest/kona_protocol/struct.Batch.html
+[channel]: https://docs.rs/kona-protocol/latest/kona_protocol/struct.Channel.html
+[add-frame]: https://docs.rs/kona-protocol/latest/kona_protocol/struct.Channel.html#method.add_frame
+[decode-frame]: https://docs.rs/kona-protocol/latest/kona_protocol/struct.Frame.html#method.decode
+[hex]: https://docs.rs/alloy_primitives/latest/alloy_primitives/macro.hex.html
+[is-ready]: https://docs.rs/kona-protocol/latest/kona_protocol/struct.Channel.html#method.is_ready
+[frame-data]: https://docs.rs/kona-protocol/latest/kona_protocol/struct.Channel.html#method.frame_data
+[bytes]: https://docs.rs/alloy_primitives/latest/alloy_primitives/struct.Bytes.html
+[decode-batch]: https://docs.rs/kona-protocol/latest/kona_protocol/struct.Batch.html#method.decode
+[fjord]: https://specs.optimism.io/protocol/fjord/overview.html
+[channel-id]: https://docs.rs/kona-protocol/latest/kona_protocol/type.ChannelId.html
 
-[frames-to-batch]: ./frames-to-batch.md
+[encode-batch]: https://docs.rs/kona-protocol/latest/kona_protocol/struct.Batch.html#method.encode
+[compress-brotli]: https://docs.rs/kona-comp/latest/kona_comp/fn.compress_brotli.html
+[channel-out]: https://docs.rs/kona-comp/latest/kona_comp/struct.ChannelOut.html
+[ready-bytes]: https://docs.rs/kona-comp/latest/kona_comp/struct.ChannelOut.html#method.ready_bytes
+[output-frame]: https://docs.rs/kona-comp/latest/kona_comp/struct.ChannelOut.html#method.output_frame
+[encode-frame]: https://docs.rs/kona-protocol/latest/kona_protocol/struct.Frame.html#method.encode
+
+
+[frames-to-batch]: /sdk/examples/frames-to-batch
 
 [op-stack]: https://github.com/ethereum-optimism/optimism
 [op-program]: https://github.com/ethereum-optimism/optimism/tree/develop/op-program

--- a/docs/docs/pages/sdk/examples/frames-to-batch.mdx
+++ b/docs/docs/pages/sdk/examples/frames-to-batch.mdx
@@ -156,7 +156,20 @@ fn example_transactions() -> Vec<Bytes> {
 ```
 
 
-[batch-to-frames]: ./batch-to-frames.md
+[batch-to-frames]: /sdk/examples/batch-to-frames
+[frame]: https://docs.rs/kona-protocol/latest/kona_protocol/struct.Frame.html
+[batch]: https://docs.rs/kona-protocol/latest/kona_protocol/struct.Batch.html
+[channel]: https://docs.rs/kona-protocol/latest/kona_protocol/struct.Channel.html
+[add-frame]: https://docs.rs/kona-protocol/latest/kona_protocol/struct.Channel.html#method.add_frame
+[decode-frame]: https://docs.rs/kona-protocol/latest/kona_protocol/struct.Frame.html#method.decode
+[hex]: https://docs.rs/alloy_primitives/latest/alloy_primitives/macro.hex.html
+[is-ready]: https://docs.rs/kona-protocol/latest/kona_protocol/struct.Channel.html#method.is_ready
+[frame-data]: https://docs.rs/kona-protocol/latest/kona_protocol/struct.Channel.html#method.frame_data
+[bytes]: https://docs.rs/alloy_primitives/latest/alloy_primitives/struct.Bytes.html
+[decode-batch]: https://docs.rs/kona-protocol/latest/kona_protocol/struct.Batch.html#method.decode
+[fjord]: https://specs.optimism.io/protocol/fjord/overview.html
+[channel-id]: https://docs.rs/kona-protocol/latest/kona_protocol/type.ChannelId.html
+
 
 [op-stack]: https://github.com/ethereum-optimism/optimism
 [op-program]: https://github.com/ethereum-optimism/optimism/tree/develop/op-program

--- a/docs/docs/pages/sdk/examples/frames-to-batch.mdx
+++ b/docs/docs/pages/sdk/examples/frames-to-batch.mdx
@@ -1,22 +1,17 @@
-import { Callout } from 'vocs/components'
-
 # Transform Frames into a Batch
 
-<Callout type="info">
-
+:::info
 This example performs the reverse transformation as the [batch-to-frames][batch-to-frames] example.
+:::
 
-</Callout>
+This example walks through transforming [`Frame`][frame]s into the [`Batch`][batch] types.
 
-<Callout type="danger">
-
+:::danger
 Steps and handling of types with respect to chain tip, ordering of frames, re-orgs, and
 more are not covered by this example. This example solely demonstrates the most trivial
 way to transform individual [`Frame`][frame]s into a [`Batch`][batch] type.
+:::
 
-</Callout>
-
-This example walks through transforming [`Frame`][frame]s into the [`Batch`][batch] types.
 
 ## Walkthrough
 
@@ -32,10 +27,11 @@ the first step is to decode the frame data into [`Frame`][frame]s using
 the [`Channel`][channel] can be constructed using the [`ChannelId`][channel-id]
 of the first frame.
 
-<Callout type="info">
+
+:::info
 [`Frame`][frame]s may also be added to a [`Channel`][channel]
 once decoded with the [`Channel::add_frame`][add-frame] method.
-</Callout>
+:::
 
 When the [`Channel`][channel] is [`Channel::is_ready()`][is-ready],
 the frame data can taken from the [`Channel`][channel] using


### PR DESCRIPTION
### Description

Fixes examples to use proper links and vite callouts.