### PR TITLE
fix: correct dead link to ChannelProvider struct in documentation

### DIFF
--- a/docs/docs/pages/sdk/protocol/derive/intro.mdx
+++ b/docs/docs/pages/sdk/protocol/derive/intro.mdx
@@ -306,7 +306,7 @@ So, [@clabby][clabby] and [@refcell][refcell] stood up [kona][kona] in a few mon
 [batch-provider]: https://docs.rs/kona-derive/latest/kona_derive/stages/struct.BatchProvider.html
 [batch-stream]: https://docs.rs/kona-derive/latest/kona_derive/stages/struct.BatchStream.html
 [channel-reader]: https://docs.rs/kona-derive/latest/kona_derive/stages/struct.ChannelReader.html
-[channel-provider]: https://docs.rs/kona-derive/latest/kona_derive/stages/struct.ChannelProvider.html
+[channel-provider]: https://docs.rs/kona-derive/latest/kona_derive/struct.ChannelProvider.html
 [frame-queue]: https://docs.rs/kona-derive/latest/kona_derive/stages/struct.FrameQueue.html
 [retrieval]: https://docs.rs/kona-derive/latest/kona_derive/stages/struct.L1Retrieval.html
 [traversal]: https://docs.rs/kona-derive/latest/kona_derive/stages/struct.IndexedTraversal.html


### PR DESCRIPTION
Fixed broken markdown link [channel-provider] in intro.mdx:

Updated path from kona_derive/stages/struct.ChannelProvider.html

To the correct path: kona_derive/struct.ChannelProvider.html