### PR TITLE
feat(node/p2p): allow disabling the bootstore

### DIFF
--- a/bin/node/src/commands/bootstore.rs
+++ b/bin/node/src/commands/bootstore.rs
@@ -3,7 +3,7 @@
 use crate::flags::GlobalArgs;
 use clap::Parser;
 use kona_cli::LogConfig;
-use kona_peers::BootStore;
+use kona_peers::{BootStore, BootStoreFile};
 use std::path::PathBuf;
 
 /// The `bootstore` Subcommand
@@ -59,8 +59,12 @@ impl BootstoreCommand {
             .get(&chain_id)
             .ok_or(anyhow::anyhow!("Chain ID {} not found in the registry", chain_id))?;
         println!("{} Bootstore (Chain ID: {})", chain.name, chain_id);
-        let bootstore = BootStore::from_chain_id(chain_id, self.bootstore.clone(), vec![]);
-        println!("Path: {}", bootstore.path.display());
+        let bootstore: BootStoreFile = self
+            .bootstore
+            .clone()
+            .map_or(BootStoreFile::Default { chain_id }, BootStoreFile::Custom);
+        let bootstore: BootStore = bootstore.try_into()?;
+        println!("Path: {}", self.bootstore.clone().unwrap_or_default().display());
         println!("Peer Count: {}", bootstore.peers.len());
         println!("Valid peers: {}", bootstore.valid_peers_with_chain_id(chain_id).len());
         println!("--------------------------");

--- a/crates/node/peers/src/lib.rs
+++ b/crates/node/peers/src/lib.rs
@@ -19,7 +19,7 @@ mod nodes;
 pub use nodes::{BootNodes, OP_RAW_BOOTNODES, OP_RAW_TESTNET_BOOTNODES};
 
 mod store;
-pub use store::BootStore;
+pub use store::{BootStore, BootStoreFile};
 
 mod score;
 pub use score::PeerScoreLevel;

--- a/crates/node/service/src/actors/network/actor.rs
+++ b/crates/node/service/src/actors/network/actor.rs
@@ -249,11 +249,7 @@ impl NodeActor for NetworkActor {
                         warn!(target: "node::p2p", "Failed to send unsafe block to network handler");
                     }
                 },
-                req = self.p2p_rpc.recv(), if !self.p2p_rpc.is_closed() => {
-                    let Some(req) = req else {
-                        error!(target: "node::p2p", "The p2p rpc receiver channel has closed");
-                        return Err(NetworkActorError::ChannelClosed);
-                    };
+                Some(req) = self.p2p_rpc.recv(), if !self.p2p_rpc.is_closed() => {
                     req.handle(&mut handler.gossip, &handler.discovery);
                 },
             }

--- a/crates/node/service/src/actors/network/builder.rs
+++ b/crates/node/service/src/actors/network/builder.rs
@@ -5,10 +5,10 @@ use discv5::{Config as Discv5Config, Enr};
 use kona_disc::{Discv5Builder, LocalNode};
 use kona_genesis::RollupConfig;
 use kona_gossip::{GaterConfig, GossipDriverBuilder};
-use kona_peers::{PeerMonitoring, PeerScoreLevel};
+use kona_peers::{BootStoreFile, PeerMonitoring, PeerScoreLevel};
 use kona_sources::BlockSigner;
 use libp2p::{Multiaddr, identity::Keypair};
-use std::{path::PathBuf, time::Duration};
+use std::time::Duration;
 
 use crate::{
     NetworkBuilderError,
@@ -86,11 +86,8 @@ impl NetworkBuilder {
     }
 
     /// Sets the bootstore path for the [`Discv5Builder`].
-    pub fn with_bootstore(self, bootstore: Option<PathBuf>) -> Self {
-        if let Some(bootstore) = bootstore {
-            return Self { discovery: self.discovery.with_bootstore(bootstore), ..self };
-        }
-        self
+    pub fn with_bootstore(self, bootstore: Option<BootStoreFile>) -> Self {
+        Self { discovery: self.discovery.with_bootstore_file(bootstore), ..self }
     }
 
     /// Sets the interval at which to randomize discovery peers.

--- a/crates/node/service/src/actors/network/config.rs
+++ b/crates/node/service/src/actors/network/config.rs
@@ -5,10 +5,9 @@ use discv5::Enr;
 use kona_disc::LocalNode;
 use kona_genesis::RollupConfig;
 use kona_gossip::GaterConfig;
-use kona_peers::{PeerMonitoring, PeerScoreLevel};
+use kona_peers::{BootStoreFile, PeerMonitoring, PeerScoreLevel};
 use kona_sources::BlockSigner;
 use libp2p::{Multiaddr, identity::Keypair};
-use std::path::PathBuf;
 use tokio::time::Duration;
 
 /// Configuration for kona's P2P stack.
@@ -38,7 +37,7 @@ pub struct NetworkConfig {
     /// Peer score monitoring config.
     pub monitor_peers: Option<PeerMonitoring>,
     /// An optional path to the bootstore.
-    pub bootstore: Option<PathBuf>,
+    pub bootstore: Option<BootStoreFile>,
     /// The configuration for the connection gater.
     pub gater_config: GaterConfig,
     /// An optional list of bootnode ENRs to start the node with.


### PR DESCRIPTION
## Description

This PR adds a CLI argument to disable writing/recovering the bootstore to/from a file. This is useful for our integration tests because we want to ensure we always have the same behavior between runs.

Revamps the bootstore