### PR TITLE
chore(node/test): update monorepo fork

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -13,7 +13,7 @@ require github.com/ethereum/go-ethereum v1.15.11
 
 require github.com/libp2p/go-libp2p v0.36.2
 
-require github.com/kurtosis-tech/kurtosis/api/golang v1.8.2-0.20250602144112-2b7d06430e48 
+require github.com/kurtosis-tech/kurtosis/api/golang v1.8.2-0.20250602144112-2b7d06430e48
 
 require golang.org/x/sync v0.14.0
 
@@ -283,6 +283,6 @@ require (
 replace github.com/ethereum-optimism/optimism/op-node => github.com/ethereum-optimism/optimism v1.13.4-0.20250610133734-335f05b575d0
 
 // Patched version of the Optimism repo that includes the latest changes of the `devstack` package to enable testing for the CL clients.
-replace github.com/ethereum-optimism/optimism => github.com/theochap/optimism v0.0.0-20250623141542-4850d4353d37
+replace github.com/ethereum-optimism/optimism => github.com/theochap/optimism v0.0.0-20250722140414-a9cde29cbe46
 
 replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250608235258-6005dd53e1b5

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -820,8 +820,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45
 github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a h1:1ur3QoCqvE5fl+nylMaIr9PVV1w343YRDtsy+Rwu7XI=
 github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
-github.com/theochap/optimism v0.0.0-20250623141542-4850d4353d37 h1:sZVHMIVd5Hm25Fm9YHL4D6zRP/CZbDXTOqpKTuAsW04=
-github.com/theochap/optimism v0.0.0-20250623141542-4850d4353d37/go.mod h1:yImPc3xmqpN9hsIQivAaubX9ROSlGvhR0JURIQ2AZrU=
+github.com/theochap/optimism v0.0.0-20250722140414-a9cde29cbe46 h1:pCmM0ShS/0Zh/pee9U/TSTmb1TjYqyOkCWBZX+DilPg=
+github.com/theochap/optimism v0.0.0-20250722140414-a9cde29cbe46/go.mod h1:+8BrJe6eeys3M4bDLKul3e8ui4vwHppq9mgUqVMXZhU=
 github.com/tklauser/go-sysconf v0.3.14 h1:g5vzr9iPFFz24v2KZXs/pvpvh8/V9Fw6vQK5ZZb78yU=
 github.com/tklauser/go-sysconf v0.3.14/go.mod h1:1ym4lWMLUOhuBOPGtRcJm7tEGX4SCYNEEEtghGG/8uY=
 github.com/tklauser/numcpus v0.8.0 h1:Mx4Wwe/FjZLeQsK/6kt2EOepwwSl7SmJrK5bV/dXYgY=

--- a/tests/node/mixed_preset.go
+++ b/tests/node/mixed_preset.go
@@ -89,10 +89,10 @@ func L2CLNodes(nodes []stack.L2CLNode, orch stack.Orchestrator) []dsl.L2CLNode {
 	return out
 }
 
-func L2ELNodes(nodes []stack.L2ELNode) []dsl.L2ELNode {
+func L2ELNodes(nodes []stack.L2ELNode, orch stack.Orchestrator) []dsl.L2ELNode {
 	out := make([]dsl.L2ELNode, len(nodes))
 	for i, node := range nodes {
-		out[i] = *dsl.NewL2ELNode(node)
+		out[i] = *dsl.NewL2ELNode(node, orch.ControlPlane())
 	}
 	return out
 }
@@ -128,11 +128,11 @@ func NewMixedOpKona(t devtest.T) *MixedOpKonaPreset {
 		ControlPlane:  orch.ControlPlane(),
 		L1Network:     dsl.NewL1Network(system.L1Network(match.FirstL1Network)),
 		L1EL:          dsl.NewL1ELNode(l1Net.L1ELNode(match.Assume(t, match.FirstL1EL))),
-		L2Chain:       dsl.NewL2Network(l2Net),
+		L2Chain:       dsl.NewL2Network(l2Net, orch.ControlPlane()),
 		L2Batcher:     dsl.NewL2Batcher(l2Net.L2Batcher(match.Assume(t, match.FirstL2Batcher))),
-		L2ELOpNodes:   L2ELNodes(opELNodes),
+		L2ELOpNodes:   L2ELNodes(opELNodes, orch),
 		L2CLOpNodes:   L2CLNodes(opCLNodes, orch),
-		L2ELKonaNodes: L2ELNodes(konaELNodes),
+		L2ELKonaNodes: L2ELNodes(konaELNodes, orch),
 		L2CLKonaNodes: L2CLNodes(konaCLNodes, orch),
 		TestSequencer: dsl.NewTestSequencer(system.TestSequencer(match.Assume(t, match.FirstTestSequencer))),
 		Wallet:        dsl.NewHDWallet(t, devkeys.TestMnemonic, 30),


### PR DESCRIPTION
## Description

Update monorepo fork to latest version of develop. Goes up to https://github.com/ethereum-optimism/optimism/commit/709d3eff834d9ef6eb0c1cbcb86f3b1b57807fe9