### PR TITLE
Fix typos

### DIFF
--- a/crates/protocol/protocol/src/batch/tx_data/wrapper.rs
+++ b/crates/protocol/protocol/src/batch/tx_data/wrapper.rs
@@ -135,7 +135,7 @@ impl SpanBatchTransactionData {
         }
     }
 
-    /// Converts the [`SpanBatchTransactionData`] into a singed transaction as [`TxEnvelope`].
+    /// Converts the [`SpanBatchTransactionData`] into a signed transaction as [`TxEnvelope`].
     pub fn to_signed_tx(
         &self,
         nonce: u64,

--- a/crates/supervisor/core/src/error.rs
+++ b/crates/supervisor/core/src/error.rs
@@ -58,7 +58,7 @@ pub enum SupervisorError {
     #[error(transparent)]
     CrossSafetyCheckerError(#[from] CrossSafetyError),
 
-    /// Indicates the L1 block does not match the epxected L1 block.
+    /// Indicates the L1 block does not match the expected L1 block.
     #[error("L1 block number mismatch. expected: {expected}, but got {got}")]
     L1BlockMismatch {
         /// Expected L1 block.


### PR DESCRIPTION

- **Fix typo**: "singed" → "signed" in `wrapper.rs` comment
- **Fix typo**: "epxected" → "expected" in `error.rs` comment

