### PR TITLE
fix(docs and tests): fix typos in gossip config and bootnode test function name

### DIFF
--- a/crates/node/p2p/src/gossip/config.rs
+++ b/crates/node/p2p/src/gossip/config.rs
@@ -51,7 +51,7 @@ lazy_static! {
     /// Limits the duration that message IDs are remembered for gossip deduplication purposes.
     pub static ref SEEN_MESSAGES_TTL: Duration = 130 * *GOSSIP_HEARTBEAT;
 
-    /// The pper score inspect frequency.
+    /// The peer score inspect frequency.
     /// The frequency at which peer scores are inspected.
     pub static ref PEER_SCORE_INSPECT_FREQUENCY: Duration = 15 * Duration::from_secs(1);
 }

--- a/crates/node/peers/src/boot.rs
+++ b/crates/node/peers/src/boot.rs
@@ -85,7 +85,7 @@ mod tests {
     }
 
     #[test]
-    fn test_derive_bootnode_enode_mutliaddr_back_and_forth() {
+    fn test_derive_bootnode_enode_multiaddr_back_and_forth() {
         let hardcoded_enode = "enode://2bd2e657bb3c8efffb8ff6db9071d9eb7be70d7c6d7d980ff80fc93b2629675c5f750bc0a5ef27cd788c2e491b8795a7e9a4a6e72178c14acc6753c0e5d77ae4@34.65.205.244:30305";
         let node_record = NodeRecord::from_str(hardcoded_enode).unwrap();
         let boot_node = BootNode::from_unsigned(node_record).unwrap();


### PR DESCRIPTION
Corrected typo in comment from "pper score inspect frequency" to "peer score inspect frequency" in crates/node/p2p/src/gossip/config.rs.

Fixed typo in test function name from test_derive_bootnode_enode_mutliaddr_back_and_forth to test_derive_bootnode_enode_multiaddr_back_and_forth in crates/node/peers/src/boot.rs.