### PR TITLE
Fix typos in task errors and P2P block validation docs

### DIFF
--- a/crates/node/engine/src/task_queue/tasks/build/error.rs
+++ b/crates/node/engine/src/task_queue/tasks/build/error.rs
@@ -65,7 +65,7 @@ pub enum BuildTaskError {
     /// A deposit-only payload failed to import.
     #[error("Deposit-only payload failed to import")]
     DepositOnlyPayloadFailed,
-    /// Failed to re-atttempt payload import with deposit-only payload.
+    /// Failed to re-attempt payload import with deposit-only payload.
     #[error("Failed to re-attempt payload import with deposit-only payload")]
     DepositOnlyPayloadReattemptFailed,
     /// The payload is invalid, and the derivation pipeline must

--- a/crates/node/engine/src/task_queue/tasks/insert/error.rs
+++ b/crates/node/engine/src/task_queue/tasks/insert/error.rs
@@ -24,7 +24,7 @@ pub enum InsertTaskError {
     /// Unexpected payload status
     #[error("Unexpected payload status: {0}")]
     UnexpectedPayloadStatus(PayloadStatusEnum),
-    /// Inconsistent forchoice state.
+    /// Inconsistent forkchoice state.
     #[error("Inconsistent forkchoice state; Pipeline reset required")]
     InconsistentForkchoiceState,
     /// Error converting the payload + chain genesis into an L2 block info.

--- a/docs/docs/pages/node/design/p2p.mdx
+++ b/docs/docs/pages/node/design/p2p.mdx
@@ -135,7 +135,7 @@ Block validity in kona follows the [OP Stack block validation specs][validation]
 As of writing these docs, block validation follows a few rules.
 
 - The timestamp is between 60 seconds in the past and at most 5 seconds in the future.
-- The block hash is valid. This is checked by transforming the paylaod into a block
+- The block hash is valid. This is checked by transforming the payload into a block
   and then hashing the block header to produce the payload hash.
 - The contents of the payload envelope are correct for its version. Since different
   versions introduce new contents to the payload from hardforks, the


### PR DESCRIPTION
This commit addresses several small but important typo fixes in both Rust error enums and documentation:

## 🛠 Code fixes:
Corrected spelling:

- re-atttempt → re-attempt in BuildTaskError

- forchoice → forkchoice in InsertTaskError

## 📘 Docs fixes:
Fixed typo:

- paylaod → payload in the P2P design spec (p2p.mdx)

These changes improve clarity and maintain consistency across code and documentation. No functional behavior is modified.