### PR TITLE
feat(node/engine): add metrics to record task success + failure

### DIFF
--- a/crates/node/engine/src/metrics/mod.rs
+++ b/crates/node/engine/src/metrics/mod.rs
@@ -19,7 +19,10 @@ impl Metrics {
     pub const FINALIZED_BLOCK_LABEL: &str = "finalized";
 
     /// Identifier for the counter that records engine task counts.
-    pub const ENGINE_TASK_COUNT: &str = "kona_node_engine_task_count";
+    pub const ENGINE_TASK_SUCCESS: &str = "kona_node_engine_task_count";
+    /// Identifier for the counter that records engine task counts.
+    pub const ENGINE_TASK_FAILURE: &str = "kona_node_engine_task_failure";
+
     /// Insert task label.
     pub const INSERT_TASK_LABEL: &str = "insert";
     /// Consolidate task label.
@@ -61,7 +64,8 @@ impl Metrics {
         metrics::describe_gauge!(Self::BLOCK_LABELS, "Blockchain head labels");
 
         // Engine task counts
-        metrics::describe_counter!(Self::ENGINE_TASK_COUNT, "Engine task counts");
+        metrics::describe_counter!(Self::ENGINE_TASK_SUCCESS, "Engine tasks successfully executed");
+        metrics::describe_counter!(Self::ENGINE_TASK_FAILURE, "Engine tasks failed");
 
         // Engine method request duration histogram
         metrics::describe_histogram!(
@@ -83,11 +87,17 @@ impl Metrics {
     #[cfg(feature = "metrics")]
     pub fn zero() {
         // Engine task counts
-        kona_macros::set!(counter, Self::ENGINE_TASK_COUNT, Self::INSERT_TASK_LABEL, 0);
-        kona_macros::set!(counter, Self::ENGINE_TASK_COUNT, Self::CONSOLIDATE_TASK_LABEL, 0);
-        kona_macros::set!(counter, Self::ENGINE_TASK_COUNT, Self::FORKCHOICE_TASK_LABEL, 0);
-        kona_macros::set!(counter, Self::ENGINE_TASK_COUNT, Self::BUILD_TASK_LABEL, 0);
-        kona_macros::set!(counter, Self::ENGINE_TASK_COUNT, Self::FINALIZE_TASK_LABEL, 0);
+        kona_macros::set!(counter, Self::ENGINE_TASK_SUCCESS, Self::INSERT_TASK_LABEL, 0);
+        kona_macros::set!(counter, Self::ENGINE_TASK_SUCCESS, Self::CONSOLIDATE_TASK_LABEL, 0);
+        kona_macros::set!(counter, Self::ENGINE_TASK_SUCCESS, Self::BUILD_TASK_LABEL, 0);
+        kona_macros::set!(counter, Self::ENGINE_TASK_SUCCESS, Self::FINALIZE_TASK_LABEL, 0);
+        kona_macros::set!(counter, Self::ENGINE_TASK_SUCCESS, Self::FORKCHOICE_TASK_LABEL, 0);
+
+        kona_macros::set!(counter, Self::ENGINE_TASK_FAILURE, Self::INSERT_TASK_LABEL, 0);
+        kona_macros::set!(counter, Self::ENGINE_TASK_FAILURE, Self::CONSOLIDATE_TASK_LABEL, 0);
+        kona_macros::set!(counter, Self::ENGINE_TASK_FAILURE, Self::BUILD_TASK_LABEL, 0);
+        kona_macros::set!(counter, Self::ENGINE_TASK_FAILURE, Self::FINALIZE_TASK_LABEL, 0);
+        kona_macros::set!(counter, Self::ENGINE_TASK_FAILURE, Self::FORKCHOICE_TASK_LABEL, 0);
 
         // Engine reset count
         kona_macros::set!(counter, Self::ENGINE_RESET_COUNT, 0);

--- a/crates/node/engine/src/task_queue/tasks/build/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/build/task.rs
@@ -4,7 +4,6 @@ use crate::{
     EngineClient, EngineGetPayloadVersion, EngineState, EngineTaskExt, ForkchoiceTask,
     ForkchoiceTaskError, InsertTask,
     InsertTaskError::{self},
-    Metrics,
     state::EngineSyncStateUpdate,
 };
 use alloy_rpc_types_engine::{ExecutionPayload, PayloadId};
@@ -224,9 +223,6 @@ impl EngineTaskExt for BuildTask {
             "Built and imported new {} block",
             if self.is_attributes_derived { "safe" } else { "unsafe" },
         );
-
-        // Update metrics.
-        kona_macros::inc!(counter, Metrics::ENGINE_TASK_COUNT, Metrics::BUILD_TASK_LABEL);
 
         Ok(())
     }

--- a/crates/node/engine/src/task_queue/tasks/consolidate/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/consolidate/task.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     BuildTask, ConsolidateTaskError, EngineClient, EngineState, EngineTaskExt, ForkchoiceTask,
-    Metrics, state::EngineSyncStateUpdate,
+    state::EngineSyncStateUpdate,
 };
 use async_trait::async_trait;
 use kona_genesis::RollupConfig;
@@ -98,13 +98,6 @@ impl ConsolidateTask {
                         ..Default::default()
                     });
 
-                    // Update metrics.
-                    kona_macros::inc!(
-                        counter,
-                        Metrics::ENGINE_TASK_COUNT,
-                        Metrics::CONSOLIDATE_TASK_LABEL
-                    );
-
                     info!(
                         target: "engine",
                         hash = %block_info.block_info.hash,
@@ -139,13 +132,6 @@ impl ConsolidateTask {
                     let fcu_duration = fcu_start.elapsed();
 
                     let total_duration = global_start.elapsed();
-
-                    // Update metrics.
-                    kona_macros::inc!(
-                        counter,
-                        Metrics::ENGINE_TASK_COUNT,
-                        Metrics::CONSOLIDATE_TASK_LABEL
-                    );
 
                     info!(
                         target: "engine",

--- a/crates/node/engine/src/task_queue/tasks/finalize/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/finalize/task.rs
@@ -1,7 +1,7 @@
 //! A task for finalizing an L2 block.
 
 use crate::{
-    EngineClient, EngineState, EngineTaskExt, FinalizeTaskError, ForkchoiceTask, Metrics,
+    EngineClient, EngineState, EngineTaskExt, FinalizeTaskError, ForkchoiceTask,
     state::EngineSyncStateUpdate,
 };
 use alloy_provider::Provider;
@@ -66,9 +66,6 @@ impl EngineTaskExt for FinalizeTask {
         .execute(state)
         .await?;
         let fcu_duration = fcu_start.elapsed();
-
-        // Update metrics.
-        kona_macros::inc!(counter, Metrics::ENGINE_TASK_COUNT, Metrics::FINALIZE_TASK_LABEL);
 
         info!(
             target: "engine",

--- a/crates/node/engine/src/task_queue/tasks/forkchoice/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/forkchoice/task.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     EngineClient, EngineForkchoiceVersion, EngineState, EngineTaskExt, ForkchoiceTaskError,
-    Metrics, state::EngineSyncStateUpdate,
+    state::EngineSyncStateUpdate,
 };
 use alloy_provider::ext::EngineApi;
 use alloy_rpc_types_engine::{INVALID_FORK_CHOICE_STATE_ERROR, PayloadId, PayloadStatusEnum};
@@ -162,9 +162,6 @@ impl EngineTaskExt for ForkchoiceTask {
 
         // Apply the new sync state to the engine state.
         state.sync_state = new_sync_state;
-
-        // Update metrics.
-        kona_macros::inc!(counter, Metrics::ENGINE_TASK_COUNT, Metrics::FORKCHOICE_TASK_LABEL);
 
         let fcu_duration = fcu_time_start.elapsed();
         debug!(

--- a/crates/node/engine/src/task_queue/tasks/insert/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/insert/task.rs
@@ -1,7 +1,7 @@
 //! A task to insert an unsafe payload into the execution engine.
 
 use crate::{
-    EngineClient, EngineState, EngineTaskExt, ForkchoiceTask, InsertTaskError, Metrics,
+    EngineClient, EngineState, EngineTaskExt, ForkchoiceTask, InsertTaskError,
     state::EngineSyncStateUpdate,
 };
 use alloy_eips::eip7685::EMPTY_REQUESTS_HASH;
@@ -149,9 +149,6 @@ impl EngineTaskExt for InsertTask {
             insert_duration = ?insert_duration,
             "Inserted new unsafe block"
         );
-
-        // Update metrics.
-        kona_macros::inc!(counter, Metrics::ENGINE_TASK_COUNT, Metrics::INSERT_TASK_LABEL);
 
         Ok(())
     }


### PR DESCRIPTION
## Description

Fire metrics when an engine task succeeds OR fails. Move the metrics logic outside of the tasks inside the `EngineTask` to avoid including task composition inside the metric counts