### PR TITLE
chore: fix typos in documentation comments

### DIFF
--- a/crates/proof/std-fpvm/src/channel.rs
+++ b/crates/proof/std-fpvm/src/channel.rs
@@ -1,4 +1,4 @@
-//! This module contains a rudamentary channel between two file descriptors, using [crate::io]
+//! This module contains a rudimentary channel between two file descriptors, using [crate::io]
 //! for reading and writing from the file descriptors.
 
 use crate::{FileDescriptor, io};

--- a/crates/proof/std-fpvm/src/types.rs
+++ b/crates/proof/std-fpvm/src/types.rs
@@ -5,7 +5,7 @@
 pub enum FileDescriptor {
     /// Read-only standard input stream.
     StdIn,
-    /// Write-only standaard output stream.
+    /// Write-only standard output stream.
     StdOut,
     /// Write-only standard error stream.
     StdErr,


### PR DESCRIPTION
Corrected spelling mistakes in doc comments in `channel.rs` and `types.rs` (`rudamentary` → `rudimentary`, `standaard` → `standard`).
