### PR TITLE
fix: Add missing colon in error message

### DIFF
--- a/crates/providers/providers-alloy/src/chain_provider.rs
+++ b/crates/providers/providers-alloy/src/chain_provider.rs
@@ -116,7 +116,7 @@ pub enum AlloyChainProviderError {
     #[error("Block not found: {0}")]
     BlockNotFound(BlockId),
     /// Failed to convert RPC receipts into consensus receipts.
-    #[error("Failed to convert RPC receipts into consensus receipts {0}")]
+    #[error("Failed to convert RPC receipts into consensus receipts: {0}")]
     ReceiptsConversion(B256),
 }
 


### PR DESCRIPTION
- Add missing colon in error message for RPC receipts conversion in chain_provider.rs