### PR TITLE
docs: fix typos in intro pages

### DIFF
--- a/docs/docs/pages/intro/lore.mdx
+++ b/docs/docs/pages/intro/lore.mdx
@@ -25,7 +25,7 @@ eventually being adopted by folks at Base in production.
 
 Once Fault Proofs were released with guardrails in the spring of 2024,
 [@clabby] and [@refcell] returned to the world of Rust to kick off a new fault
-proof implementation, this time in Rust. Using our learnings from goland, we
+proof implementation, this time in Rust. Using our learnings from golang, we
 built the kona-proof, and [released it at Frontiers 2024][proofs].
 
 After a few hardforks and side quests into interop, [@refcell][refcell] kicked

--- a/docs/docs/pages/node/design/intro.mdx
+++ b/docs/docs/pages/node/design/intro.mdx
@@ -25,7 +25,7 @@ state through message passing, using channels, rather than using
 shared memory.
 
 The [`RollupNodeService`][trait] defines the set of required
-actors  using associated types. These are subject to change,
+actors using associated types. These are subject to change,
 but are currently defined as follows.
 
 - **Derivation Actor**: Orchestrates the derivation pipeline,


### PR DESCRIPTION
- Corrected "goland" → "golang" in `lore.mdx`.
- Removed extra space in "actors  using" → "actors using" in `design/intro.mdx`.

