### PR TITLE
fix: update P2P component references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ getting started with building your own programs, and a reference for the librari
 - [`service`](./crates/node/service): The OP Stack rollup node service.
 - [`engine`](./crates/node/engine): An extensible implementation of the [OP Stack][op-stack] rollup node engine client
 - [`rpc`](./crates/node/rpc): OP Stack RPC types and extensions.
-- [`p2p`](./crates/node/p2p): OP Stack P2P Networking including Gossip and Discovery.
+- [`peers`](./crates/node/peers): Network peers library for the OP Stack.
+- [`disc`](./crates/node/disc): Discovery service for the OP Stack.
+- [`gossip`](./crates/node/gossip): Gossip protocol implementation for the OP Stack.
 - [`sources`](./crates/node/sources): Data source types and utilities for the kona-node.
 
 **Providers**


### PR DESCRIPTION
Replace outdated reference to non-existent `./crates/node/p2p` directory 
with correct references to the three separate P2P components:
- `peers`: Network peers library for the OP Stack
- `disc`: Discovery service for the OP Stack  
- `gossip`: Gossip protocol implementation for the OP Stack

The P2P functionality was split into these modular components