### PR TITLE
release(kona-node): 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,33 +2,84 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.1.1] - 2025-07-24
+## [0.1.2] - 2025-07-31
 
 ### ⚙️ Miscellaneous Tasks
 
-- Release 0.3.1
-- Release 0.1.1
-- Release 0.1.1
-- Release 0.1.1
-- Release 0.1.1
-- Release 0.1.1
-- Release 0.3.1
-- Release 0.1.1
+- Release 0.4.5
+- Release 0.4.5
+- Release 0.4.5
+- Release 0.4.5
+- Release 0.4.5
+- Release 0.1.2
+- Release 0.2.2
+- Release 0.3.2
+- Release 0.4.5
+- Release 0.3.2
+- Release 0.1.2
+- Release 0.1.2
+- Release 0.1.2
+- Release 0.1.2
+- Release 0.3.2
+- Release 0.1.2
 
-## [0.2.1] - 2025-07-24
+## [0.4.5] - 2025-07-31
+
+### 🚀 Features
+
+- *(node/service)* Expose standalone `healthz` endpoint (#2603)
 
 ### ⚙️ Miscellaneous Tasks
 
-- Release 0.2.1
+- Fix a large number of spelling issues in comments (#2592)
+- Release 0.4.5
 
-## [0.3.1] - 2025-07-24
+### Patch
+
+- *(node/conductor)* Patch conductor bootstrap (#2589)
+
+## [kona-node/v0.1.1-beta.1] - 2025-07-30
+
+### 🚀 Features
+
+- *(node/service)* Support sequencer recovery mode (#2460)
+- *(supervisor/core)* [Safety Checker] validate interop timestamps (#2537)
+- *(supervisor/core)* Integrate unsafe block reorg (#2539)
+- *(node/service)* Delay sequencer's view of L1 chain (#2568)
+- *(supervisor/core)* Handle invalidate blocks (#2564)
+- *(supervisor/core)* [Safety Checker] executing message validation (#2570)
+- *(protocol)* Add `Jovian` fork definition (#2584)
+- *(node/sequencer)* Implement remote signer skeleton (#2572)
+- *(node/sequencer)* Integrate remote signer in CLI (#2587)
+- Introduce CLAUDE.md file (#2596)
+
+### 🐛 Bug Fixes
+
+- *(node/engine)* Audit engine for bugs. rename forkchoice task -> synchronize task. move block building logic to build task (#2524)
+- *(supervisor/core)* Message checksum validation (#2586)
+
+### 🧪 Testing
+
+- *(node/engine)* Add positive engine test (#2552)
 
 ### ⚙️ Miscellaneous Tasks
 
-- Release 0.1.1
-- Release 0.3.1
+- Fix broken url (#2557)
+- *(bin/node)* Improve error pattern matching when pre-validating jwt (#2367)
+- *(supervisor/storage)* Define `EntryNotFoundError` (#2542)
+- *(docs)* Remove `RuntimeActor` mention (#2567)
+- *(protocol)* Optional `OpAttributesWithParent::derived_from` field (#2569)
+- *(docs)* Replaced the non-working link driver (#2576)
+- *(supervisor)* Add supervisor path to log targets (#2565)
+- *(supervisor)* Refactor interop validation (#2578)
+- *(supervisor)* Refactor chain processor (#2590)
+- *(workspace)* Add `theochap` as author (#2599)
 
-## [0.1.1] - 2025-07-24
+### Patch
+
+- *(node)* Fix macos builds (#2600)
+
+## [kona-node/v0.1.1] - 2025-07-24
 
 ### 🚀 Features
 
@@ -133,8 +184,10 @@ All notable changes to this project will be documented in this file.
 - *(supervisor/storage)* Log improvements (#2525)
 - *(supervisor)* Remove deprecated supervisor api from `kona-node` (#2024)
 - *(supervisor/core)* Log improvements in managed node (#2526)
-- Release 0.4.4
-- Release 0.1.1
+
+### Release
+
+- Kona-node v0.1.1 (#2550)
 
 ## [kona-node/v0.1.0-beta.5] - 2025-07-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4315,7 +4315,7 @@ dependencies = [
 
 [[package]]
 name = "kona-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4372,7 +4372,7 @@ dependencies = [
 
 [[package]]
 name = "kona-comp"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "alloc-no-stdlib",
  "alloy-consensus",
@@ -4402,7 +4402,7 @@ dependencies = [
 
 [[package]]
 name = "kona-derive"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "kona-engine"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4529,7 +4529,7 @@ dependencies = [
 
 [[package]]
 name = "kona-genesis"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -4551,7 +4551,7 @@ dependencies = [
 
 [[package]]
 name = "kona-hardforks"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -4611,7 +4611,7 @@ dependencies = [
 
 [[package]]
 name = "kona-interop"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4636,7 +4636,7 @@ dependencies = [
 
 [[package]]
 name = "kona-macros"
-version = "0.1.1"
+version = "0.1.2"
 
 [[package]]
 name = "kona-mpt"
@@ -4662,7 +4662,7 @@ dependencies = [
 
 [[package]]
 name = "kona-node"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -4711,7 +4711,7 @@ dependencies = [
 
 [[package]]
 name = "kona-node-service"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "alloy-chains",
  "alloy-eips",
@@ -4765,7 +4765,7 @@ dependencies = [
 
 [[package]]
 name = "kona-p2p"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -4805,7 +4805,7 @@ dependencies = [
 
 [[package]]
 name = "kona-peers"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "kona-protocol"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "alloc-no-stdlib",
  "alloy-consensus",
@@ -4953,7 +4953,7 @@ dependencies = [
 
 [[package]]
 name = "kona-providers-alloy"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4982,7 +4982,7 @@ dependencies = [
 
 [[package]]
 name = "kona-registry"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "alloy-chains",
  "alloy-eips",
@@ -4998,7 +4998,7 @@ dependencies = [
 
 [[package]]
 name = "kona-rpc"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -5030,7 +5030,7 @@ dependencies = [
 
 [[package]]
 name = "kona-serde"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -5040,7 +5040,7 @@ dependencies = [
 
 [[package]]
 name = "kona-sources"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,21 +77,21 @@ kona-host = { path = "bin/host", version = "1.0.2", default-features = false }
 kona-client = { path = "bin/client", version = "1.0.2", default-features = false }
 
 # Protocol
-kona-comp = { path = "crates/protocol/comp", version = "0.4.4", default-features = false }
-kona-derive = { path = "crates/protocol/derive", version = "0.4.4", default-features = false }
-kona-interop = { path = "crates/protocol/interop", version = "0.4.4", default-features = false }
-kona-genesis = { path = "crates/protocol/genesis", version = "0.4.4", default-features = false }
-kona-protocol = { path = "crates/protocol/protocol", version = "0.4.4", default-features = false }
-kona-registry = { path = "crates/protocol/registry", version = "0.4.4", default-features = false }
-kona-hardforks = { path = "crates/protocol/hardforks", version = "0.4.4", default-features = false }
+kona-comp = { path = "crates/protocol/comp", version = "0.4.5", default-features = false }
+kona-derive = { path = "crates/protocol/derive", version = "0.4.5", default-features = false }
+kona-interop = { path = "crates/protocol/interop", version = "0.4.5", default-features = false }
+kona-genesis = { path = "crates/protocol/genesis", version = "0.4.5", default-features = false }
+kona-protocol = { path = "crates/protocol/protocol", version = "0.4.5", default-features = false }
+kona-registry = { path = "crates/protocol/registry", version = "0.4.5", default-features = false }
+kona-hardforks = { path = "crates/protocol/hardforks", version = "0.4.5", default-features = false }
 
 # Node
-kona-p2p = { path = "crates/node/p2p", version = "0.1.1", default-features = false }
-kona-rpc = { path = "crates/node/rpc", version = "0.3.1", default-features = false }
-kona-peers = { path = "crates/node/peers", version = "0.1.1", default-features = false }
-kona-engine = { path = "crates/node/engine", version = "0.1.1", default-features = false }
-kona-sources = { path = "crates/node/sources", version = "0.1.1", default-features = false }
-kona-node-service = { path = "crates/node/service", version = "0.1.1", default-features = false }
+kona-p2p = { path = "crates/node/p2p", version = "0.1.2", default-features = false }
+kona-rpc = { path = "crates/node/rpc", version = "0.3.2", default-features = false }
+kona-peers = { path = "crates/node/peers", version = "0.1.2", default-features = false }
+kona-engine = { path = "crates/node/engine", version = "0.1.2", default-features = false }
+kona-sources = { path = "crates/node/sources", version = "0.1.2", default-features = false }
+kona-node-service = { path = "crates/node/service", version = "0.1.2", default-features = false }
 
 # Supervisor
 kona-supervisor-rpc = { path = "crates/supervisor/rpc", version = "0.1.1", default-features = false }
@@ -102,7 +102,7 @@ kona-supervisor-storage = { path = "crates/supervisor/storage", version = "0.1.0
 kona-supervisor-metrics = { path = "crates/supervisor/metrics", version = "0.1.0", default-features = false }
 
 # Providers
-kona-providers-alloy = { path = "crates/providers/providers-alloy", version = "0.3.1", default-features = false }
+kona-providers-alloy = { path = "crates/providers/providers-alloy", version = "0.3.2", default-features = false }
 
 # Proof
 kona-driver = { path = "crates/proof/driver", version = "0.4.0", default-features = false }
@@ -115,9 +115,9 @@ kona-std-fpvm-proc = { path = "crates/proof/std-fpvm-proc", version = "0.2.0", d
 kona-proof-interop = { path = "crates/proof/proof-interop", version = "0.2.0", default-features = false }
 
 # Utilities
-kona-cli = { path = "crates/utilities/cli", version = "0.3.1", default-features = false }
-kona-serde = { path = "crates/utilities/serde", version = "0.2.1", default-features = false }
-kona-macros = { path = "crates/utilities/macros", version = "0.1.1", default-features = false }
+kona-cli = { path = "crates/utilities/cli", version = "0.3.2", default-features = false }
+kona-serde = { path = "crates/utilities/serde", version = "0.2.2", default-features = false }
+kona-macros = { path = "crates/utilities/macros", version = "0.1.2", default-features = false }
 
 # Alloy
 alloy-rlp = { version = "0.3.12", default-features = false }

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kona-node"
-version = "0.1.1"
+version = "0.1.2"
 description = "Kona Consensus Node"
 
 edition.workspace = true

--- a/crates/node/engine/Cargo.toml
+++ b/crates/node/engine/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kona-engine"
 description = "An implementation of the OP Stack engine client"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/node/p2p/Cargo.toml
+++ b/crates/node/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kona-p2p"
-version = "0.1.1"
+version = "0.1.2"
 description = "P2P library for the OP Stack"
 
 edition.workspace = true

--- a/crates/node/peers/Cargo.toml
+++ b/crates/node/peers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kona-peers"
-version = "0.1.1"
+version = "0.1.2"
 description = "Network peers library for the OP Stack"
 
 edition.workspace = true

--- a/crates/node/rpc/Cargo.toml
+++ b/crates/node/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kona-rpc"
-version = "0.3.1"
+version = "0.3.2"
 description = "Optimism RPC Types and API"
 
 edition.workspace = true

--- a/crates/node/service/Cargo.toml
+++ b/crates/node/service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kona-node-service"
 description = "An implementation of the OP Stack consensus node service"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/node/sources/Cargo.toml
+++ b/crates/node/sources/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kona-sources"
-version = "0.1.1"
+version = "0.1.2"
 description = "Data source types and utilities for the kona-node"
 
 edition.workspace = true

--- a/crates/protocol/comp/Cargo.toml
+++ b/crates/protocol/comp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kona-comp"
-version = "0.4.4"
+version = "0.4.5"
 description = "Compression types for the OP Stack"
 
 edition.workspace = true

--- a/crates/protocol/derive/Cargo.toml
+++ b/crates/protocol/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kona-derive"
 description = "A no_std derivation pipeline implementation for the OP Stack"
-version = "0.4.4"
+version = "0.4.5"
 resolver = "2"
 edition.workspace = true
 authors.workspace = true

--- a/crates/protocol/genesis/Cargo.toml
+++ b/crates/protocol/genesis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kona-genesis"
-version = "0.4.4"
+version = "0.4.5"
 description = "Optimism genesis types"
 
 edition.workspace = true

--- a/crates/protocol/hardforks/Cargo.toml
+++ b/crates/protocol/hardforks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kona-hardforks"
-version = "0.4.4"
+version = "0.4.5"
 description = "Consensus hardfork types for the OP Stack"
 
 edition.workspace = true

--- a/crates/protocol/interop/Cargo.toml
+++ b/crates/protocol/interop/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kona-interop"
 description = "Core functionality and primitives for the Interop feature of the OP Stack."
-version = "0.4.4"
+version = "0.4.5"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/protocol/protocol/Cargo.toml
+++ b/crates/protocol/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kona-protocol"
-version = "0.4.4"
+version = "0.4.5"
 description = "Optimism protocol-specific types"
 
 edition.workspace = true

--- a/crates/protocol/registry/Cargo.toml
+++ b/crates/protocol/registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kona-registry"
-version = "0.4.4"
+version = "0.4.5"
 description = "A registry of superchain configs"
 
 edition.workspace = true

--- a/crates/providers/providers-alloy/Cargo.toml
+++ b/crates/providers/providers-alloy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kona-providers-alloy"
-version = "0.3.1"
+version = "0.3.2"
 description = "Alloy Backed Providers"
 
 edition.workspace = true

--- a/crates/utilities/cli/Cargo.toml
+++ b/crates/utilities/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kona-cli"
-version = "0.3.1"
+version = "0.3.2"
 description = "Shared CLI utilities for Kona crates"
 edition.workspace = true
 license.workspace = true

--- a/crates/utilities/macros/Cargo.toml
+++ b/crates/utilities/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kona-macros"
-version = "0.1.1"
+version = "0.1.2"
 description = "Utility macros for kona crates"
 
 edition.workspace = true

--- a/crates/utilities/serde/Cargo.toml
+++ b/crates/utilities/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kona-serde"
-version = "0.2.1"
+version = "0.2.2"
 description = "Serde related helpers for kona"
 
 edition.workspace = true


### PR DESCRIPTION
### Description

Release diff for `kona-node` v0.1.2. Already published to crates.io.