### PR TITLE
test(node/rpc): test rollup config rpc endpoint. fix rollup config metrics

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        devnet-config: ["simple-kona", "simple-kona-geth", "large-kona", "simple-kona-sequencer", "large-kona-sequencer"]
+        devnet-config: ["simple-kona", "simple-kona-geth", "large-kona", "simple-kona-sequencer", "large-kona-sequencer", "simple-kona-conductor"]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4623,6 +4623,7 @@ dependencies = [
 name = "kona-node"
 version = "0.1.0"
 dependencies = [
+ "alloy-chains",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types-engine",

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -30,6 +30,7 @@ kona-sources = { workspace = true, features = ["metrics"] }
 kona-node-service = { workspace = true, features = ["metrics"] }
 
 # alloy
+alloy-chains.workspace = true
 alloy-signer.workspace = true
 alloy-provider.workspace = true
 alloy-transport.workspace = true

--- a/bin/node/src/commands/bootstore.rs
+++ b/bin/node/src/commands/bootstore.rs
@@ -40,7 +40,7 @@ impl BootstoreCommand {
         if self.all {
             self.all()?;
         } else {
-            self.info(args.l2_chain_id)?;
+            self.info(args.l2_chain_id.into())?;
         }
         Ok(())
     }

--- a/bin/node/src/commands/info.rs
+++ b/bin/node/src/commands/info.rs
@@ -31,9 +31,9 @@ impl InfoCommand {
     pub fn run(&self, args: &GlobalArgs) -> anyhow::Result<()> {
         info!("Running info command");
 
-        let op_chain_config = OPCHAINS.get(&args.l2_chain_id).expect("No Chain config found");
+        let op_chain_config = OPCHAINS.get(&args.l2_chain_id.id()).expect("No Chain config found");
         let op_rollup_config =
-            ROLLUP_CONFIGS.get(&args.l2_chain_id).expect("No Rollup config found");
+            ROLLUP_CONFIGS.get(&args.l2_chain_id.id()).expect("No Rollup config found");
 
         println!("Name: {}", op_chain_config.name);
         println!("Block Time: {}", op_chain_config.block_time);

--- a/bin/node/src/commands/net.rs
+++ b/bin/node/src/commands/net.rs
@@ -9,6 +9,7 @@ use kona_node_service::{
     NetworkActor, NetworkBuilder, NetworkContext, NetworkInboundData, NodeActor,
 };
 use kona_p2p::P2pRpcRequest;
+use kona_registry::scr_rollup_config_by_alloy_ident;
 use kona_rpc::{OpP2PApiServer, P2pRpc, RpcBuilder};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -59,14 +60,15 @@ impl NetCommand {
 
         let rpc_config = Option::<RpcBuilder>::from(self.rpc);
 
+        let alloy_chain: alloy_chains::Chain = args.l2_chain_id.into();
+
         // Get the rollup config from the args
-        let rollup_config = args
-            .rollup_config()
+        let rollup_config = scr_rollup_config_by_alloy_ident(&alloy_chain)
             .ok_or(anyhow::anyhow!("Rollup config not found for chain id: {}", args.l2_chain_id))?;
 
         // Start the Network Stack
         self.p2p.check_ports()?;
-        let p2p_config = self.p2p.config(&rollup_config, args, self.l1_eth_rpc).await?;
+        let p2p_config = self.p2p.config(rollup_config, args, self.l1_eth_rpc).await?;
 
         let (NetworkInboundData { p2p_rpc: rpc, .. }, network) =
             NetworkActor::new(NetworkBuilder::from(p2p_config));

--- a/bin/node/src/commands/net.rs
+++ b/bin/node/src/commands/net.rs
@@ -60,10 +60,8 @@ impl NetCommand {
 
         let rpc_config = Option::<RpcBuilder>::from(self.rpc);
 
-        let alloy_chain: alloy_chains::Chain = args.l2_chain_id.into();
-
         // Get the rollup config from the args
-        let rollup_config = scr_rollup_config_by_alloy_ident(&alloy_chain)
+        let rollup_config = scr_rollup_config_by_alloy_ident(&args.l2_chain_id)
             .ok_or(anyhow::anyhow!("Rollup config not found for chain id: {}", args.l2_chain_id))?;
 
         // Start the Network Stack

--- a/bin/node/src/commands/node.rs
+++ b/bin/node/src/commands/node.rs
@@ -203,9 +203,7 @@ impl NodeCommand {
         let cfg = self.get_l2_config(args)?;
 
         // If metrics are enabled, initialize the global cli metrics.
-        if args.metrics.enabled {
-            init_rollup_config_metrics(&cfg);
-        }
+        args.metrics.enabled.then(|| init_rollup_config_metrics(&cfg));
 
         let jwt_secret = self.validate_jwt(&cfg).await?;
 
@@ -266,8 +264,7 @@ impl NodeCommand {
             }
             None => {
                 debug!("Loading l2 config from superchain registry");
-                let alloy_chain: alloy_chains::Chain = args.l2_chain_id.into();
-                let Some(cfg) = scr_rollup_config_by_alloy_ident(&alloy_chain) else {
+                let Some(cfg) = scr_rollup_config_by_alloy_ident(&args.l2_chain_id) else {
                     bail!("Failed to find l2 config for chain ID {}", args.l2_chain_id);
                 };
                 Ok(cfg.clone())

--- a/bin/node/src/flags/globals.rs
+++ b/bin/node/src/flags/globals.rs
@@ -1,11 +1,10 @@
 //! Global arguments for the CLI.
 
-use crate::metrics::CliMetrics;
 use alloy_primitives::Address;
 use clap::Parser;
-use kona_cli::log::LogArgs;
+use kona_cli::{log::LogArgs, metrics_args::MetricsArgs};
 use kona_genesis::RollupConfig;
-use kona_registry::{OPCHAINS, ROLLUP_CONFIGS};
+use kona_registry::OPCHAINS;
 
 /// Global arguments for the CLI.
 #[derive(Parser, Default, Clone, Debug)]
@@ -26,57 +25,12 @@ pub struct GlobalArgs {
     /// Embed the override flags globally to provide override values adjacent to the configs.
     #[command(flatten)]
     pub override_args: super::OverrideArgs,
+    /// Prometheus CLI arguments.
+    #[command(flatten)]
+    pub metrics: MetricsArgs,
 }
 
 impl GlobalArgs {
-    /// Initializes cli metrics for global argument values.
-    pub fn init_cli_metrics(&self) {
-        metrics::describe_gauge!(
-            CliMetrics::ROLLUP_CONFIG,
-            "Rollup configuration settings for the OP Stack"
-        );
-        metrics::describe_gauge!(
-            CliMetrics::HARDFORK_ACTIVATION_TIMES,
-            "Activation times for hardforks in the OP Stack"
-        );
-
-        let config = self.rollup_config().unwrap_or_default();
-
-        metrics::gauge!(
-            CliMetrics::ROLLUP_CONFIG,
-            &[
-                ("l1_genesis_block_num", config.genesis.l1.number.to_string()),
-                ("l2_genesis_block_num", config.genesis.l2.number.to_string()),
-                ("genesis_l2_time", config.genesis.l2_time.to_string()),
-                ("l1_chain_id", config.l1_chain_id.to_string()),
-                ("l2_chain_id", config.l2_chain_id.to_string()),
-                ("block_time", config.block_time.to_string()),
-                ("max_sequencer_drift", config.max_sequencer_drift.to_string()),
-                ("sequencer_window_size", config.seq_window_size.to_string()),
-                ("channel_timeout", config.channel_timeout.to_string()),
-                ("granite_channel_timeout", config.granite_channel_timeout.to_string()),
-                ("batch_inbox_address", config.batch_inbox_address.to_string()),
-                ("deposit_contract_address", config.deposit_contract_address.to_string()),
-                ("l1_system_config_address", config.l1_system_config_address.to_string()),
-                ("protocol_versions_address", config.protocol_versions_address.to_string()),
-            ]
-        )
-        .set(1);
-
-        for (fork_name, activation_time) in config.hardforks.iter() {
-            // Set the value of the metric for the given hardfork, using `-1` as a signal that the
-            // fork is not scheduled.
-            metrics::gauge!(CliMetrics::HARDFORK_ACTIVATION_TIMES, "fork" => fork_name)
-                .set(activation_time.map(|t| t as f64).unwrap_or(-1f64));
-        }
-    }
-
-    /// Returns the [`RollupConfig`] for the [`GlobalArgs::l2_chain_id`] specified on the global
-    /// arguments.
-    pub fn rollup_config(&self) -> Option<RollupConfig> {
-        ROLLUP_CONFIGS.get(&self.l2_chain_id).cloned().map(|c| self.apply_overrides(c))
-    }
-
     /// Applies the specified overrides to the given rollup config.
     ///
     /// Transforms the rollup config and returns the updated config with the overrides applied.

--- a/bin/node/src/flags/globals.rs
+++ b/bin/node/src/flags/globals.rs
@@ -21,7 +21,7 @@ pub struct GlobalArgs {
         env = "KONA_NODE_L2_CHAIN_ID",
         help = "The L2 chain ID to use"
     )]
-    pub l2_chain_id: u64,
+    pub l2_chain_id: alloy_chains::Chain,
     /// Embed the override flags globally to provide override values adjacent to the configs.
     #[command(flatten)]
     pub override_args: super::OverrideArgs,
@@ -42,7 +42,7 @@ impl GlobalArgs {
     pub fn genesis_signer(&self) -> anyhow::Result<Address> {
         let id = self.l2_chain_id;
         OPCHAINS
-            .get(&id)
+            .get(&id.id())
             .ok_or(anyhow::anyhow!("No chain config found for chain ID: {id}"))?
             .roles
             .as_ref()
@@ -58,7 +58,7 @@ mod tests {
 
     #[test]
     fn test_genesis_signer() {
-        let args = GlobalArgs { l2_chain_id: 10, ..Default::default() };
+        let args = GlobalArgs { l2_chain_id: 10.into(), ..Default::default() };
         assert_eq!(
             args.genesis_signer().unwrap(),
             alloy_primitives::address!("aaaa45d9549eda09e70937013520214382ffc4a2")

--- a/bin/node/src/flags/p2p.rs
+++ b/bin/node/src/flags/p2p.rs
@@ -405,7 +405,7 @@ impl P2PArgs {
             .as_ref()
             .map(PrivateKeySigner::from_bytes)
             .transpose()?
-            .map(|s| s.with_chain_id(Some(args.l2_chain_id)));
+            .map(|s| s.with_chain_id(Some(args.l2_chain_id.into())));
 
         Ok(NetworkConfig {
             discovery_config,

--- a/bin/node/src/metrics/mod.rs
+++ b/bin/node/src/metrics/mod.rs
@@ -1,7 +1,7 @@
 //! Global metrics for `kona-node`
 
 mod cli_opts;
-pub use cli_opts::CliMetrics;
+pub use cli_opts::{CliMetrics, init_rollup_config_metrics};
 
 mod version;
 pub use version::VersionInfo;

--- a/crates/protocol/registry/src/lib.rs
+++ b/crates/protocol/registry/src/lib.rs
@@ -36,13 +36,13 @@ lazy_static::lazy_static! {
 }
 
 /// Returns a [RollupConfig] by its identifier.
-pub fn rollup_config_by_ident(ident: &str) -> Option<&RollupConfig> {
+pub fn scr_rollup_config_by_ident(ident: &str) -> Option<&RollupConfig> {
     let chain_id = CHAINS.get_chain_by_ident(ident)?.chain_id;
     ROLLUP_CONFIGS.get(&chain_id)
 }
 
 /// Returns a [RollupConfig] by its identifier.
-pub fn rollup_config_by_alloy_ident(chain: &alloy_chains::Chain) -> Option<&RollupConfig> {
+pub fn scr_rollup_config_by_alloy_ident(chain: &alloy_chains::Chain) -> Option<&RollupConfig> {
     ROLLUP_CONFIGS.get(&chain.id())
 }
 
@@ -83,8 +83,8 @@ mod tests {
     fn test_rollup_config_by_ident() {
         const ALLOY_BASE: AlloyChain = AlloyChain::base_mainnet();
 
-        let rollup_config_by_ident = rollup_config_by_ident("mainnet/base").unwrap();
-        let rollup_config_by_alloy_ident = rollup_config_by_alloy_ident(&ALLOY_BASE).unwrap();
+        let rollup_config_by_ident = scr_rollup_config_by_ident("mainnet/base").unwrap();
+        let rollup_config_by_alloy_ident = scr_rollup_config_by_alloy_ident(&ALLOY_BASE).unwrap();
         let rollup_config_by_id = ROLLUP_CONFIGS.get(&8453).unwrap();
 
         assert_eq!(rollup_config_by_ident, rollup_config_by_id);

--- a/tests/README.md
+++ b/tests/README.md
@@ -66,6 +66,14 @@ Then, you can run the tests using:
 just build-devnet-and-test-e2e DEVNET BINARY
 ```
 
+### Hacks/Notes
+
+For the `op-devstack` to properly parse the nodes of the network (inside the `mixed_preset`) we're using the following hacks/methods:
+
+- All the kona nodes should have the `kona` string in their names.
+- All the op-node nodes should have the `optimism` string in their names.
+- All the sequencer nodes should have the `sequencer` string in their names.
+
 ## Contributing
 
 We welcome contributions to this repository.

--- a/tests/devnets/large-kona.yaml
+++ b/tests/devnets/large-kona.yaml
@@ -8,7 +8,7 @@ optimism_package:
     chain0:
     # Chain with more nodes
       participants:
-        optimism-1:
+        optimism-sequencer:
         # Note: it seems that op-reth isn't fully compatible with the sequencer mode.
         # So we use op-geth for now.
           el:
@@ -18,7 +18,7 @@ optimism_package:
             type: op-node
             log_level: "info"
           sequencer: true
-        optimism-2:
+        optimism-1:
         # Note: it seems that op-reth isn't fully compatible with the sequencer mode.
         # So we use op-geth for now.
           el:

--- a/tests/devnets/simple-kona-conductor.yaml
+++ b/tests/devnets/simple-kona-conductor.yaml
@@ -1,5 +1,6 @@
 # A simple network configuration for kurtosis (https://github.com/ethpandaops/optimism-package)
-# Spins up a 2 EL/CL networks. One with op-geth/op-node and one with op-reth/kona-node.
+# Spins up a dual-sequencer EL/CL network. One participant sequencing the network with kona-node/op-geth,
+# the other with op-node/op-geth
 
 optimism_package:
   faucet:
@@ -9,26 +10,26 @@ optimism_package:
       # Chain with only two nodes
       participants:
         optimism-sequencer:
-        # Note: it seems that op-reth isn't fully compatible with the sequencer mode.
-        # So we use op-geth for now.
           el:
             type: op-geth
-            log_level: "debug"
           cl:
             type: op-node
-            log_level: "debug"
           sequencer: true
-        kona:
+          conductor_params:
+            enabled: true
+            bootstrap: true
+        kona-sequencer:
           el:
-            type: op-reth
-          cl: 
+            type: op-geth
+          cl:
             type: kona-node
             # Note: we use the local image for now. This allows us to run the tests in CI pipelines without publishing new docker images every time.
             image: "kona-node:local"
             extra_env_vars:
               KONA_NODE_RPC_WS_ENABLED: "true"
-            log_level: "debug"
-          sequencer: false
+          sequencer: true
+          conductor_params:
+            enabled: true
       network_params:
         network: "kurtosis"
         network_id: "2151908"
@@ -54,3 +55,4 @@ ethereum_package:
         }
       }
     '
+

--- a/tests/devnets/simple-kona-geth.yaml
+++ b/tests/devnets/simple-kona-geth.yaml
@@ -8,7 +8,7 @@ optimism_package:
     chain0:
       # Chain with only two nodes
       participants:
-        optimism:
+        optimism-sequencer:
         # Note: it seems that op-reth isn't fully compatible with the sequencer mode.
         # So we use op-geth for now.
           el:

--- a/tests/devnets/simple-kona-sequencer.yaml
+++ b/tests/devnets/simple-kona-sequencer.yaml
@@ -9,16 +9,7 @@ optimism_package:
     chain0:
       # Chain with only two nodes
       participants:
-        optimism-seq:
-          el:
-            type: op-geth
-          cl:
-            type: op-node
-          sequencer: true
-          conductor_params:
-            enabled: true
-            bootstrap: true
-        kona-seq:
+        kona-sequencer:
           el:
             type: op-geth
           cl:
@@ -28,8 +19,12 @@ optimism_package:
             extra_env_vars:
               KONA_NODE_RPC_WS_ENABLED: "true"
           sequencer: true
-          conductor_params:
-            enabled: true
+        optimism-1:
+          el:
+            type: op-geth
+          cl:
+            type: op-node
+          sequencer: false
       network_params:
         network: "kurtosis"
         network_id: "2151908"

--- a/tests/node/cpu_monitor_test.go
+++ b/tests/node/cpu_monitor_test.go
@@ -65,7 +65,7 @@ func TestKurtosisCPUMonitor(gt *testing.T) {
 	konaNode := out.L2CLKonaNodes[0]
 
 	// Wait for a few blocks to be produced before checking the CPU usage.
-	dsl.CheckAll(t, konaNode.ReachedFn(types.LocalUnsafe, 40, 40), opNode.ReachedFn(types.LocalUnsafe, 40, 40))
+	dsl.CheckAll(t, konaNode.ReachedFn(types.LocalUnsafe, 40, 80), opNode.ReachedFn(types.LocalUnsafe, 40, 80))
 
 	ctx := context.Background()
 

--- a/tests/node/mixed_preset.go
+++ b/tests/node/mixed_preset.go
@@ -20,8 +20,9 @@ import (
 type L2NodeKind string
 
 const (
-	OpNode   L2NodeKind = "optimism"
-	KonaNode L2NodeKind = "kona"
+	OpNode    L2NodeKind = "optimism"
+	KonaNode  L2NodeKind = "kona"
+	Sequencer L2NodeKind = "sequencer"
 )
 
 type MixedOpKonaPreset struct {
@@ -40,8 +41,6 @@ type MixedOpKonaPreset struct {
 
 	L2ELKonaNodes []dsl.L2ELNode
 	L2CLKonaNodes []dsl.L2CLNode
-
-	TestSequencer *dsl.TestSequencer
 
 	Wallet *dsl.HDWallet
 
@@ -134,7 +133,6 @@ func NewMixedOpKona(t devtest.T) *MixedOpKonaPreset {
 		L2CLOpNodes:   L2CLNodes(opCLNodes, orch),
 		L2ELKonaNodes: L2ELNodes(konaELNodes, orch),
 		L2CLKonaNodes: L2CLNodes(konaCLNodes, orch),
-		TestSequencer: dsl.NewTestSequencer(system.TestSequencer(match.Assume(t, match.FirstTestSequencer))),
 		Wallet:        dsl.NewHDWallet(t, devkeys.TestMnemonic, 30),
 		Faucet:        dsl.NewFaucet(l2Net.Faucet(match.Assume(t, match.FirstFaucet))),
 	}
@@ -156,8 +154,6 @@ type DefaultMixedOpKonaSystemIDs struct {
 
 	L2Batcher  stack.L2BatcherID
 	L2Proposer stack.L2ProposerID
-
-	TestSequencer stack.TestSequencerID
 }
 
 func NewDefaultMixedOpKonaSystemIDs(l1ID, l2ID eth.ChainID, opNodes, konaNodes int) DefaultMixedOpKonaSystemIDs {
@@ -186,9 +182,8 @@ func NewDefaultMixedOpKonaSystemIDs(l1ID, l2ID eth.ChainID, opNodes, konaNodes i
 		L2CLKonaNodes: konaCLNodes,
 		L2ELKonaNodes: konaELNodes,
 
-		L2Batcher:     stack.NewL2BatcherID("main", l2ID),
-		L2Proposer:    stack.NewL2ProposerID("main", l2ID),
-		TestSequencer: "test-sequencer",
+		L2Batcher:  stack.NewL2BatcherID("main", l2ID),
+		L2Proposer: stack.NewL2ProposerID("main", l2ID),
 	}
 	return ids
 }
@@ -229,8 +224,6 @@ func DefaultMixedOpKonaSystem(dest *DefaultMixedOpKonaSystemIDs, opNodes, konaNo
 	opt.Add(sysgo.WithProposer(ids.L2Proposer, ids.L1EL, &ids.L2CLOpNodes[0], nil))
 
 	opt.Add(sysgo.WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2ELOpNodes[0], ids.L2ELKonaNodes[0]}))
-
-	opt.Add(sysgo.WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2CLOpNodes[0], ids.L1EL, ids.L2ELOpNodes[0]))
 
 	opt.Add(stack.Finally(func(orch *sysgo.Orchestrator) {
 		*dest = ids


### PR DESCRIPTION
## Description

This PR:
- Tests `RollupConfig` rpc endpoint
- Fixes the rollup config metrics in grafana if the chain id is not part of the scr
- Adds a test to ensure the other nodes of the network are lagging behind the sequencer unsafe head