### PR TITLE
feat(tests): Leadership transfer test

### DIFF
--- a/tests/devnets/simple-kona-sequencer.yaml
+++ b/tests/devnets/simple-kona-sequencer.yaml
@@ -1,6 +1,6 @@
-
 # A simple network configuration for kurtosis (https://github.com/ethpandaops/optimism-package)
-# Spins up a single EL/CL network. One participant sequencing the network with kona-node/op-geth.
+# Spins up a dual-sequencer EL/CL network. One participant sequencing the network with kona-node/op-geth,
+# the other with op-node/op-geth
 
 optimism_package:
   faucet:
@@ -9,7 +9,16 @@ optimism_package:
     chain0:
       # Chain with only two nodes
       participants:
-        kona:
+        optimism-seq:
+          el:
+            type: op-geth
+          cl:
+            type: op-node
+          sequencer: true
+          conductor_params:
+            enabled: true
+            bootstrap: true
+        kona-seq:
           el:
             type: op-geth
           cl:
@@ -18,8 +27,9 @@ optimism_package:
             image: "kona-node:local"
             extra_env_vars:
               KONA_NODE_RPC_WS_ENABLED: "true"
-            log_level: "debug"
           sequencer: true
+          conductor_params:
+            enabled: true
       network_params:
         network: "kurtosis"
         network_id: "2151908"
@@ -45,3 +55,4 @@ ethereum_package:
         }
       }
     '
+

