### PR TITLE
fix(docs): Kailua description

### DIFF
--- a/docs/docs/components/SdkShowcase.tsx
+++ b/docs/docs/components/SdkShowcase.tsx
@@ -22,13 +22,13 @@ const projects: SdkProject[] = [
   },
   {
     name: 'OP Succinct',
-    description: 'zkVM-based fault proof system using Kona',
+    description: 'zkVM-based proof system using Kona',
     linesOfCode: '~2K LoC',
     githubUrl: 'https://github.com/succinctlabs/op-succinct'
   },
   {
     name: 'Kailua',
-    description: 'Alternative OP Stack node built with Kona',
+    description: 'zkVM-based proof system using Kona',
     linesOfCode: '~5K LoC',
     githubUrl: 'https://github.com/op-rs/kailua'
   }


### PR DESCRIPTION
## Overview

Fixes the description of `kailua` on the docs' front-page.