### PR TITLE
Fix typos in code comments

### DIFF
--- a/crates/node/p2p/src/gossip/handler.rs
+++ b/crates/node/p2p/src/gossip/handler.rs
@@ -11,7 +11,7 @@ use tokio::sync::watch::Receiver;
 /// This trait defines the functionality required to process incoming messages
 /// and determine their acceptance within the network.
 ///
-/// Implementors of this trait can specify how messages are handled and which
+/// Implementers of this trait can specify how messages are handled and which
 /// topics they are interested in.
 pub trait Handler: Send {
     /// Manages validation and further processing of messages

--- a/crates/proof/proof/src/l1/chain_provider.rs
+++ b/crates/proof/proof/src/l1/chain_provider.rs
@@ -109,7 +109,7 @@ impl<T: CommsClient + Sync + Send> ChainProvider for OracleL1ChainProvider<T> {
         let transactions = trie_walker
             .into_iter()
             .map(|(_, rlp)| {
-                // note: not short-handed for error type coersion w/ `?`.
+                // note: not short-handed for error type coercion w/ `?`.
                 let rlp = TxEnvelope::decode_2718(&mut rlp.as_ref())?;
                 Ok(rlp)
             })


### PR DESCRIPTION
## Summary
Fixed two spelling errors in code comments across two files.

## Changes
- **`crates/proof/proof/src/l1/chain_provider.rs`**: Fixed "coersion" → "coercion" in line 112
- **`crates/node/p2p/src/gossip/handler.rs`**: Fixed "Implementors" → "Implementers" in line 14

