### PR TITLE
feat!(bin/node): Remove `--l2.provider` flag

### DIFF
--- a/bin/node/README.md
+++ b/bin/node/README.md
@@ -39,7 +39,6 @@ kona-node \
   --l1 <L1_PROVIDER_RPC> \
   --l1-beacon <L1_BEACON_API> \
   --l2 <L2_ENGINE_RPC> \
-  --l2-provider-rpc <L2_PROVIDER_RPC> \
   --l2-engine-jwt-secret /path/to/jwt.hex \
   --port 5060 \
   --p2p.listen.tcp 9223 \
@@ -66,7 +65,6 @@ kona-node \
   --l1 $L1_PROVIDER_RPC \
   --l1-beacon $L1_BEACON_API \
   --l2 http://localhost:8551 \
-  --l2-provider-rpc http://localhost:8545 \
   --l2-engine-jwt-secret ./jwt.hex \
   --port 5060 \
   --p2p.listen.tcp 9223 \
@@ -80,9 +78,8 @@ kona-node \
 Many configuration options can be set via environment variables:
 
 - `KONA_NODE_L1_ETH_RPC` - L1 execution client RPC URL
-- `KONA_NODE_L1_BEACON` - L1 beacon API URL  
+- `KONA_NODE_L1_BEACON` - L1 beacon API URL
 - `KONA_NODE_L2_ENGINE_RPC` - L2 engine API URL
-- `KONA_NODE_L2_ETH_RPC` - L2 provider RPC URL
 - `KONA_NODE_L2_ENGINE_AUTH` - Path to L2 engine JWT secret file
 - `KONA_NODE_MODE` - Node operation mode (default: validator)
 - `RUST_LOG` - Logging configuration

--- a/crates/node/engine/README.md
+++ b/crates/node/engine/README.md
@@ -43,12 +43,11 @@ use std::sync::Arc;
 # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 // Create an engine client
 let engine_url = Url::parse("http://localhost:8551")?;
-let l2_url = Url::parse("http://localhost:9545")?;
 let l1_url = Url::parse("http://localhost:8545")?;
 let config = Arc::new(RollupConfig::default());
 let jwt = JwtSecret::from_hex("0xabcd")?;
 
-let client = EngineClient::new_http(engine_url, l2_url, l1_url, config, jwt);
+let client = EngineClient::new_http(engine_url, l1_url, config, jwt);
 
 // Initialize engine state
 let state = EngineState::default();

--- a/crates/node/engine/src/client.rs
+++ b/crates/node/engine/src/client.rs
@@ -2,7 +2,7 @@
 
 use crate::Metrics;
 use alloy_eips::eip1898::BlockNumberOrTag;
-use alloy_network::{AnyNetwork, Network};
+use alloy_network::Network;
 use alloy_primitives::{B256, BlockHash, Bytes};
 use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_client::RpcClient;
