### PR TITLE
feat(node/sequencer): integrate remote signer in CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4693,6 +4693,7 @@ dependencies = [
  "metrics",
  "op-alloy-provider",
  "op-alloy-rpc-types-engine",
+ "reqwest",
  "rstest",
  "serde_json",
  "strum",

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -52,6 +52,7 @@ libp2p.workspace = true
 anyhow.workspace = true
 futures.workspace = true
 metrics.workspace = true
+reqwest.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 tokio-stream.workspace = true

--- a/bin/node/src/flags/mod.rs
+++ b/bin/node/src/flags/mod.rs
@@ -17,3 +17,6 @@ pub use metrics::init_unified_metrics;
 
 mod sequencer;
 pub use sequencer::SequencerArgs;
+
+mod signer;
+pub use signer::{SignerArgs, SignerArgsParseError};

--- a/bin/node/src/flags/signer.rs
+++ b/bin/node/src/flags/signer.rs
@@ -18,7 +18,7 @@ pub struct SignerArgs {
     #[arg(
         long = "p2p.sequencer.key",
         env = "KONA_NODE_P2P_SEQUENCER_KEY",
-        conflicts_with = "p2p.signer.endpoint"
+        conflicts_with = "endpoint"
     )]
     pub sequencer_key: Option<B256>,
     /// The URL of the remote signer endpoint. If not provided, remote signer will be disabled.
@@ -27,39 +27,31 @@ pub struct SignerArgs {
     #[arg(
         long = "p2p.signer.endpoint",
         env = "KONA_NODE_P2P_SIGNER_ENDPOINT",
-        requires = "p2p.signer.address"
+        requires = "address"
     )]
     pub endpoint: Option<Url>,
     /// The address to sign transactions for. Required if `signer.endpoint` is provided.
     #[arg(
         long = "p2p.signer.address",
         env = "KONA_NODE_P2P_SIGNER_ADDRESS",
-        requires = "p2p.signer.endpoint"
+        requires = "endpoint"
     )]
     pub address: Option<Address>,
     /// Headers to pass to the remote signer. Format `key=value`. Value can contain any character
     /// allowed in a HTTP header. When using env vars, split with commas. When using flags one
     /// key value pair per flag.
-    #[arg(
-        long = "p2p.signer.header",
-        env = "KONA_NODE_P2P_SIGNER_HEADER",
-        requires = "p2p.signer.endpoint"
-    )]
+    #[arg(long = "p2p.signer.header", env = "KONA_NODE_P2P_SIGNER_HEADER", requires = "endpoint")]
     pub header: Vec<String>,
     /// An optional path to CA certificates to be used for the remote signer.
-    #[arg(
-        long = "p2p.signer.tls.ca",
-        env = "KONA_NODE_P2P_SIGNER_TLS_CA",
-        requires = "p2p.signer.endpoint"
-    )]
+    #[arg(long = "p2p.signer.tls.ca", env = "KONA_NODE_P2P_SIGNER_TLS_CA", requires = "endpoint")]
     pub ca_cert: Option<PathBuf>,
     /// An optional path to the client certificate for the remote signer. If specified,
     /// `signer.tls.key` must also be specified.
     #[arg(
         long = "p2p.signer.tls.cert",
         env = "KONA_NODE_P2P_SIGNER_TLS_CERT",
-        requires = "p2p.signer.tls.key",
-        requires = "p2p.signer.endpoint"
+        requires = "key",
+        requires = "endpoint"
     )]
     pub cert: Option<PathBuf>,
     /// An optional path to the client key for the remote signer. If specified,
@@ -67,8 +59,8 @@ pub struct SignerArgs {
     #[arg(
         long = "p2p.signer.tls.key",
         env = "KONA_NODE_P2P_SIGNER_TLS_KEY",
-        requires = "p2p.signer.tls.cert",
-        requires = "p2p.signer.endpoint"
+        requires = "cert",
+        requires = "endpoint"
     )]
     pub key: Option<PathBuf>,
 }

