### PR TITLE
chore(supervisor): Add supervisor path to log targets

### DIFF
--- a/crates/supervisor/core/src/chain_processor/chain.rs
+++ b/crates/supervisor/core/src/chain_processor/chain.rs
@@ -96,7 +96,7 @@ where
     pub async fn start(&mut self) -> Result<(), ChainProcessorError> {
         let mut handle_guard = self.task_handle.lock().await;
         if handle_guard.is_some() {
-            warn!(target: "chain_processor", chain_id = %self.chain_id, "ChainProcessor is already running");
+            warn!(target: "supervisor::chain_processor", chain_id = %self.chain_id, "ChainProcessor is already running");
             return Ok(())
         }
 

--- a/crates/supervisor/core/src/chain_processor/task.rs
+++ b/crates/supervisor/core/src/chain_processor/task.rs
@@ -205,7 +205,7 @@ where
             ChainEvent::InvalidateBlock { block } => {
                 let _ = self.handle_invalidate_block(block).await.inspect_err(|err| {
                     error!(
-                        target: "chain_processor",
+                        target: "supervisor::chain_processor",
                         chain_id = self.chain_id,
                         block_number = block.number,
                         %err,
@@ -278,7 +278,7 @@ where
         replacement: BlockReplacement,
     ) -> Result<(), ChainProcessorError> {
         debug!(
-            target: "chain_processor",
+            target: "supervisor::chain_processor",
             chain_id = self.chain_id,
             %replacement,
             "Handling block replacement"
@@ -289,7 +289,7 @@ where
         if let Some(invalidated_ref_pair) = *guard {
             if invalidated_ref_pair.derived.hash != replacement.invalidated {
                 debug!(
-                    target: "chain_processor",
+                    target: "supervisor::chain_processor",
                     chain_id = self.chain_id,
                     invalidated_block = %invalidated_ref_pair.derived,
                     replacement_block = %replacement.replacement,
@@ -312,7 +312,7 @@ where
 
     async fn handle_invalidate_block(&self, block: BlockInfo) -> Result<(), ChainProcessorError> {
         debug!(
-            target: "chain_processor",
+            target: "supervisor::chain_processor",
             chain_id = self.chain_id,
             invalidated_block = %block,
             "Processing invalidate block"
@@ -321,7 +321,7 @@ where
         let mut invalidated_block = self.invalidated_block.write().await;
         if invalidated_block.is_some() {
             debug!(
-                target: "chain_processor",
+                target: "supervisor::chain_processor",
                 chain_id = self.chain_id,
                 block_number = block.number,
                 "Invalidated block already set, skipping"
@@ -372,7 +372,7 @@ where
         let invalidated_block = self.invalidated_block.read().await;
         if invalidated_block.is_some() {
             trace!(
-                target: "chain_processor",
+                target: "supervisor::chain_processor",
                 chain_id = self.chain_id,
                 block_number = origin.number,
                 "Invalidated block set, skipping derivation origin update"
@@ -418,7 +418,7 @@ where
         let invalidated_block = self.invalidated_block.read().await;
         if invalidated_block.is_some() {
             trace!(
-                target: "chain_processor",
+                target: "supervisor::chain_processor",
                 chain_id = self.chain_id,
                 block_number = derived_ref_pair.derived.number,
                 "Invalidated block already set, skipping safe event processing"
@@ -541,7 +541,7 @@ where
         let invalidated_block = self.invalidated_block.read().await;
         if invalidated_block.is_some() {
             trace!(
-                target: "chain_processor",
+                target: "supervisor::chain_processor",
                 chain_id = self.chain_id,
                 block_number = block.number,
                 "Invalidated block already set, skipping unsafe event processing"

--- a/crates/supervisor/core/src/chain_processor/task.rs
+++ b/crates/supervisor/core/src/chain_processor/task.rs
@@ -110,7 +110,7 @@ where
                     Ok(duration) => duration.as_secs_f64(),
                     Err(e) => {
                         error!(
-                            target: "chain_processor",
+                            target: "supervisor::chain_processor",
                             chain_id = self.chain_id,
                             "SystemTime error when recording block processing latency: {e}"
                         );
@@ -151,7 +151,7 @@ where
                 }
                 _ = self.cancel_token.cancelled() => {
                     info!(
-                        target: "chain_processor",
+                        target: "supervisor::chain_processor",
                         chain_id = self.chain_id,
                         "ChainProcessorTask cancellation requested, stopping..."
                     );
@@ -168,7 +168,7 @@ where
                     .observe_block_processing("local_unsafe", || async {
                         self.handle_unsafe_event(block).await.inspect_err(|err| {
                             error!(
-                                target: "chain_processor",
+                                target: "supervisor::chain_processor",
                                 chain_id = self.chain_id,
                                 block_number = block.number,
                                 %err,
@@ -183,7 +183,7 @@ where
                     .observe_block_processing("local_safe", || async {
                         self.handle_safe_event(derived_ref_pair).await.inspect_err(|err| {
                             error!(
-                                target: "chain_processor",
+                                target: "supervisor::chain_processor",
                                 chain_id = self.chain_id,
                                 block_number = derived_ref_pair.derived.number,
                                 %err,
@@ -196,7 +196,7 @@ where
             ChainEvent::DerivationOriginUpdate { origin } => {
                 let _ = self.handle_derivation_origin_update(origin).await.inspect_err(|err| {
                     error!(
-                        target: "chain_processor",
+                        target: "supervisor::chain_processor",
                         chain_id = self.chain_id,
                         block_number = origin.number,
                         %err,
@@ -207,7 +207,7 @@ where
             ChainEvent::BlockReplaced { replacement } => {
                 let _ = self.handle_block_replacement(replacement).inspect_err(|err| {
                     error!(
-                        target: "chain_processor",
+                        target: "supervisor::chain_processor",
                         chain_id = self.chain_id,
                         %err,
                         "Failed to handle block replacement"
@@ -220,7 +220,7 @@ where
                         self.handle_finalized_l1_update(finalized_source_block).await.inspect_err(
                             |err| {
                                 error!(
-                                    target: "chain_processor",
+                                    target: "supervisor::chain_processor",
                                     chain_id = self.chain_id,
                                     block_number = finalized_source_block.number,
                                     %err,
@@ -236,7 +236,7 @@ where
                     .observe_block_processing("cross_unsafe", || async {
                         self.handle_cross_unsafe_update(block).await.inspect_err(|err| {
                             error!(
-                                target: "chain_processor",
+                                target: "supervisor::chain_processor",
                                 chain_id = self.chain_id,
                                 block_number = block.number,
                                 %err,
@@ -251,7 +251,7 @@ where
                     .observe_block_processing("cross_safe", || async {
                         self.handle_cross_safe_update(derived_ref_pair).await.inspect_err(|err| {
                             error!(
-                                target: "chain_processor",
+                                target: "supervisor::chain_processor",
                                 chain_id = self.chain_id,
                                 block_number = derived_ref_pair.derived.number,
                                 %err,
@@ -278,7 +278,7 @@ where
         finalized_source_block: BlockInfo,
     ) -> Result<BlockInfo, ChainProcessorError> {
         debug!(
-            target: "chain_processor",
+            target: "supervisor::chain_processor",
             chain_id = self.chain_id,
             block_number = finalized_source_block.number,
             "Processing finalized L1 update"
@@ -294,7 +294,7 @@ where
         origin: BlockInfo,
     ) -> Result<(), ChainProcessorError> {
         debug!(
-            target: "chain_processor",
+            target: "supervisor::chain_processor",
             chain_id = self.chain_id,
             block_number = origin.number,
             "Processing derivation origin update"
@@ -303,7 +303,7 @@ where
             Ok(_) => Ok(()),
             Err(StorageError::BlockOutOfOrder | StorageError::ConflictError) => {
                 error!(
-                    target: "chain_processor",
+                    target: "supervisor::chain_processor",
                     chain_id = self.chain_id,
                     block_number = origin.number,
                     "Source block out of order detected, resetting managed node"
@@ -311,7 +311,7 @@ where
 
                 if let Err(err) = self.managed_node.reset().await {
                     error!(
-                        target: "chain_processor",
+                        target: "supervisor::chain_processor",
                         chain_id = self.chain_id,
                         %err,
                         "Failed to reset managed node after block out of order"
@@ -328,7 +328,7 @@ where
         derived_ref_pair: DerivedRefPair,
     ) -> Result<BlockInfo, ChainProcessorError> {
         debug!(
-            target: "chain_processor",
+            target: "supervisor::chain_processor",
             chain_id = self.chain_id,
             block_number = derived_ref_pair.derived.number,
             "Processing local safe derived block pair"
@@ -340,7 +340,7 @@ where
 
         if self.rollup_config.is_interop_activation_block(derived_ref_pair.derived) {
             info!(
-                target: "chain_processor",
+                target: "supervisor::chain_processor",
                 chain_id = self.chain_id,
                 block_number = derived_ref_pair.derived.number,
                 "Initialising derivation storage for interop activation block"
@@ -360,7 +360,7 @@ where
             Ok(_) => Ok(derived_ref_pair.derived),
             Err(StorageError::BlockOutOfOrder) => {
                 error!(
-                    target: "chain_processor",
+                    target: "supervisor::chain_processor",
                     chain_id = self.chain_id,
                     block_number = derived_ref_pair.derived.number,
                     "Block out of order detected, resetting managed node"
@@ -368,7 +368,7 @@ where
 
                 if let Err(err) = self.managed_node.reset().await {
                     error!(
-                        target: "chain_processor",
+                        target: "supervisor::chain_processor",
                         chain_id = self.chain_id,
                         %err,
                         "Failed to reset managed node after block out of order"
@@ -379,7 +379,7 @@ where
 
             Err(StorageError::ReorgRequired) => {
                 debug!(
-                    target: "chain_processor",
+                    target: "supervisor::chain_processor",
                     chain = self.chain_id,
                     derived_block = %derived_ref_pair.derived,
                     "Local derivation conflict detected — rewinding"
@@ -394,7 +394,7 @@ where
 
             Err(err) => {
                 error!(
-                    target: "chain_processor",
+                    target: "supervisor::chain_processor",
                     chain_id = self.chain_id,
                     block_number = derived_ref_pair.derived.number,
                     %err,
@@ -414,7 +414,7 @@ where
             .await
             .inspect_err(|err| {
                 error!(
-                    target: "chain_processor",
+                    target: "supervisor::chain_processor",
                     chain_id = self.chain_id,
                     block_number = derived_ref_pair.derived.number,
                     %err,
@@ -423,7 +423,7 @@ where
             })?;
         self.state_manager.save_derived_block(derived_ref_pair).inspect_err(|err| {
             error!(
-                target: "chain_processor",
+                target: "supervisor::chain_processor",
                 chain_id = self.chain_id,
                 block_number = derived_ref_pair.derived.number,
                 %err,
@@ -439,7 +439,7 @@ where
         block: BlockInfo,
     ) -> Result<BlockInfo, ChainProcessorError> {
         debug!(
-            target: "chain_processor",
+            target: "supervisor::chain_processor",
             chain_id = self.chain_id,
             block_number = block.number,
             "Processing unsafe block"
@@ -452,7 +452,7 @@ where
 
         if self.rollup_config.is_interop_activation_block(block) {
             info!(
-                target: "chain_processor",
+                target: "supervisor::chain_processor",
                 chain_id = self.chain_id,
                 block_number = block.number,
                 "Initialising log storage for interop activation block"
@@ -469,7 +469,7 @@ where
         block: BlockInfo,
     ) -> Result<BlockInfo, ChainProcessorError> {
         debug!(
-            target: "chain_processor",
+            target: "supervisor::chain_processor",
             chain_id = self.chain_id,
             block_number = block.number,
             "Processing cross unsafe update"
@@ -484,7 +484,7 @@ where
         derived_ref_pair: DerivedRefPair,
     ) -> Result<BlockInfo, ChainProcessorError> {
         debug!(
-            target: "chain_processor",
+            target: "supervisor::chain_processor",
             chain_id = self.chain_id,
             block_number = derived_ref_pair.derived.number,
             "Processing cross safe update"

--- a/crates/supervisor/core/src/l1_watcher/watcher.rs
+++ b/crates/supervisor/core/src/l1_watcher/watcher.rs
@@ -76,18 +76,18 @@ where
         loop {
             tokio::select! {
                 _ = self.cancellation.cancelled() => {
-                    info!(target: "l1_watcher", "L1Watcher cancellation requested, stopping polling");
+                    info!(target: "supervisor::l1_watcher", "L1Watcher cancellation requested, stopping polling");
                     break;
                 }
                 latest_block = latest_head_stream.next() => {
                     if let Some(latest_block) = latest_block {
-                        info!(target: "l1_watcher", "Latest L1 block received: {:?}", latest_block.header.number);
+                        info!(target: "supervisor::l1_watcher", "Latest L1 block received: {:?}", latest_block.header.number);
                         self.handle_new_latest_block(latest_block, &mut last_latest_number);
                     }
                 }
                 finalized_block = finalized_head_stream.next() => {
                     if let Some(finalized_block) = finalized_block {
-                        info!(target: "l1_watcher", "Finalized L1 block received: {:?}", finalized_block.header.number);
+                        info!(target: "supervisor::l1_watcher", "Finalized L1 block received: {:?}", finalized_block.header.number);
                         self.handle_new_finalized_block(finalized_block, &mut last_finalized_number);
                     }
                 }
@@ -109,13 +109,13 @@ where
         let finalized_source_block = BlockInfo::new(hash, number, parent_hash, timestamp);
 
         info!(
-            target: "l1_watcher",
+            target: "supervisor::l1_watcher",
             block_number = finalized_source_block.number,
             "New finalized L1 block received"
         );
 
         if let Err(err) = self.finalized_l1_storage.update_finalized_l1(finalized_source_block) {
-            error!(target: "l1_watcher", %err, "Failed to update finalized L1 block");
+            error!(target: "supervisor::l1_watcher", %err, "Failed to update finalized L1 block");
             return;
         }
 
@@ -130,7 +130,7 @@ where
                 sender.try_send(ChainEvent::FinalizedSourceUpdate { finalized_source_block })
             {
                 error!(
-                    target: "l1_watcher",
+                    target: "supervisor::l1_watcher",
                     chain_id = %chain_id,
                     %err, "Failed to send finalized L1 update event",
                 );
@@ -142,7 +142,7 @@ where
         let incoming_block_number = incoming_block.header.number;
         if incoming_block_number <= previous_block.number {
             info!(
-                target: "l1_watcher",
+                target: "supervisor::l1_watcher",
                 "Incoming latest L1 block is not greater than the stored latest block"
             );
             return;
@@ -156,7 +156,7 @@ where
         let latest_block = BlockInfo::new(hash, number, parent_hash, timestamp);
 
         info!(
-            target: "l1_watcher",
+            target: "supervisor::l1_watcher",
             block_number = latest_block.number,
             "New latest L1 block received"
         );

--- a/crates/supervisor/core/src/logindexer/indexer.rs
+++ b/crates/supervisor/core/src/logindexer/indexer.rs
@@ -53,7 +53,7 @@ where
             let mut running = self.is_catch_up_running.lock().await;
 
             if *running {
-                debug!(target: "log_indexer", chain_id = %self.chain_id, "Catch-up running log index");
+                debug!(target: "supervisor::log_indexer", chain_id = %self.chain_id, "Catch-up running log index");
                 return;
             }
 
@@ -62,7 +62,7 @@ where
 
             if let Err(err) = self.index_log_upto(&block).await {
                 error!(
-                    target: "log_indexer",
+                    target: "supervisor::log_indexer",
                     chain_id = %self.chain_id,
                     %err,
                     "Log indexer catch-up failed"

--- a/crates/supervisor/core/src/rewinder/chain.rs
+++ b/crates/supervisor/core/src/rewinder/chain.rs
@@ -34,7 +34,7 @@ where
         let conflicting_block =
             self.db.get_block(derived_pair.derived.number).inspect_err(|err| {
                 error!(
-                    target: "rewinder",
+                    target: "supervisor::rewinder",
                     chain = %self.chain_id,
                     block_number = derived_pair.derived.number,
                     %err,
@@ -50,7 +50,7 @@ where
         // rewind the log storage to remove all the blocks till the conflicting one
         self.db.rewind_log_storage(&conflicting_block.id()).inspect_err(|err| {
             error!(
-                target: "rewinder",
+                target: "supervisor::rewinder",
                 chain = %self.chain_id,
                 block_number = derived_pair.derived.number,
                 %err,
@@ -62,7 +62,7 @@ where
         // todo: save the derived_pair - now it should succeed
 
         info!(
-            target: "rewinder",
+            target: "supervisor::rewinder",
             chain = self.chain_id,
             "Rewind successful after local derivation conflict"
         );
@@ -77,7 +77,7 @@ where
     /// reorganization.
     fn handle_l1_reorg(&self) -> Result<(), StorageError> {
         warn!(
-            target: "rewinder",
+            target: "supervisor::rewinder",
             chain = self.chain_id,
             "L1 reorg handling is not yet implemented. Skipping rewind."
         );

--- a/crates/supervisor/core/src/rpc/server.rs
+++ b/crates/supervisor/core/src/rpc/server.rs
@@ -28,7 +28,7 @@ impl<T> SupervisorRpc<T> {
     /// Creates a new [`SupervisorRpc`] instance.
     pub fn new(supervisor: Arc<T>) -> Self {
         super::Metrics::init();
-        trace!(target: "supervisor_rpc", "Creating new SupervisorRpc handler");
+        trace!(target: "supervisor::rpc", "Creating new SupervisorRpc handler");
         Self { supervisor }
     }
 }
@@ -48,7 +48,7 @@ where
             "cross_derived_to_source",
             async {
                 trace!(
-                    target: "supervisor_rpc",
+                    target: "supervisor::rpc",
                     %chain_id,
                     ?derived,
                     "Received cross_derived_to_source request"
@@ -57,7 +57,7 @@ where
                 let source_block =
                     self.supervisor.derived_to_source_block(chain_id, derived).map_err(|err| {
                         warn!(
-                            target: "supervisor_rpc",
+                            target: "supervisor::rpc",
                             %chain_id,
                             ?derived,
                             %err,
@@ -77,7 +77,7 @@ where
         crate::observe_rpc_call!(
             "local_unsafe",
             async {
-                trace!(target: "supervisor_rpc",
+                trace!(target: "supervisor::rpc",
                     %chain_id,
                     "Received local_unsafe request"
                 );
@@ -92,7 +92,7 @@ where
         crate::observe_rpc_call!(
             "dependency_set",
             async {
-                trace!(target: "supervisor_rpc",
+                trace!(target: "supervisor::rpc",
                     "Received the dependency set"
                 );
 
@@ -107,7 +107,7 @@ where
         crate::observe_rpc_call!(
             "cross_safe",
             async {
-                trace!(target: "supervisor_rpc",
+                trace!(target: "supervisor::rpc",
                     %chain_id,
                     "Received cross_safe request"
                 );
@@ -126,7 +126,7 @@ where
         crate::observe_rpc_call!(
             "finalized",
             async {
-                trace!(target: "supervisor_rpc",
+                trace!(target: "supervisor::rpc",
                     %chain_id,
                     "Received finalized request"
                 );
@@ -141,7 +141,7 @@ where
         crate::observe_rpc_call!(
             "finalized_l1",
             async {
-                trace!(target: "supervisor_rpc", "Received finalized_l1 request");
+                trace!(target: "supervisor::rpc", "Received finalized_l1 request");
                 Ok(self.supervisor.finalized_l1()?)
             }
             .await
@@ -156,7 +156,7 @@ where
             "super_root_at_timestamp",
             async {
                 let timestamp = u64::from(timestamp_hex);
-                trace!(target: "supervisor_rpc",
+                trace!(target: "supervisor::rpc",
                     %timestamp,
                     "Received super_root_at_timestamp request"
                 );
@@ -164,7 +164,7 @@ where
                 self.supervisor.super_root_at_timestamp(timestamp)
                     .await
                     .map_err(|err| {
-                        warn!(target: "supervisor_rpc", %err, "Error from core supervisor super_root_at_timestamp");
+                        warn!(target: "supervisor::rpc", %err, "Error from core supervisor super_root_at_timestamp");
                         ErrorObject::from(err)
                     })
             }.await
@@ -181,7 +181,7 @@ where
         crate::observe_rpc_call!(
             "check_access_list", 
             async {
-                trace!(target: "supervisor_rpc", 
+                trace!(target: "supervisor::rpc", 
                     num_inbox_entries = inbox_entries.len(),
                     ?min_safety,
                     ?executing_descriptor,
@@ -190,7 +190,7 @@ where
                 self.supervisor
                     .check_access_list(inbox_entries, min_safety, executing_descriptor)
                     .map_err(|err| {
-                        warn!(target: "supervisor_rpc", %err, "Error from core supervisor check_access_list");
+                        warn!(target: "supervisor::rpc", %err, "Error from core supervisor check_access_list");
                         ErrorObject::from(err)
                     })
             }.await
@@ -201,7 +201,7 @@ where
         crate::observe_rpc_call!(
             "sync_status",
             async {
-                trace!(target: "supervisor_rpc", "Received sync_status request");
+                trace!(target: "supervisor::rpc", "Received sync_status request");
 
                 let mut chains = self
                     .supervisor
@@ -261,7 +261,7 @@ where
                 }
 
                 if uninitialized_chain_db_count == chains.len() {
-                    warn!(target: "supervisor_rpc", "No chain db initialized");
+                    warn!(target: "supervisor::rpc", "No chain db initialized");
                     return Err(SuperchainDAError::UninitializedChainDatabase.into());
                 }
 
@@ -283,7 +283,7 @@ where
         crate::observe_rpc_call!(
             "all_safe_derived_at",
             async {
-                trace!(target: "supervisor_rpc",
+                trace!(target: "supervisor::rpc",
                     ?derived_from,
                     "Received all_safe_derived_at request"
                 );

--- a/crates/supervisor/core/src/safety_checker/task.rs
+++ b/crates/supervisor/core/src/safety_checker/task.rs
@@ -44,7 +44,7 @@ where
         let chain_id = self.chain_id;
 
         info!(
-            target: "safety_checker",
+            target: "supervisor::safety_checker",
             chain_id,
             %target_level,
             "Started safety checker");
@@ -54,7 +54,7 @@ where
         loop {
             tokio::select! {
                 _ = self.cancel_token.cancelled() => {
-                    info!(target: "safety_checker", chain_id, %target_level, "Canceled safety checker");
+                    info!(target: "supervisor::safety_checker", chain_id, %target_level, "Canceled safety checker");
                     break;
                 }
 
@@ -62,7 +62,7 @@ where
                     match self.promote_next_block(&checker) {
                         Ok(block_info) => {
                             info!(
-                                target: "safety_checker",
+                                target: "supervisor::safety_checker",
                                 chain_id,
                                 %target_level,
                                 %block_info,
@@ -75,7 +75,7 @@ where
                                 CrossSafetyError::NoBlockToPromote => {},
                                 _ => {
                                     warn!(
-                                        target: "safety_checker",
+                                        target: "supervisor::safety_checker",
                                         chain_id,
                                         %target_level,
                                         %err,
@@ -91,7 +91,7 @@ where
             }
         }
 
-        info!(target: "safety_checker", chain_id = self.chain_id, %target_level, "Stopped safety checker");
+        info!(target: "supervisor::safety_checker", chain_id = self.chain_id, %target_level, "Stopped safety checker");
     }
 
     // Attempts to promote the next block by the Promoter
@@ -149,7 +149,7 @@ where
     fn broadcast_event(&self, event: ChainEvent) {
         if let Err(err) = self.event_tx.try_send(event) {
             error!(
-                target: "safety_checker",
+                target: "supervisor::safety_checker",
                 target_level = %self.promoter.target_level(),
                 %err,
                 "Failed to broadcast cross head update event",

--- a/crates/supervisor/core/src/supervisor.rs
+++ b/crates/supervisor/core/src/supervisor.rs
@@ -146,11 +146,11 @@ impl Supervisor {
             let interop_time = config.interop_time;
             let derived_pair = config.genesis.get_derived_pair();
             if config.is_interop(derived_pair.derived.timestamp) {
-                info!(target: "supervisor_service", chain_id, interop_time, %derived_pair, "Initialising database for interop activation block");
+                info!(target: "supervisor::service", chain_id, interop_time, %derived_pair, "Initialising database for interop activation block");
                 db.initialise_log_storage(derived_pair.derived)?;
                 db.initialise_derivation_storage(derived_pair)?;
             }
-            info!(target: "supervisor_service", chain_id, "Database initialized successfully");
+            info!(target: "supervisor::service", chain_id, "Database initialized successfully");
         }
         Ok(())
     }
@@ -200,12 +200,12 @@ impl Supervisor {
             // todo: remove dependency from chain processors to get event txs
             // initialize event txs independently and pass at the time of initialization
             let processor = self.chain_processors.get(&chain_id).ok_or_else(|| {
-                error!(target: "supervisor_service", %chain_id, "processor not initialized");
+                error!(target: "supervisor::service", %chain_id, "processor not initialized");
                 SupervisorError::Initialise("processor not initialized".into())
             })?;
 
             let event_tx = processor.event_sender().ok_or_else(|| {
-                error!(target: "supervisor_service", %chain_id, "no event tx found in chain processor");
+                error!(target: "supervisor::service", %chain_id, "no event tx found in chain processor");
                 SupervisorError::Initialise("event sender not found".into())
             })?;
 
@@ -244,14 +244,14 @@ impl Supervisor {
     async fn init_managed_nodes(&mut self) -> Result<(), SupervisorError> {
         for config in self.config.l2_consensus_nodes_config.iter() {
             let url = Url::parse(&self.config.l1_rpc).map_err(|err| {
-                error!(target: "supervisor_service", %err, "Failed to parse L1 RPC URL");
+                error!(target: "supervisor::service", %err, "Failed to parse L1 RPC URL");
                 SupervisorError::Initialise("invalid l1 rpc url".to_string())
             })?;
             let provider = RootProvider::<Ethereum>::new_http(url);
             let client = Arc::new(Client::new(config.clone()));
 
             let chain_id = client.chain_id().await.map_err(|err| {
-                error!(target: "supervisor_service", %err, "Failed to get chain ID from client");
+                error!(target: "supervisor::service", %err, "Failed to get chain ID from client");
                 SupervisorError::Initialise("failed to get chain id from client".to_string())
             })?;
             let db = self.database_factory.get_db(chain_id)?;
@@ -264,11 +264,11 @@ impl Supervisor {
             );
 
             if self.managed_nodes.contains_key(&chain_id) {
-                warn!(target: "supervisor_service", %chain_id, "Managed node for chain already exists, skipping initialization");
+                warn!(target: "supervisor::service", %chain_id, "Managed node for chain already exists, skipping initialization");
                 continue;
             }
             self.managed_nodes.insert(chain_id, Arc::new(managed_node));
-            info!(target: "supervisor_service",
+            info!(target: "supervisor::service",
                  chain_id,
                 "Managed node for chain initialized successfully",
             );
@@ -284,7 +284,7 @@ impl Supervisor {
             if let Some(sender) = chain_processor.event_sender() {
                 senders.insert(*chain_id, sender);
             } else {
-                error!(target: "supervisor_service", chain_id, "No sender found for chain processor");
+                error!(target: "supervisor::service", chain_id, "No sender found for chain processor");
                 return Err(SupervisorError::Initialise(format!(
                     "no sender found for chain processor for chain {}",
                     chain_id
@@ -322,7 +322,7 @@ impl Supervisor {
 
     fn get_db(&self, chain: ChainId) -> Result<Arc<ChainDb>, SupervisorError> {
         self.database_factory.get_db(chain).map_err(|err| {
-            error!(target: "supervisor_service", %chain, %err, "Failed to get database for chain");
+            error!(target: "supervisor::service", %chain, %err, "Failed to get database for chain");
             SpecError::from(err).into()
         })
     }
@@ -340,7 +340,7 @@ impl SupervisorService for Supervisor {
 
     fn super_head(&self, chain: ChainId) -> Result<SuperHead, SupervisorError> {
         Ok(self.get_db(chain)?.get_super_head().map_err(|err| {
-            error!(target: "supervisor_service", %chain, %err, "Failed to get super head for chain");
+            error!(target: "supervisor::service", %chain, %err, "Failed to get super head for chain");
             SpecError::from(err)
         })?)
     }
@@ -354,7 +354,7 @@ impl SupervisorService for Supervisor {
             .get_db(chain)?
             .latest_derived_block_at_source(l1_block)
             .map_err(|err| {
-                error!(target: "supervisor_service", %chain, %err, "Failed to get latest derived block at source for chain");
+                error!(target: "supervisor::service", %chain, %err, "Failed to get latest derived block at source for chain");
                 SpecError::from(err)
             })?
         )
@@ -366,35 +366,35 @@ impl SupervisorService for Supervisor {
         derived: BlockNumHash,
     ) -> Result<BlockInfo, SupervisorError> {
         Ok(self.get_db(chain)?.derived_to_source(derived).map_err(|err| {
-            error!(target: "supervisor_service", %chain, %err, "Failed to get derived to source block for chain");
+            error!(target: "supervisor::service", %chain, %err, "Failed to get derived to source block for chain");
             SpecError::from(err)
         })?)
     }
 
     fn local_unsafe(&self, chain: ChainId) -> Result<BlockInfo, SupervisorError> {
         Ok(self.get_db(chain)?.get_safety_head_ref(SafetyLevel::LocalUnsafe).map_err(|err| {
-            error!(target: "supervisor_service", %chain, %err, "Failed to get local unsafe head ref for chain");
+            error!(target: "supervisor::service", %chain, %err, "Failed to get local unsafe head ref for chain");
             SpecError::from(err)
         })?)
     }
 
     fn cross_safe(&self, chain: ChainId) -> Result<BlockInfo, SupervisorError> {
         Ok(self.get_db(chain)?.get_safety_head_ref(SafetyLevel::CrossSafe).map_err(|err| {
-            error!(target: "supervisor_service", %chain, %err, "Failed to get cross safe head ref for chain");
+            error!(target: "supervisor::service", %chain, %err, "Failed to get cross safe head ref for chain");
             SpecError::from(err)
         })?)
     }
 
     fn finalized(&self, chain: ChainId) -> Result<BlockInfo, SupervisorError> {
         Ok(self.get_db(chain)?.get_safety_head_ref(SafetyLevel::Finalized).map_err(|err| {
-            error!(target: "supervisor_service", %chain, %err, "Failed to get finalized head ref for chain");
+            error!(target: "supervisor::service", %chain, %err, "Failed to get finalized head ref for chain");
             SpecError::from(err)
         })?)
     }
 
     fn finalized_l1(&self) -> Result<BlockInfo, SupervisorError> {
         Ok(self.database_factory.get_finalized_l1().map_err(|err| {
-            error!(target: "supervisor_service", %err, "Failed to get finalized L1");
+            error!(target: "supervisor::service", %err, "Failed to get finalized L1");
             SpecError::from(err)
         })?)
     }
@@ -435,7 +435,7 @@ impl SupervisorService for Supervisor {
             let source = self
                 .derived_to_source_block(*id, l2_block.id())
                 .inspect_err(|err| {
-                    error!(target: "supervisor_service", %id, %err, "Failed to get derived to source block for chain");
+                    error!(target: "supervisor::service", %id, %err, "Failed to get derived to source block for chain");
                 })?;
 
             if cross_safe_source.number == 0 || cross_safe_source.number < source.number {
@@ -487,7 +487,7 @@ impl SupervisorService for Supervisor {
             let db = self.get_db(initiating_chain_id)?;
 
             let block = db.get_block(access.block_number).map_err(|err| {
-                error!(target: "supervisor_service", %initiating_chain_id, %err, "Failed to get block for chain");
+                error!(target: "supervisor::service", %initiating_chain_id, %err, "Failed to get block for chain");
                 SpecError::from(err)
             })?;
             if block.timestamp != access.timestamp {
@@ -497,7 +497,7 @@ impl SupervisorService for Supervisor {
             }
 
             let log = db.get_log(access.block_number, access.log_index).map_err(|err| {
-                error!(target: "supervisor_service", %initiating_chain_id, %err, "Failed to get log for chain");
+                error!(target: "supervisor::service", %initiating_chain_id, %err, "Failed to get log for chain");
                 SpecError::from(err)
             })?;
             access.verify_checksum(&log.hash)?;

--- a/crates/supervisor/service/src/service.rs
+++ b/crates/supervisor/service/src/service.rs
@@ -38,7 +38,7 @@ impl Service {
     /// Runs the Supervisor service.
     /// This function will typically run indefinitely until interrupted.
     pub async fn run(&mut self) -> Result<()> {
-        info!(target: "supervisor_service",
+        info!(target: "supervisor::service",
             address=%self.config.rpc_addr,
             "Attempting to start Supervisor RPC server on address"
         );
@@ -59,7 +59,7 @@ impl Service {
         .start()
         .await
         .map_err(|err| {
-            warn!(target: "supervisor_service",
+            warn!(target: "supervisor::service",
                 %err,
                 "Failed to start MetricReporter actor"
             );
@@ -70,7 +70,7 @@ impl Service {
             Supervisor::new(self.config.clone(), database_factory, self.cancel_token.clone());
 
         supervisor.initialise().await.map_err(|err| {
-            warn!(target: "supervisor_service",
+            warn!(target: "supervisor::service",
                 %err,
                 "Failed to initialise Supervisor"
             );
@@ -86,7 +86,7 @@ impl Service {
         let server = ServerBuilder::default().build(self.config.rpc_addr).await?;
         self.rpc_server_handle = Some(server.start(rpc_impl.clone().into_rpc()));
 
-        info!(target: "supervisor_service",
+        info!(target: "supervisor::service",
             addr=%self.config.rpc_addr,
             "Supervisor RPC server started successfully and listening on address",
         );
@@ -101,15 +101,15 @@ impl Service {
         // This will signal the server to stop accepting new connections
         // and wait for existing connections to finish.
         if let Some(handle) = self.rpc_server_handle.take() {
-            info!(target: "supervisor_service", "Sending stop signal to RPC server...");
+            info!(target: "supervisor::service", "Sending stop signal to RPC server...");
             handle.stop()?; // Signal the server to stop accepting new connections
-            info!(target: "supervisor_service",
+            info!(target: "supervisor::service",
                 "Waiting for RPC server to shut down completely..."
             );
             handle.stopped().await; // Wait for the server to fully stop
-            info!(target: "supervisor_service", "Supervisor RPC server shut down gracefully.");
+            info!(target: "supervisor::service", "Supervisor RPC server shut down gracefully.");
         } else {
-            warn!(target: "supervisor_service",
+            warn!(target: "supervisor::service",
                 "Shutdown called, but RPC server handle was not present. Was run() called?"
             );
         }

--- a/crates/supervisor/storage/src/chaindb.rs
+++ b/crates/supervisor/storage/src/chaindb.rs
@@ -131,7 +131,7 @@ impl DerivationStorageWriter for ChainDb {
                     .map_err(|err| match err {
                         StorageError::EntryNotFound(_) => {
                             error!(
-                                target: "supervisor_storage",
+                                target: "supervisor::storage",
                                 incoming_block = %derived_block,
                                 "Derived block not found in log storage: {derived_block:?}"
                             );
@@ -141,7 +141,7 @@ impl DerivationStorageWriter for ChainDb {
                     })?;
                 if block != derived_block {
                     error!(
-                        target: "supervisor_storage",
+                        target: "supervisor::storage",
                         incoming_block = %derived_block,
                         stored_log_block = %block,
                         "Derived block does not match the stored log block"
@@ -299,7 +299,7 @@ impl HeadRefStorageWriter for ChainDb {
                 if finalized_source_block.number >= safe_block_pair.source.number {
                     // this could happen during initial sync
                     warn!(
-                        target: "supervisor_storage",
+                        target: "supervisor::storage",
                         chain_id = %self.chain_id,
                         l1_finalized_block_number = finalized_source_block.number,
                         safe_source_block_number = safe_block_pair.source.number,
@@ -327,7 +327,7 @@ impl HeadRefStorageWriter for ChainDb {
                 let parent = sp.get_safety_head_ref(SafetyLevel::CrossUnsafe)?;
                 if !parent.is_parent_of(block) {
                     error!(
-                        target: "supervisor_storage",
+                        target: "supervisor::storage",
                         chain_id = %self.chain_id,
                         incoming_block = %block,
                         latest_block = %parent,
@@ -340,7 +340,7 @@ impl HeadRefStorageWriter for ChainDb {
                 let stored_block = lp.get_block(block.number)?;
                 if stored_block.hash != block.hash {
                     warn!(
-                        target: "supervisor_storage",
+                        target: "supervisor::storage",
                         chain_id = %self.chain_id,
                         incoming_block_hash = %block.hash,
                         stored_block_hash = %stored_block.hash,
@@ -365,7 +365,7 @@ impl HeadRefStorageWriter for ChainDb {
                 let parent = sp.get_safety_head_ref(SafetyLevel::CrossSafe)?;
                 if !parent.is_parent_of(block) {
                     error!(
-                        target: "supervisor_storage",
+                        target: "supervisor::storage",
                         chain_id = %self.chain_id,
                         incoming_block = %block,
                         latest_block = %parent,
@@ -494,7 +494,7 @@ impl MetricsReporter for ChainDb {
                 Ok::<(), eyre::Report>(())
             })
             .inspect_err(|err| {
-                warn!(target: "supervisor_storage", %err, "Failed to collect database metrics");
+                warn!(target: "supervisor::storage", %err, "Failed to collect database metrics");
             });
 
         for (name, value, labels) in metrics {

--- a/crates/supervisor/storage/src/chaindb_factory.rs
+++ b/crates/supervisor/storage/src/chaindb_factory.rs
@@ -72,7 +72,7 @@ impl ChainDbFactory {
         {
             // Try to get it without locking for write
             let dbs = self.dbs.read().map_err(|err| {
-                error!(target: "supervisor_storage", %err, "Failed to acquire read lock on databases");
+                error!(target: "supervisor::storage", %err, "Failed to acquire read lock on databases");
                 StorageError::LockPoisoned
             })?;
             if let Some(db) = dbs.get(&chain_id) {
@@ -82,7 +82,7 @@ impl ChainDbFactory {
 
         // Not found, create and insert
         let mut dbs = self.dbs.write().map_err(|err| {
-            error!(target: "supervisor_storage", %err, "Failed to acquire write lock on databases");
+            error!(target: "supervisor::storage", %err, "Failed to acquire write lock on databases");
             StorageError::LockPoisoned
         })?;
         // Double-check in case another thread inserted
@@ -132,7 +132,7 @@ impl FinalizedL1Storage for ChainDbFactory {
             "get_finalized_l1",
             || {
                 let guard = self.finalized_l1.read().map_err(|err| {
-                    error!(target: "supervisor_storage", %err, "Failed to acquire read lock on finalized_l1");
+                    error!(target: "supervisor::storage", %err, "Failed to acquire read lock on finalized_l1");
                     StorageError::LockPoisoned
                 })?;
                 guard.as_ref().cloned().ok_or(StorageError::FutureData)
@@ -148,14 +148,14 @@ impl FinalizedL1Storage for ChainDbFactory {
                     .finalized_l1
                     .write()
                     .map_err(|err| {
-                        error!(target: "supervisor_storage", %err, "Failed to acquire write lock on finalized_l1");
+                        error!(target: "supervisor::storage", %err, "Failed to acquire write lock on finalized_l1");
                         StorageError::LockPoisoned
                     })?;
 
                 // Check if the new block number is greater than the current finalized block
                 if let Some(ref current) = *guard {
                     if block.number <= current.number {
-                        error!(target: "supervisor_storage",
+                        error!(target: "supervisor::storage",
                             current_block_number = current.number,
                             new_block_number = block.number,
                             "New finalized block number is not greater than current finalized block number",

--- a/crates/supervisor/storage/src/providers/derivation_provider.rs
+++ b/crates/supervisor/storage/src/providers/derivation_provider.rs
@@ -35,7 +35,7 @@ where
         let derived_block_pair_opt =
             self.tx.get::<DerivedBlocks>(derived_block_number).inspect_err(|err| {
                 error!(
-                  target: "supervisor_storage",
+                  target: "supervisor::storage",
                   chain_id = %self.chain_id,
                   derived_block_number,
                   %err,
@@ -45,7 +45,7 @@ where
 
         let derived_block_pair = derived_block_pair_opt.ok_or_else(|| {
             warn!(
-              target: "supervisor_storage",
+              target: "supervisor::storage",
               chain_id = %self.chain_id,
               derived_block_number,
               "Derived block not found"
@@ -67,7 +67,7 @@ where
 
         if derived_block_pair.derived.hash != derived_block_id.hash {
             warn!(
-              target: "supervisor_storage",
+              target: "supervisor::storage",
               chain_id = %self.chain_id,
               derived_block_number = derived_block_id.number,
               expected_hash = %derived_block_id.hash,
@@ -104,7 +104,7 @@ where
         let block_traversal =
             self.tx.get::<BlockTraversal>(source_block_number).inspect_err(|err| {
                 error!(
-                    target: "supervisor_storage",
+                    target: "supervisor::storage",
                     chain_id = %self.chain_id,
                     source_block_number,
                     %err,
@@ -114,7 +114,7 @@ where
 
         Ok(block_traversal.ok_or_else(|| {
             warn!(
-              target: "supervisor_storage",
+              target: "supervisor::storage",
               chain_id = %self.chain_id,
               source_block_number,
               "source block not found"
@@ -139,7 +139,7 @@ where
 
         if block_traversal.source.hash != source_block_id.hash {
             warn!(
-                target: "supervisor_storage",
+                target: "supervisor::storage",
                 chain_id = %self.chain_id,
                 source_block_hash = %source_block_id.hash,
                 "Source block hash mismatch"
@@ -170,7 +170,7 @@ where
     pub(crate) fn latest_derivation_state(&self) -> Result<DerivedRefPair, StorageError> {
         let mut cursor = self.tx.cursor_read::<DerivedBlocks>().inspect_err(|err| {
             error!(
-                target: "supervisor_storage",
+                target: "supervisor::storage",
                 chain_id = %self.chain_id,
                 %err,
                 "Failed to get cursor for DerivedBlocks"
@@ -179,7 +179,7 @@ where
 
         let result = cursor.last().inspect_err(|err| {
             error!(
-                target: "supervisor_storage",
+                target: "supervisor::storage",
                 chain_id = %self.chain_id,
                 %err,
                 "Failed to seek to last block"
@@ -188,7 +188,7 @@ where
 
         let (_, block) = result.ok_or_else(|| {
             error!(
-                target: "supervisor_storage",
+                target: "supervisor::storage",
                 chain_id = %self.chain_id,
                 "No blocks found in storage"
             );
@@ -197,7 +197,7 @@ where
 
         let latest_source_block = self.latest_source_block().inspect_err(|err| {
             error!(
-                target: "supervisor_storage",
+                target: "supervisor::storage",
                 chain_id = %self.chain_id,
                 %err,
                 "Failed to get latest source block"
@@ -229,7 +229,7 @@ where
     pub(crate) fn latest_source_block(&self) -> Result<BlockInfo, StorageError> {
         let block = self.latest_source_block_traversal().inspect_err(|err| {
             error!(
-                target: "supervisor_storage",
+                target: "supervisor::storage",
                 chain_id = %self.chain_id,
                 %err,
                 "Failed to get latest source block traversal"
@@ -283,7 +283,7 @@ where
                 .get_derived_block_pair_by_number(incoming_pair.derived.number)
                 .inspect_err(|err| {
                 error!(
-                    target: "supervisor_storage",
+                    target: "supervisor::storage",
                     chain_id = %self.chain_id,
                     incoming_derived_block_pair = %incoming_pair,
                     %err,
@@ -295,7 +295,7 @@ where
                 return Ok(());
             } else {
                 error!(
-                    target: "supervisor_storage",
+                    target: "supervisor::storage",
                     chain_id = %self.chain_id,
                     %latest_derivation_state,
                     incoming_derived_block_pair = %incoming_pair,
@@ -308,7 +308,7 @@ where
         // Latest source block must be same as the incoming source block
         if latest_derivation_state.source != incoming_pair.source {
             warn!(
-                target: "supervisor_storage",
+                target: "supervisor::storage",
                 chain_id = %self.chain_id,
                 latest_source_block = %latest_derivation_state.source,
                 incoming_source = %incoming_pair.source,
@@ -319,7 +319,7 @@ where
 
         if !latest_derivation_state.derived.is_parent_of(&incoming_pair.derived) {
             warn!(
-              target: "supervisor_storage",
+              target: "supervisor::storage",
               chain_id = %self.chain_id,
               %latest_derivation_state,
               incoming_derived_block_pair = %incoming_pair,
@@ -341,7 +341,7 @@ where
         // the derived block must be derived from the latest source block
         let mut block_traversal = self.latest_source_block_traversal().inspect_err(|err| {
             error!(
-                target: "supervisor_storage",
+                target: "supervisor::storage",
                 chain_id = %self.chain_id,
                 incoming_derived_block_pair = %incoming_pair,
                 %err,
@@ -352,7 +352,7 @@ where
         let latest_source_block = block_traversal.clone().source.into();
         if incoming_pair.source != latest_source_block {
             warn!(
-                target: "supervisor_storage",
+                target: "supervisor::storage",
                 chain_id = %self.chain_id,
                 latest_source_block = %latest_source_block,
                 incoming_source = %incoming_pair.source,
@@ -369,7 +369,7 @@ where
             .put::<DerivedBlocks>(incoming_pair.derived.number, incoming_pair.into())
             .inspect_err(|err| {
                 error!(
-                    target: "supervisor_storage",
+                    target: "supervisor::storage",
                     chain_id = %self.chain_id,
                     incoming_derived_block_pair = %incoming_pair,
                     %err,
@@ -381,7 +381,7 @@ where
         self.tx.put::<BlockTraversal>(incoming_pair.source.number, block_traversal).inspect_err(
             |err| {
                 error!(
-                    target: "supervisor_storage",
+                    target: "supervisor::storage",
                     chain_id = %self.chain_id,
                     incoming_derived_block_pair = %incoming_pair,
                     %err,
@@ -416,7 +416,7 @@ where
             let source_block =
                 self.get_source_block(incoming_source.number).inspect_err(|err| {
                     error!(
-                        target: "supervisor_storage",
+                        target: "supervisor::storage",
                         chain_id = %self.chain_id,
                         incoming_source = %incoming_source,
                         %err,
@@ -428,7 +428,7 @@ where
                 return Ok(());
             } else {
                 error!(
-                    target: "supervisor_storage",
+                    target: "supervisor::storage",
                     chain_id = %self.chain_id,
                     latest_source_block = %latest_source_block,
                     incoming_source = %incoming_source,
@@ -440,7 +440,7 @@ where
 
         if !latest_source_block.is_parent_of(&incoming_source) {
             error!(
-                target: "supervisor_storage",
+                target: "supervisor::storage",
                 chain_id = %self.chain_id,
                 latest_source_block = %latest_source_block,
                 incoming_source = %incoming_source,
@@ -461,7 +461,7 @@ where
 
         self.tx.put::<BlockTraversal>(incoming_source.number, block_traversal).inspect_err(
             |err| {
-                error!(target: "supervisor_storage", chain_id = %self.chain_id, %err, "Failed to save block traversal");
+                error!(target: "supervisor::storage", chain_id = %self.chain_id, %err, "Failed to save block traversal");
             },
         )?;
 
@@ -505,7 +505,7 @@ where
         if !traversal.derived_block_numbers.is_empty() {
             self.tx.put::<BlockTraversal>(block_pair.source.number, traversal).inspect_err(
                 |err| {
-                    error!(target: "supervisor_storage", chain_id = %self.chain_id, %err, "Failed to update block traversal");
+                    error!(target: "supervisor::storage", chain_id = %self.chain_id, %err, "Failed to update block traversal");
                 },
             )?;
             walk_from += 1;

--- a/crates/supervisor/storage/src/providers/head_ref_provider.rs
+++ b/crates/supervisor/storage/src/providers/head_ref_provider.rs
@@ -25,7 +25,7 @@ where
         let head_ref_key = safety_level.into();
         let result = self.tx.get::<SafetyHeadRefs>(head_ref_key).inspect_err(|err| {
             error!(
-                target: "supervisor_storage",
+                target: "supervisor::storage",
                 chain_id = %self.chain_id,
                 %safety_level,
                 %err,
@@ -54,7 +54,7 @@ where
         if let Ok(current_head_ref) = self.get_safety_head_ref(safety_level) {
             if current_head_ref.number > incoming_head_ref.number {
                 warn!(
-                    target: "supervisor_storage",
+                    target: "supervisor::storage",
                     chain_id = %self.chain_id,
                     %current_head_ref,
                     %incoming_head_ref,
@@ -69,7 +69,7 @@ where
             .put::<SafetyHeadRefs>(safety_level.into(), (*incoming_head_ref).into())
             .inspect_err(|err| {
                 error!(
-                    target: "supervisor_storage",
+                    target: "supervisor::storage",
                     chain_id = %self.chain_id,
                     %incoming_head_ref,
                     %safety_level,
@@ -107,7 +107,7 @@ where
             .put::<SafetyHeadRefs>(safety_level.into(), (*incoming_head_ref).into())
             .inspect_err(|err| {
                 error!(
-                    target: "supervisor_storage",
+                    target: "supervisor::storage",
                     chain_id = %self.chain_id,
                     %incoming_head_ref,
                     %safety_level,

--- a/crates/supervisor/storage/src/providers/log_provider.rs
+++ b/crates/supervisor/storage/src/providers/log_provider.rs
@@ -58,7 +58,7 @@ where
         logs: Vec<Log>,
     ) -> Result<(), StorageError> {
         debug!(
-            target: "supervisor_storage",
+            target: "supervisor::storage",
             chain_id = %self.chain_id,
             block_number = block.number,
             "Storing logs",
@@ -78,7 +78,7 @@ where
                 return Ok(());
             }
             error!(
-                target: "supervisor_storage",
+                target: "supervisor::storage",
                 chain_id = %self.chain_id,
                 %stored_block,
                 incoming_block = %block,
@@ -89,7 +89,7 @@ where
 
         if !latest_block.is_parent_of(block) {
             warn!(
-                target: "supervisor_storage",
+                target: "supervisor::storage",
                 chain_id = %self.chain_id,
                 %latest_block,
                 incoming_block = %block,
@@ -108,7 +108,7 @@ where
     ) -> Result<(), StorageError> {
         self.tx.put::<BlockRefs>(block.number, (*block).into()).inspect_err(|err| {
             error!(
-                target: "supervisor_storage",
+                target: "supervisor::storage",
                 chain_id = %self.chain_id,
                 block_number = block.number,
                 %err,
@@ -118,7 +118,7 @@ where
 
         let mut cursor = self.tx.cursor_dup_write::<LogEntries>().inspect_err(|err| {
             error!(
-                target: "supervisor_storage",
+                target: "supervisor::storage",
                 chain_id = %self.chain_id,
                 %err,
                 "Failed to get dup cursor"
@@ -128,7 +128,7 @@ where
         for log in logs {
             cursor.append_dup(block.number, log.into()).inspect_err(|err| {
                 error!(
-                    target: "supervisor_storage",
+                    target: "supervisor::storage",
                     chain_id = %self.chain_id,
                     block_number = block.number,
                     %err,
@@ -148,7 +148,7 @@ where
         while let Some(Ok((key, stored_block))) = walker.next() {
             if key == block.number && block.hash != stored_block.hash {
                 error!(
-                    target: "supervisor_storage",
+                    target: "supervisor::storage",
                     chain_id = %self.chain_id,
                     %stored_block,
                     incoming_block = ?block,
@@ -169,7 +169,7 @@ where
 {
     pub(crate) fn get_block(&self, block_number: u64) -> Result<BlockInfo, StorageError> {
         debug!(
-            target: "supervisor_storage",
+            target: "supervisor::storage",
             chain_id = %self.chain_id,
             block_number,
             "Fetching block"
@@ -177,7 +177,7 @@ where
 
         let block_option = self.tx.get::<BlockRefs>(block_number).inspect_err(|err| {
             error!(
-                target: "supervisor_storage",
+                target: "supervisor::storage",
                 chain_id = %self.chain_id,
                 block_number,
                 %err,
@@ -187,7 +187,7 @@ where
 
         let block = block_option.ok_or_else(|| {
             warn!(
-                target: "supervisor_storage",
+                target: "supervisor::storage",
                 chain_id = %self.chain_id,
                 block_number,
                 "Block not found"
@@ -198,11 +198,11 @@ where
     }
 
     pub(crate) fn get_latest_block(&self) -> Result<BlockInfo, StorageError> {
-        debug!(target: "supervisor_storage", chain_id = %self.chain_id, "Fetching latest block");
+        debug!(target: "supervisor::storage", chain_id = %self.chain_id, "Fetching latest block");
 
         let mut cursor = self.tx.cursor_read::<BlockRefs>().inspect_err(|err| {
             error!(
-                target: "supervisor_storage",
+                target: "supervisor::storage",
                 chain_id = %self.chain_id,
                 %err,
                 "Failed to get cursor"
@@ -211,7 +211,7 @@ where
 
         let result = cursor.last().inspect_err(|err| {
             error!(
-                target: "supervisor_storage",
+                target: "supervisor::storage",
                 chain_id = %self.chain_id,
                 %err,
                 "Failed to seek to last block"
@@ -220,7 +220,7 @@ where
 
         let (_, block) = result.ok_or_else(|| {
             warn!(
-                target: "supervisor_storage",
+                target: "supervisor::storage",
                 chain_id = %self.chain_id,
                 "No blocks found in storage"
             );
@@ -231,7 +231,7 @@ where
 
     pub(crate) fn get_log(&self, block_number: u64, log_index: u32) -> Result<Log, StorageError> {
         debug!(
-            target: "supervisor_storage",
+            target: "supervisor::storage",
             chain_id = %self.chain_id,
             block_number,
             log_index,
@@ -240,7 +240,7 @@ where
 
         let mut cursor = self.tx.cursor_dup_read::<LogEntries>().inspect_err(|err| {
             error!(
-                target: "supervisor_storage",
+                target: "supervisor::storage",
                 chain_id = %self.chain_id,
                 %err,
                 "Failed to get cursor for LogEntries"
@@ -249,7 +249,7 @@ where
 
         let result = cursor.seek_by_key_subkey(block_number, log_index).inspect_err(|err| {
             error!(
-                target: "supervisor_storage",
+                target: "supervisor::storage",
                 chain_id = %self.chain_id,
                 block_number,
                 log_index,
@@ -260,7 +260,7 @@ where
 
         let log_entry = result.ok_or_else(|| {
             warn!(
-                target: "supervisor_storage",
+                target: "supervisor::storage",
                 chain_id = %self.chain_id,
                 block_number,
                 log_index,
@@ -273,11 +273,11 @@ where
     }
 
     pub(crate) fn get_logs(&self, block_number: u64) -> Result<Vec<Log>, StorageError> {
-        debug!(target: "supervisor_storage", chain_id = %self.chain_id, block_number, "Fetching logs");
+        debug!(target: "supervisor::storage", chain_id = %self.chain_id, block_number, "Fetching logs");
 
         let mut cursor = self.tx.cursor_dup_read::<LogEntries>().inspect_err(|err| {
             error!(
-                target: "supervisor_storage",
+                target: "supervisor::storage",
                 chain_id = %self.chain_id,
                 %err,
                 "Failed to get dup cursor"
@@ -286,7 +286,7 @@ where
 
         let walker = cursor.walk_range(block_number..=block_number).inspect_err(|err| {
             error!(
-                target: "supervisor_storage",
+                target: "supervisor::storage",
                 chain_id = %self.chain_id,
                 block_number,
                 %err,
@@ -300,7 +300,7 @@ where
                 Ok((_, entry)) => logs.push(entry.into()),
                 Err(err) => {
                     error!(
-                        target: "supervisor_storage",
+                        target: "supervisor::storage",
                         chain_id = %self.chain_id,
                         block_number,
                         %err,


### PR DESCRIPTION
Ref https://github.com/op-rs/kona/issues/2123, https://github.com/op-rs/kona/issues/2283

Adds `supervisor` path to log targets in supervisor. This makes it easier to tell `kona-node` and `kona-supervisor` components apart when running `kona-node` as an embedded system in `kona-supervisor`.