@@ -79,9 +79,7 @@ type HyperAuthClient<B = Full<Bytes>> = HyperClient<B, AuthService<Client<HttpCo
 pub struct EngineClient {
     /// The L2 engine provider for Engine API calls.
     #[deref]
-    engine: RootProvider<AnyNetwork>,
-    /// The L2 chain provider for reading chain data.
-    l2_provider: RootProvider<Optimism>,
+    engine: RootProvider<Optimism>,
     /// The L1 chain provider for reading L1 data.
     l1_provider: RootProvider,
     /// The [`RollupConfig`] for determining Engine API versions based on hardfork activations.
@@ -103,33 +101,25 @@ impl EngineClient {
 
     /// Creates a new [`EngineClient`] with authenticated HTTP connections.
     ///
-    /// Sets up JWT-authenticated connections to the Engine API endpoint and L2 chain,
+    /// Sets up JWT-authenticated connections to the Engine API endpoint,
     /// along with an unauthenticated connection to the L1 chain.
     ///
     /// # Arguments
     ///
-    /// * `engine` - Engine API endpoint URL (typically port 8551)
-    /// * `l2_rpc` - L2 chain RPC endpoint URL
+    /// * `engine` - L2 Engine API endpoint URL (typically port 8551)
     /// * `l1_rpc` - L1 chain RPC endpoint URL
     /// * `cfg` - Rollup configuration for version selection
     /// * `jwt` - JWT secret for authentication
-    pub fn new_http(
-        engine: Url,
-        l2_rpc: Url,
-        l1_rpc: Url,
-        cfg: Arc<RollupConfig>,
-        jwt: JwtSecret,
-    ) -> Self {
-        let engine = Self::rpc_client::<AnyNetwork>(engine, jwt);
-        let l2_provider = Self::rpc_client::<Optimism>(l2_rpc, jwt);
+    pub fn new_http(engine: Url, l1_rpc: Url, cfg: Arc<RollupConfig>, jwt: JwtSecret) -> Self {
+        let engine = Self::rpc_client::<Optimism>(engine, jwt);
         let l1_provider = RootProvider::new_http(l1_rpc);
 
-        Self { engine, l2_provider, l1_provider, cfg }
+        Self { engine, l1_provider, cfg }
     }
 
     /// Returns a reference to the inner L2 [`RootProvider`].
-    pub const fn l2_provider(&self) -> &RootProvider<Optimism> {
-        &self.l2_provider
+    pub const fn l2_engine(&self) -> &RootProvider<Optimism> {
+        &self.engine
     }
 
     /// Returns a reference to the inner L1 [`RootProvider`].
@@ -147,7 +137,7 @@ impl EngineClient {
         &self,
         numtag: BlockNumberOrTag,
     ) -> Result<Option<Block<Transaction>>, EngineClientError> {
-        Ok(<RootProvider<Optimism>>::get_block_by_number(&self.l2_provider, numtag).full().await?)
+        Ok(<RootProvider<Optimism>>::get_block_by_number(&self.engine, numtag).full().await?)
     }
 
     /// Fetches the [L2BlockInfo] by [BlockNumberOrTag].
@@ -156,7 +146,7 @@ impl EngineClient {
         numtag: BlockNumberOrTag,
     ) -> Result<Option<L2BlockInfo>, EngineClientError> {
         let block =
-            <RootProvider<Optimism>>::get_block_by_number(&self.l2_provider, numtag).full().await?;
+            <RootProvider<Optimism>>::get_block_by_number(&self.engine, numtag).full().await?;
         let Some(block) = block else {
             return Ok(None);
         };
@@ -165,13 +155,13 @@ impl EngineClient {
 }
 
 #[async_trait::async_trait]
-impl OpEngineApi<AnyNetwork, Http<HyperAuthClient>> for EngineClient {
+impl OpEngineApi<Optimism, Http<HyperAuthClient>> for EngineClient {
     async fn new_payload_v2(
         &self,
         payload: ExecutionPayloadInputV2,
     ) -> TransportResult<PayloadStatus> {
-        let call = <RootProvider<AnyNetwork> as OpEngineApi<
-            AnyNetwork,
+        let call = <RootProvider<Optimism> as OpEngineApi<
+            Optimism,
             Http<HyperAuthClient>,
         >>::new_payload_v2(&self.engine, payload);
 
@@ -183,8 +173,8 @@ impl OpEngineApi<AnyNetwork, Http<HyperAuthClient>> for EngineClient {
         payload: ExecutionPayloadV3,
         parent_beacon_block_root: B256,
     ) -> TransportResult<PayloadStatus> {
-        let call = <RootProvider<AnyNetwork> as OpEngineApi<
-            AnyNetwork,
+        let call = <RootProvider<Optimism> as OpEngineApi<
+            Optimism,
             Http<HyperAuthClient>,
         >>::new_payload_v3(&self.engine, payload, parent_beacon_block_root);
 
@@ -196,8 +186,8 @@ impl OpEngineApi<AnyNetwork, Http<HyperAuthClient>> for EngineClient {
         payload: OpExecutionPayloadV4,
         parent_beacon_block_root: B256,
     ) -> TransportResult<PayloadStatus> {
-        let call = <RootProvider<AnyNetwork> as OpEngineApi<
-            AnyNetwork,
+        let call = <RootProvider<Optimism> as OpEngineApi<
+            Optimism,
             Http<HyperAuthClient>,
         >>::new_payload_v4(&self.engine, payload, parent_beacon_block_root);
 
@@ -209,8 +199,8 @@ impl OpEngineApi<AnyNetwork, Http<HyperAuthClient>> for EngineClient {
         fork_choice_state: ForkchoiceState,
         payload_attributes: Option<OpPayloadAttributes>,
     ) -> TransportResult<ForkchoiceUpdated> {
-        let call = <RootProvider<AnyNetwork> as OpEngineApi<
-            AnyNetwork,
+        let call = <RootProvider<Optimism> as OpEngineApi<
+            Optimism,
             Http<HyperAuthClient>,
         >>::fork_choice_updated_v2(&self.engine, fork_choice_state, payload_attributes);
 
@@ -222,8 +212,8 @@ impl OpEngineApi<AnyNetwork, Http<HyperAuthClient>> for EngineClient {
         fork_choice_state: ForkchoiceState,
         payload_attributes: Option<OpPayloadAttributes>,
     ) -> TransportResult<ForkchoiceUpdated> {
-        let call = <RootProvider<AnyNetwork> as OpEngineApi<
-            AnyNetwork,
+        let call = <RootProvider<Optimism> as OpEngineApi<
+            Optimism,
             Http<HyperAuthClient>,
         >>::fork_choice_updated_v3(&self.engine, fork_choice_state, payload_attributes);
 
@@ -234,8 +224,8 @@ impl OpEngineApi<AnyNetwork, Http<HyperAuthClient>> for EngineClient {
         &self,
         payload_id: PayloadId,
     ) -> TransportResult<ExecutionPayloadEnvelopeV2> {
-        let call = <RootProvider<AnyNetwork> as OpEngineApi<
-            AnyNetwork,
+        let call = <RootProvider<Optimism> as OpEngineApi<
+            Optimism,
             Http<HyperAuthClient>,
         >>::get_payload_v2(&self.engine, payload_id);
 
@@ -246,8 +236,8 @@ impl OpEngineApi<AnyNetwork, Http<HyperAuthClient>> for EngineClient {
         &self,
         payload_id: PayloadId,
     ) -> TransportResult<OpExecutionPayloadEnvelopeV3> {
-        let call = <RootProvider<AnyNetwork> as OpEngineApi<
-            AnyNetwork,
+        let call = <RootProvider<Optimism> as OpEngineApi<
+            Optimism,
             Http<HyperAuthClient>,
         >>::get_payload_v3(&self.engine, payload_id);
 
@@ -258,8 +248,8 @@ impl OpEngineApi<AnyNetwork, Http<HyperAuthClient>> for EngineClient {
         &self,
         payload_id: PayloadId,
     ) -> TransportResult<OpExecutionPayloadEnvelopeV4> {
-        let call = <RootProvider<AnyNetwork> as OpEngineApi<
-            AnyNetwork,
+        let call = <RootProvider<Optimism> as OpEngineApi<
+            Optimism,
             Http<HyperAuthClient>,
         >>::get_payload_v4(&self.engine, payload_id);
 
@@ -270,8 +260,8 @@ impl OpEngineApi<AnyNetwork, Http<HyperAuthClient>> for EngineClient {
         &self,
         block_hashes: Vec<BlockHash>,
     ) -> TransportResult<ExecutionPayloadBodiesV1> {
-        <RootProvider<AnyNetwork> as OpEngineApi<
-            AnyNetwork,
+        <RootProvider<Optimism> as OpEngineApi<
+            Optimism,
             Http<HyperAuthClient>,
         >>::get_payload_bodies_by_hash_v1(&self.engine, block_hashes).await
     }
@@ -281,8 +271,8 @@ impl OpEngineApi<AnyNetwork, Http<HyperAuthClient>> for EngineClient {
         start: u64,
         count: u64,
     ) -> TransportResult<ExecutionPayloadBodiesV1> {
-        <RootProvider<AnyNetwork> as OpEngineApi<
-            AnyNetwork,
+        <RootProvider<Optimism> as OpEngineApi<
+            Optimism,
             Http<HyperAuthClient>,
         >>::get_payload_bodies_by_range_v1(&self.engine, start, count).await
     }
@@ -291,8 +281,8 @@ impl OpEngineApi<AnyNetwork, Http<HyperAuthClient>> for EngineClient {
         &self,
         client_version: ClientVersionV1,
     ) -> TransportResult<Vec<ClientVersionV1>> {
-        <RootProvider<AnyNetwork> as OpEngineApi<
-            AnyNetwork,
+        <RootProvider<Optimism> as OpEngineApi<
+            Optimism,
             Http<HyperAuthClient>,
         >>::get_client_version_v1(&self.engine, client_version).await
     }
@@ -302,8 +292,8 @@ impl OpEngineApi<AnyNetwork, Http<HyperAuthClient>> for EngineClient {
         recommended: ProtocolVersion,
         required: ProtocolVersion,
     ) -> TransportResult<ProtocolVersion> {
-        <RootProvider<AnyNetwork> as OpEngineApi<
-            AnyNetwork,
+        <RootProvider<Optimism> as OpEngineApi<
+            Optimism,
             Http<HyperAuthClient>,
         >>::signal_superchain_v1(&self.engine, recommended, required).await
     }
@@ -312,8 +302,8 @@ impl OpEngineApi<AnyNetwork, Http<HyperAuthClient>> for EngineClient {
         &self,
         capabilities: Vec<String>,
     ) -> TransportResult<Vec<String>> {
-        <RootProvider<AnyNetwork> as OpEngineApi<
-            AnyNetwork,
+        <RootProvider<Optimism> as OpEngineApi<
+            Optimism,
             Http<HyperAuthClient>,
         >>::exchange_capabilities(&self.engine, capabilities).await
     }

--- a/crates/node/engine/src/client.rs
+++ b/crates/node/engine/src/client.rs
@@ -66,12 +66,11 @@ type HyperAuthClient<B = Full<Bytes>> = HyperClient<B, AuthService<Client<HttpCo
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let engine_url = Url::parse("http://localhost:8551")?;
-/// let l2_url = Url::parse("http://localhost:9545")?;
 /// let l1_url = Url::parse("http://localhost:8545")?;
 /// let config = Arc::new(RollupConfig::default());
 /// let jwt = JwtSecret::from_hex("0xabcd")?;
 ///
-/// let client = EngineClient::new_http(engine_url, l2_url, l1_url, config, jwt);
+/// let client = EngineClient::new_http(engine_url, l1_url, config, jwt);
 /// # Ok(())
 /// # }
 /// ```

--- a/crates/node/engine/src/task_queue/core.rs
+++ b/crates/node/engine/src/task_queue/core.rs
@@ -85,7 +85,7 @@ impl Engine {
         self.clear();
 
         let start =
-            find_starting_forkchoice(&config, client.l1_provider(), client.l2_provider()).await?;
+            find_starting_forkchoice(&config, client.l1_provider(), client.l2_engine()).await?;
 
         // Retry to synchronize the engine until we succeeds or a critical error occurs.
         while let Err(err) = SynchronizeTask::new(
@@ -129,7 +129,7 @@ impl Engine {
             .into_consensus()
             .into();
         let l2_safe_block = client
-            .l2_provider()
+            .l2_engine()
             .get_block(start.safe.block_info.hash.into())
             .full()
             .await

--- a/crates/node/engine/src/task_queue/tasks/finalize/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/finalize/task.rs
@@ -44,7 +44,7 @@ impl EngineTaskExt for FinalizeTask {
         let block_fetch_start = Instant::now();
         let block = self
             .client
-            .l2_provider()
+            .l2_engine()
             .get_block(self.block_number.into())
             .full()
             .await

--- a/crates/node/service/src/actors/engine/actor.rs
+++ b/crates/node/service/src/actors/engine/actor.rs
@@ -116,7 +116,6 @@ impl EngineBuilder {
     pub fn client(&self) -> Arc<EngineClient> {
         EngineClient::new_http(
             self.engine_url.clone(),
-            self.l2_rpc_url.clone(),
             self.l1_rpc_url.clone(),
             self.config.clone(),
             self.jwt_secret,

--- a/crates/node/service/src/actors/engine/actor.rs
+++ b/crates/node/service/src/actors/engine/actor.rs
@@ -84,8 +84,6 @@ pub struct EngineBuilder {
     pub config: Arc<RollupConfig>,
     /// The engine rpc url.
     pub engine_url: Url,
-    /// The L2 rpc url.
-    pub l2_rpc_url: Url,
     /// The L1 rpc url.
     pub l1_rpc_url: Url,
     /// The engine jwt secret.

--- a/crates/node/service/src/service/standard/builder.rs
+++ b/crates/node/service/src/service/standard/builder.rs
@@ -30,8 +30,6 @@ pub struct RollupNodeBuilder {
     l1_beacon_api_url: Option<Url>,
     /// The L2 engine RPC URL.
     l2_engine_rpc_url: Option<Url>,
-    /// The L2 EL provider RPC URL.
-    l2_provider_rpc_url: Option<Url>,
     /// The JWT secret.
     jwt_secret: Option<JwtSecret>,
     /// The [`NetworkConfig`].
@@ -72,11 +70,6 @@ impl RollupNodeBuilder {
         Self { l2_engine_rpc_url: Some(l2_engine_rpc_url), ..self }
     }
 
-    /// Appends an L2 EL provider RPC URL to the builder.
-    pub fn with_l2_provider_rpc_url(self, l2_provider_rpc_url: Url) -> Self {
-        Self { l2_provider_rpc_url: Some(l2_provider_rpc_url), ..self }
-    }
-
     /// Appends a JWT secret to the builder.
     pub fn with_jwt_secret(self, jwt_secret: JwtSecret) -> Self {
         Self { jwt_secret: Some(jwt_secret), ..self }
@@ -115,7 +108,7 @@ impl RollupNodeBuilder {
             self.l1_beacon_api_url.expect("l1 beacon api url not set").to_string(),
         );
 
-        let l2_rpc_url = self.l2_provider_rpc_url.expect("l2 provider rpc url not set");
+        let l2_rpc_url = self.l2_engine_rpc_url.clone().expect("l2 engine rpc url not set");
         let jwt_secret = self.jwt_secret.expect("jwt secret not set");
         let hyper_client = Client::builder(TokioExecutor::new()).build_http::<Full<Bytes>>();
 

--- a/crates/node/service/src/service/standard/builder.rs
+++ b/crates/node/service/src/service/standard/builder.rs
@@ -108,7 +108,7 @@ impl RollupNodeBuilder {
             self.l1_beacon_api_url.expect("l1 beacon api url not set").to_string(),
         );
 
-        let l2_rpc_url = self.l2_engine_rpc_url.clone().expect("l2 engine rpc url not set");
+        let engine_url = self.l2_engine_rpc_url.expect("l2 engine rpc url not set");
         let jwt_secret = self.jwt_secret.expect("jwt secret not set");
         let hyper_client = Client::builder(TokioExecutor::new()).build_http::<Full<Bytes>>();
 
@@ -116,16 +116,15 @@ impl RollupNodeBuilder {
         let service = ServiceBuilder::new().layer(auth_layer).service(hyper_client);
 
         let layer_transport = HyperClient::with_service(service);
-        let http_hyper = Http::with_client(layer_transport, l2_rpc_url.clone());
+        let http_hyper = Http::with_client(layer_transport, engine_url.clone());
         let rpc_client = RpcClient::new(http_hyper, false);
         let l2_provider = RootProvider::<Optimism>::new(rpc_client);
 
         let rollup_config = Arc::new(self.config);
         let engine_builder = EngineBuilder {
             config: Arc::clone(&rollup_config),
-            l2_rpc_url,
             l1_rpc_url,
-            engine_url: self.l2_engine_rpc_url.expect("missing l2 engine rpc url"),
+            engine_url,
             jwt_secret,
             mode: self.mode,
         };

--- a/docker/recipes/kona-node/docker-compose.yaml
+++ b/docker/recipes/kona-node/docker-compose.yaml
@@ -82,7 +82,6 @@ services:
       --l1 $L1_PROVIDER_RPC
       --l1-beacon $L1_BEACON_API
       --l2 http://op-reth:8551
-      --l2-provider-rpc http://op-reth:8545
       --l2-engine-jwt-secret /root/jwt/jwt.hex
       --rpc.port 5060
       --p2p.listen.tcp 9223

--- a/docs/docs/pages/node/configuration.mdx
+++ b/docs/docs/pages/node/configuration.mdx
@@ -25,7 +25,6 @@ For more details on each flag, see the inline help (`kona-node node --help`) or 
 | `--l1-eth-rpc <URL>` | `KONA_NODE_L1_ETH_RPC` | URL of the L1 execution client RPC API | Yes | - |
 | `--l1-beacon <URL>` | `KONA_NODE_L1_BEACON` | URL of the L1 beacon API | Yes | - |
 | `--l2-engine-rpc <URL>` | `KONA_NODE_L2_ENGINE_RPC` | URL of the engine API endpoint of an L2 execution client | Yes | - |
-| `--l2-provider-rpc <URL>` | `KONA_NODE_L2_ETH_RPC` | An L2 RPC URL | Yes | - |
 | `--l2-engine-jwt-secret <PATH>` | `KONA_NODE_L2_ENGINE_AUTH` | Path to file containing the hex-encoded JWT secret for the execution client | No | - |
 | `--l2-config-file <PATH>` | `KONA_NODE_ROLLUP_CONFIG` | Path to a custom L2 rollup configuration file | No | - |
 | `--l1-runtime-config-reload-interval <SECONDS>` | `KONA_NODE_L1_RUNTIME_CONFIG_RELOAD_INTERVAL` | Poll interval for reloading runtime config | No | `600` |

--- a/docs/docs/pages/node/design/sequencer.mdx
+++ b/docs/docs/pages/node/design/sequencer.mdx
@@ -111,7 +111,6 @@ kona-node node \
   --l1-eth-rpc=http://l1-node:8545 \
   --l1-beacon=http://l1-beacon:5052 \
   --l2-engine-rpc=http://l2-execution:8551 \
-  --l2-provider-rpc=http://l2-execution:8545 \
   --l2.jwt-secret=./jwt.hex \
   --chain=123456
 ```
@@ -130,7 +129,6 @@ Sequencer mode requires all standard node arguments plus the `--mode=Sequencer` 
 | **L1 RPC** | `--l1-eth-rpc` | `KONA_NODE_L1_ETH_RPC` | L1 execution client RPC URL |
 | **L1 Beacon** | `--l1-beacon` | `KONA_NODE_L1_BEACON` | L1 beacon API URL |
 | **L2 Engine** | `--l2-engine-rpc` | `KONA_NODE_L2_ENGINE_RPC` | L2 engine API endpoint |
-| **L2 Provider** | `--l2-provider-rpc` | `KONA_NODE_L2_ETH_RPC` | L2 execution client RPC URL |
 | **JWT Secret** | `--l2.jwt-secret` | `KONA_NODE_L2_ENGINE_AUTH` | Path to JWT secret file |
 | **Chain ID** | `--chain` | `KONA_NODE_L2_CHAIN_ID` | L2 chain identifier |
 
@@ -154,7 +152,6 @@ kona-node node \
   --l1-eth-rpc=http://localhost:8545 \
   --l1-beacon=http://localhost:5052 \
   --l2-engine-rpc=http://localhost:8551 \
-  --l2-provider-rpc=http://localhost:8545 \
   --chain=42161
 ```
 
@@ -168,7 +165,6 @@ kona-node node \
   --l1-eth-rpc=http://l1-node:8545 \
   --l1-beacon=http://l1-beacon:5052 \
   --l2-engine-rpc=http://l2-execution:8551 \
-  --l2-provider-rpc=http://l2-execution:8545 \
   --chain=123456
 ```
 
@@ -181,7 +177,6 @@ kona-node node \
   --l1-eth-rpc=http://localhost:8545 \
   --l1-beacon=http://localhost:5052 \
   --l2-engine-rpc=http://localhost:8551 \
-  --l2-provider-rpc=http://localhost:8545 \
   --chain=42161
 ```
 

--- a/docs/docs/pages/node/run/binary.mdx
+++ b/docs/docs/pages/node/run/binary.mdx
@@ -45,11 +45,9 @@ The `kona-node` requires a few CLI flags.
   URL of the L1 beacon API.
 - `--l2-engine-rpc <L2_ENGINE_RPC>`
   URL of the engine API endpoint of an L2 execution client.
-- `--l2-provider-rpc <L2_PROVIDER_RPC>`
-  An L2 RPC URL.
 
-The L2 engine RPC and L2 provider RPC are both endpoints that
-point to the execution layer client, [`op-reth`][op-reth].
+The L2 engine RPC points to the execution layer client's engine API,
+[`op-reth`][op-reth].
 
 An L1 beacon endpoint and rpc endpoint are also required to
 fetch the L1 chain data that the L2 chain is derived from.
@@ -97,7 +95,6 @@ kona-node node \
     --l1-eth-rpc <L1_RPC_URL> \
     --l1-beacon <L1_BEACON_URL> \
     --l2-engine-rpc http://127.0.0.1:9551 \
-    --l2-provider-rpc http://127.0.0.1:8545
 ```
 
 That's it! Your node should connect to P2P and start syncing


### PR DESCRIPTION
## Overview

Removes the `--l2.provider` flag from the `kona-node` in favor of proxying L2 RPC requests through the engine API.

### TODO

This change is breaking to the CLI interface, and will require an update to:
- [x] The `optimism-package`
- [ ] The helm charts in OP Labs' infrastructure (not blocking)