### PR TITLE
feat (supervisor): verify L1 chain consistency at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5218,6 +5218,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-client",
+ "alloy-rpc-types-eth",
  "anyhow",
  "async-trait",
  "derive_more",

--- a/crates/supervisor/core/src/reorg/task.rs
+++ b/crates/supervisor/core/src/reorg/task.rs
@@ -25,7 +25,8 @@ where
     C: ManagedNodeController + Send + Sync + 'static,
     DB: DbReader + StorageRewinder + Send + Sync + 'static,
 {
-    /// Processes reorg for a single chain
+    /// Processes reorg for a single chain. If the chain is consistent with the L1 chain,
+    /// does nothing.
     pub(crate) async fn process_chain_reorg(&self) -> Result<(), ReorgHandlerError> {
         let latest_state = self.db.latest_derivation_state()?;
 

--- a/crates/supervisor/service/Cargo.toml
+++ b/crates/supervisor/service/Cargo.toml
@@ -29,6 +29,7 @@ tracing = { workspace = true}
 alloy-eips = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-provider = { workspace = true }
+alloy-rpc-types-eth = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
 kona-genesis = { workspace = true }


### PR DESCRIPTION
Closes #2662 

The `ReorgTask` already contains the logic for verifying the consistency. I'm reusing it at startup by calling the `handle_l1_reorg` when initializing the l1 watcher.