--- a/bin/node/src/flags/signer.rs
+++ b/bin/node/src/flags/signer.rs
@@ -1,0 +1,159 @@
+use std::path::PathBuf;
+
+use alloy_primitives::{Address, B256};
+use alloy_signer::{Signer, k256::ecdsa};
+use alloy_signer_local::PrivateKeySigner;
+use clap::{Parser, arg};
+use kona_sources::{BlockSigner, ClientCert, RemoteSigner};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use std::str::FromStr;
+use url::Url;
+
+use crate::flags::GlobalArgs;
+
+/// Signer CLI Flags
+#[derive(Debug, Clone, Parser, Default, PartialEq, Eq)]
+pub struct SignerArgs {
+    /// An optional flag to specify a local private key for the sequencer to sign unsafe blocks.
+    #[arg(
+        long = "p2p.sequencer.key",
+        env = "KONA_NODE_P2P_SEQUENCER_KEY",
+        conflicts_with = "p2p.signer.endpoint"
+    )]
+    pub sequencer_key: Option<B256>,
+    /// The URL of the remote signer endpoint. If not provided, remote signer will be disabled.
+    /// This is mutually exclusive with `p2p.sequencer.key`.
+    /// This is required if any of the other signer flags are provided.
+    #[arg(
+        long = "p2p.signer.endpoint",
+        env = "KONA_NODE_P2P_SIGNER_ENDPOINT",
+        requires = "p2p.signer.address"
+    )]
+    pub endpoint: Option<Url>,
+    /// The address to sign transactions for. Required if `signer.endpoint` is provided.
+    #[arg(
+        long = "p2p.signer.address",
+        env = "KONA_NODE_P2P_SIGNER_ADDRESS",
+        requires = "p2p.signer.endpoint"
+    )]
+    pub address: Option<Address>,
+    /// Headers to pass to the remote signer. Format `key=value`. Value can contain any character
+    /// allowed in a HTTP header. When using env vars, split with commas. When using flags one
+    /// key value pair per flag.
+    #[arg(
+        long = "p2p.signer.header",
+        env = "KONA_NODE_P2P_SIGNER_HEADER",
+        requires = "p2p.signer.endpoint"
+    )]
+    pub header: Vec<String>,
+    /// An optional path to CA certificates to be used for the remote signer.
+    #[arg(
+        long = "p2p.signer.tls.ca",
+        env = "KONA_NODE_P2P_SIGNER_TLS_CA",
+        requires = "p2p.signer.endpoint"
+    )]
+    pub ca_cert: Option<PathBuf>,
+    /// An optional path to the client certificate for the remote signer. If specified,
+    /// `signer.tls.key` must also be specified.
+    #[arg(
+        long = "p2p.signer.tls.cert",
+        env = "KONA_NODE_P2P_SIGNER_TLS_CERT",
+        requires = "p2p.signer.tls.key",
+        requires = "p2p.signer.endpoint"
+    )]
+    pub cert: Option<PathBuf>,
+    /// An optional path to the client key for the remote signer. If specified,
+    /// `signer.tls.cert` must also be specified.
+    #[arg(
+        long = "p2p.signer.tls.key",
+        env = "KONA_NODE_P2P_SIGNER_TLS_KEY",
+        requires = "p2p.signer.tls.cert",
+        requires = "p2p.signer.endpoint"
+    )]
+    pub key: Option<PathBuf>,
+}
+
+/// Errors that can occur when parsing the signer arguments.
+#[derive(Debug, thiserror::Error)]
+pub enum SignerArgsParseError {
+    /// The local sequencer key and remote signer cannot be specified at the same time.
+    #[error("A local sequencer key and a remote signer cannot be specified at the same time.")]
+    LocalAndRemoteSigner,
+    /// The sequencer key is invalid.
+    #[error("The sequencer key is invalid.")]
+    SequencerKeyInvalid(#[from] ecdsa::Error),
+    /// The address is required if `signer.endpoint` is provided.
+    #[error("The address is required if `signer.endpoint` is provided.")]
+    AddressRequired,
+    /// The header is invalid.
+    #[error("The header is invalid.")]
+    InvalidHeader,
+    /// The private key field is required if `signer.tls.cert` is provided.
+    #[error("The private key field is required if `signer.tls.cert` is provided.")]
+    KeyRequired,
+    /// The header name is invalid.
+    #[error("The header name is invalid.")]
+    InvalidHeaderName(#[from] reqwest::header::InvalidHeaderName),
+    /// The header value is invalid.
+    #[error("The header value is invalid.")]
+    InvalidHeaderValue(#[from] reqwest::header::InvalidHeaderValue),
+}
+
+impl SignerArgs {
+    /// Creates a [`BlockSigner`] from the [`SignerArgs`].
+    pub fn config(self, args: &GlobalArgs) -> Result<Option<BlockSigner>, SignerArgsParseError> {
+        // The sequencer signer obtained from the CLI arguments.
+        let gossip_signer: Option<BlockSigner> = match (self.sequencer_key, self.config_remote()?) {
+            (Some(_), Some(_)) => return Err(SignerArgsParseError::LocalAndRemoteSigner),
+            (Some(key), None) => {
+                let signer: BlockSigner = PrivateKeySigner::from_bytes(&key)?
+                    .with_chain_id(Some(args.l2_chain_id.into()))
+                    .into();
+                Some(signer)
+            }
+            (None, Some(signer)) => Some(signer.into()),
+            (None, None) => None,
+        };
+
+        Ok(gossip_signer)
+    }
+
+    /// Creates a [`RemoteSigner`] from the [`SignerArgs`].
+    fn config_remote(self) -> Result<Option<RemoteSigner>, SignerArgsParseError> {
+        let Some(endpoint) = self.endpoint else {
+            return Ok(None);
+        };
+
+        let Some(address) = self.address else {
+            return Err(SignerArgsParseError::AddressRequired);
+        };
+
+        let headers = self
+            .header
+            .iter()
+            .map(|h| {
+                let (key, value) = h.split_once('=').ok_or(SignerArgsParseError::InvalidHeader)?;
+                Ok((HeaderName::from_str(key)?, HeaderValue::from_str(value)?))
+            })
+            .collect::<Result<HeaderMap, SignerArgsParseError>>()?;
+
+        let client_cert = self
+            .cert
+            .clone()
+            .map(|cert| {
+                Ok::<_, SignerArgsParseError>(ClientCert {
+                    cert,
+                    key: self.key.clone().ok_or(SignerArgsParseError::KeyRequired)?,
+                })
+            })
+            .transpose()?;
+
+        Ok(Some(RemoteSigner {
+            address,
+            endpoint,
+            ca_cert: self.ca_cert.clone(),
+            client_cert,
+            headers,
+        }))
+    }
+}

--- a/crates/node/service/src/actors/network/builder.rs
+++ b/crates/node/service/src/actors/network/builder.rs
@@ -44,7 +44,7 @@ impl From<NetworkConfig> for NetworkBuilder {
         .with_peer_monitoring(config.monitor_peers)
         .with_topic_scoring(config.topic_scoring)
         .with_gater_config(config.gater_config)
-        .with_signer(config.signer)
+        .with_signer(config.gossip_signer)
     }
 }
 
@@ -79,7 +79,7 @@ impl NetworkBuilder {
         Self { gossip: self.gossip.with_gater_config(config), ..self }
     }
 
-    /// Sets the local signer for the [`NetworkBuilder`].
+    /// Sets the signer for the [`NetworkBuilder`].
     pub fn with_signer(self, signer: Option<BlockSigner>) -> Self {
         Self { signer, ..self }
     }

--- a/crates/node/service/src/actors/network/config.rs
+++ b/crates/node/service/src/actors/network/config.rs
@@ -44,8 +44,8 @@ pub struct NetworkConfig {
     pub bootnodes: Vec<Enr>,
     /// The [`RollupConfig`].
     pub rollup_config: RollupConfig,
-    /// A local signer for payloads.
-    pub signer: Option<BlockSigner>,
+    /// A signer for gossip payloads.
+    pub gossip_signer: Option<BlockSigner>,
 }
 
 impl NetworkConfig {
@@ -76,7 +76,7 @@ impl NetworkConfig {
             scoring: Default::default(),
             topic_scoring: Default::default(),
             monitor_peers: Default::default(),
-            signer: Default::default(),
+            gossip_signer: Default::default(),
         }
     }
 }

--- a/examples/gossip/src/main.rs
+++ b/examples/gossip/src/main.rs
@@ -102,7 +102,7 @@ impl GossipCommand {
                 gater_config: Default::default(),
                 bootnodes: Default::default(),
                 rollup_config: rollup_config.clone(),
-                signer: None,
+                gossip_signer: None,
             }
             .into(),
         );


### PR DESCRIPTION
## Description

This PR integrates the remote signer in our CLI interface. It ensures we are replicating the op-node's interface.