### PR TITLE
fix(node/engine): Do not use FCU V1

### DIFF
--- a/crates/node/engine/src/task_queue/tasks/forkchoice/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/forkchoice/task.rs
@@ -4,7 +4,6 @@ use crate::{
     EngineClient, EngineForkchoiceVersion, EngineState, EngineTaskExt, ForkchoiceTaskError,
     Metrics, state::EngineSyncStateUpdate,
 };
-use alloy_provider::ext::EngineApi;
 use alloy_rpc_types_engine::{INVALID_FORK_CHOICE_STATE_ERROR, PayloadId, PayloadStatusEnum};
 use async_trait::async_trait;
 use kona_genesis::RollupConfig;
@@ -130,14 +129,6 @@ impl EngineTaskExt for ForkchoiceTask {
 
         // Handle the forkchoice update result.
         let response = match version {
-            EngineForkchoiceVersion::V1 => {
-                self.client
-                    .fork_choice_updated_v1(
-                        forkchoice,
-                        payload_attributes.map(|p| p.payload_attributes),
-                    )
-                    .await
-            }
             EngineForkchoiceVersion::V2 => {
                 self.client.fork_choice_updated_v2(forkchoice, payload_attributes).await
             }

--- a/crates/node/engine/src/versions.rs
+++ b/crates/node/engine/src/versions.rs
@@ -9,8 +9,6 @@ use kona_genesis::RollupConfig;
 /// The method version for the `engine_forkchoiceUpdated` api.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum EngineForkchoiceVersion {
-    /// The `engine_forkchoiceUpdated` api version 1.
-    V1,
     /// The `engine_forkchoiceUpdated` api version 2.
     V2,
     /// The `engine_forkchoiceUpdated` api version 3.
@@ -23,15 +21,11 @@ impl EngineForkchoiceVersion {
     /// Uses the [`RollupConfig`] to check which hardfork is active at the given timestamp.
     pub fn from_cfg(cfg: &RollupConfig, timestamp: u64) -> Self {
         if cfg.is_ecotone_active(timestamp) {
-            // Cancun
+            // Cancun+
             Self::V3
-        } else if cfg.is_canyon_active(timestamp) {
-            // Shanghai
-            Self::V2
         } else {
-            // According to Ethereum engine API spec, we can use fcuV2 here,
-            // but Geth v1.13.11 does not accept V2 before Shanghai.
-            Self::V1
+            // Bedrock, Canyon, Delta
+            Self::V2
         }
     }
 }


### PR DESCRIPTION
## Overview

Removes the usage of FCU V1 in the `ForkchoiceTask`. [specs](https://specs.optimism.io/protocol/derivation.html#engine-api-usage)