--- a/tests/node/conductor_test.go
+++ b/tests/node/conductor_test.go
@@ -1,0 +1,130 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-conductor/consensus"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+type conductorWithInfo struct {
+	*dsl.Conductor
+	info consensus.ServerInfo
+}
+
+// TestConductorLeadershipTransfer checks if the leadership transfer works correctly on the conductors
+func TestConductorLeadershipTransfer(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	logger := testlog.Logger(t, log.LevelInfo).With("Test", "TestConductorLeadershipTransfer")
+
+	sys := NewMixedOpKonaWithConductors(t)
+	tracer := t.Tracer()
+	ctx := t.Ctx()
+	logger.Info("Started Conductor Leadership Transfer test")
+
+	for _, conductors := range sys.ConductorSets {
+		t.Gate().Greater(len(conductors), 0, "Expected at least one conductor in the system")
+	}
+
+	ctx, span := tracer.Start(ctx, "test chains")
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	// Test all L2 chains in the system
+	for l2Chain, conductors := range sys.ConductorSets {
+		chainId := l2Chain.String()
+
+		_, span = tracer.Start(ctx, fmt.Sprintf("test chain %s", chainId))
+		defer span.End()
+
+		membership := conductors[0].FetchClusterMembership()
+		require.Equal(t, len(membership.Servers), len(conductors), "cluster membership does not match the number of conductors", "chainId", chainId)
+
+		idToConductor := make(map[string]conductorWithInfo)
+		for _, conductor := range conductors {
+			conductorId := strings.TrimPrefix(conductor.String(), stack.ConductorKind.String()+"-")
+			idToConductor[conductorId] = conductorWithInfo{conductor, consensus.ServerInfo{}}
+		}
+		for _, memberInfo := range membership.Servers {
+			conductor, ok := idToConductor[memberInfo.ID]
+			require.True(t, ok, "unknown conductor in cluster membership", "unknown conductor id", memberInfo.ID, "chainId", chainId)
+			conductor.info = memberInfo
+			idToConductor[memberInfo.ID] = conductor
+		}
+
+		leaderInfo, err := conductors[0].Escape().RpcAPI().LeaderWithID(ctx)
+		require.NoError(t, err, "failed to get current conductor info", "chainId", chainId)
+
+		leaderConductor := idToConductor[leaderInfo.ID]
+
+		voters := []conductorWithInfo{leaderConductor}
+		for _, member := range membership.Servers {
+			if member.ID == leaderInfo.ID || member.Suffrage == consensus.Nonvoter {
+				continue
+			}
+
+			voters = append(voters, idToConductor[member.ID])
+		}
+
+		if len(voters) == 1 {
+			t.Skip("only one voter found in the cluster, skipping leadership transfer test")
+			continue
+		}
+
+		t.Run(fmt.Sprintf("L2_Chain_%s", chainId), func(tt devtest.T) {
+			numOfLeadershipTransfers := len(voters)
+			for i := range numOfLeadershipTransfers {
+				oldLeaderIndex, newLeaderIndex := i%len(voters), (i+1)%len(voters)
+				oldLeader, newLeader := voters[oldLeaderIndex], voters[newLeaderIndex]
+
+				time.Sleep(3 * time.Second)
+
+				testTransferLeadershipAndCheck(t, oldLeader, newLeader)
+			}
+		})
+	}
+}
+
+// testTransferLeadershipAndCheck tests conductor's leadership transfer from one leader to another
+func testTransferLeadershipAndCheck(t devtest.T, oldLeader, targetLeader conductorWithInfo) {
+	t.Run(fmt.Sprintf("Conductor_%s_to_%s", oldLeader, targetLeader), func(tt devtest.T) {
+		// ensure that the current and target leader are healthy and unpaused before transferring leadership
+		require.True(tt, oldLeader.FetchSequencerHealthy(), "current leader's sequencer is not healthy, id", oldLeader)
+		require.True(tt, targetLeader.FetchSequencerHealthy(), "target leader's sequencer is not healthy, id", targetLeader)
+		require.False(tt, oldLeader.FetchPaused(), "current leader's sequencer is paused, id", oldLeader)
+		require.False(tt, targetLeader.FetchPaused(), "target leader's sequencer is paused, id", targetLeader)
+
+		// ensure that the current leader is the leader before transfering leadership
+		require.True(tt, oldLeader.IsLeader(), "current leader was not found to be the leader")
+		require.False(tt, targetLeader.IsLeader(), "target leader was already found to be the leader")
+
+		oldLeader.TransferLeadershipTo(targetLeader.info)
+
+		require.Eventually(
+			tt,
+			func() bool { return targetLeader.IsLeader() },
+			5*time.Second, 1*time.Second, "target leader was not found to be the leader",
+		)
+
+		require.False(tt, oldLeader.IsLeader(), "old leader was still found to be the leader")
+
+		// sometimes leadership transfer can cause a very brief period of unhealthiness,
+		// but eventually, they should be healthy again
+		require.Eventually(
+			tt,
+			func() bool { return oldLeader.FetchSequencerHealthy() && targetLeader.FetchSequencerHealthy() },
+			3*time.Second, 1*time.Second, "at least one of the sequencers was found to be unhealthy",
+		)
+	})
+}

--- a/tests/node/mixed_preset_with_conductor.go
+++ b/tests/node/mixed_preset_with_conductor.go
@@ -1,0 +1,34 @@
+package node
+
+import (
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/shim"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
+)
+
+type MinimalWithConductors struct {
+	*MixedOpKonaPreset
+
+	ConductorSets map[stack.L2NetworkID]dsl.ConductorSet
+}
+
+func NewMixedOpKonaWithConductors(t devtest.T) *MinimalWithConductors {
+	system := shim.NewSystem(t)
+	orch := presets.Orchestrator()
+	orch.Hydrate(system)
+	chains := system.L2Networks()
+	conductorSets := make(map[stack.L2NetworkID]dsl.ConductorSet)
+	for _, chain := range chains {
+		chainMatcher := match.L2ChainById(chain.ID())
+		l2 := system.L2Network(match.Assume(t, chainMatcher))
+
+		conductorSets[chain.ID()] = dsl.NewConductorSet(l2.Conductors())
+	}
+	return &MinimalWithConductors{
+		MixedOpKonaPreset: NewMixedOpKona(t),
+		ConductorSets:     conductorSets,
+	}
+}


### PR DESCRIPTION
## Overview

Adds an e2e test for leadership transfer in a network with an `op-node` and `kona-node` in the conductor set.

closes #2243 