### PR TITLE
chore(docker): Don't disable p2p scoring in `kona-node` recipe

### DIFF
--- a/docker/recipes/kona-node/docker-compose.yaml
+++ b/docker/recipes/kona-node/docker-compose.yaml
@@ -87,7 +87,6 @@ services:
       --rpc.port 5060
       --p2p.listen.tcp 9223
       --p2p.listen.udp 9223
-      --p2p.scoring off
       --p2p.bootstore /db
 
 volumes:


### PR DESCRIPTION
## Overview

Removes the `--p2p.scoring=off` flag in the `kona-node` recipe.