### PR TITLE
feat(ci): Add `kona` + `cannon` job

### DIFF
--- a/.github/workflows/proof.yaml
+++ b/.github/workflows/proof.yaml
@@ -97,7 +97,7 @@ jobs:
     name: FPP e2e - ${{ matrix.target}} | ${{ matrix.name }}
     strategy:
       matrix:
-        target: ["native", "asterisc"]
+        target: ["native", "asterisc", "cannon"]
         name: ["OP Sepolia (Holocene) - Block #26215604"]
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -117,21 +117,36 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Clone `asterisc` repository
-        if: "!contains(matrix.target, 'native')"
+        if: "contains(matrix.target, 'asterisc')"
         run: |
           git clone https://github.com/ethereum-optimism/asterisc.git
-      - name: Setup Go toolchain
-        if: "!contains(matrix.target, 'native')"
+      - name: Clone `optimism` repository
+        if: "contains(matrix.target, 'cannon')"
+        run: |
+          git clone https://github.com/ethereum-optimism/optimism.git
+      - name: Setup Go toolchain (asterisc cache)
+        if: "contains(matrix.target, 'asterisc')"
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21.6"
+          go-version: "1.23.8"
           cache-dependency-path: |
             asterisc/go.sum
+      - name: Setup Go toolchain (cannon cache)
+        if: "contains(matrix.target, 'cannon')"
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23.8"
+          cache-dependency-path: |
+            optimism/go.sum
       - name: Build `asterisc`
-        if: "!contains(matrix.target, 'native')"
+        if: "contains(matrix.target, 'asterisc')"
         run: |
           cd asterisc && git checkout v1.3.0 && make build-rvgo
           mv ./rvgo/bin/asterisc /usr/local/bin/
+      - name: Build `cannon`
+        if: "contains(matrix.target, 'cannon')"
+        run: |
+          cd optimism/cannon && make && mv ./bin/cannon /usr/local/bin/
       - name: Set run environment
         run: |
           if [[ ${{ contains(matrix.name, 26215604) }} == true ]]; then

--- a/.gitignore
+++ b/.gitignore
@@ -35,9 +35,9 @@ data/
 jwt.hex
 
 # FPVM artifacts
-./state.bin.gz
-./meta.json
-./out.json
+state.bin.gz
+meta.json
+out.json
 
 # Prestate artifacts
 prestate-artifacts-*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,7 +2795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3999,7 +3999,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5340,7 +5340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.2",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -6451,9 +6451,8 @@ dependencies = [
 
 [[package]]
 name = "nybbles"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675b3a54e5b12af997abc8b6638b0aee51a28caedab70d4967e0d5db3a3f1d06"
+version = "0.4.2"
+source = "git+https://github.com/clabby/nybbles?branch=cl%2Fpack-fix#35e5f12ee1d54b5a0f545ef61cd5d85205969f7f"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -7309,7 +7308,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8383,7 +8382,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8450,7 +8449,7 @@ dependencies = [
  "security-framework 3.2.0",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9226,7 +9225,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10178,7 +10177,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6451,8 +6451,9 @@ dependencies = [
 
 [[package]]
 name = "nybbles"
-version = "0.4.2"
-source = "git+https://github.com/clabby/nybbles?branch=cl%2Fpack-fix#35e5f12ee1d54b5a0f545ef61cd5d85205969f7f"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63cb50036b1ad148038105af40aaa70ff24d8a14fbc44ae5c914e1348533d12e"
 dependencies = [
  "alloy-rlp",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,6 +263,3 @@ c-kzg = { version = "2.1.1", default-features = false }
 ark-ff = { version = "0.5.0", default-features = false }
 secp256k1 = { version = "0.31.0", default-features = false }
 ark-bls12-381 = { version = "0.5.0", default-features = false }
-
-[patch.crates-io]
-nybbles = { git = "https://github.com/clabby/nybbles", branch = "cl/pack-fix" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,3 +263,6 @@ c-kzg = { version = "2.1.1", default-features = false }
 ark-ff = { version = "0.5.0", default-features = false }
 secp256k1 = { version = "0.31.0", default-features = false }
 ark-bls12-381 = { version = "0.5.0", default-features = false }
+
+[patch.crates-io]
+nybbles = { git = "https://github.com/clabby/nybbles", branch = "cl/pack-fix" }

--- a/bin/client/justfile
+++ b/bin/client/justfile
@@ -223,7 +223,7 @@ run-client-cannon block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc rollu
   just build-cannon-client
 
   echo "Loading client program into Cannon state format..."
-  cannon load-elf --path=$CLIENT_BIN_PATH --type multithreaded64-4
+  cannon load-elf --path=$CLIENT_BIN_PATH --type multithreaded64-5
 
   echo "Building host program for native target..."
   cargo build --bin kona-host --release


### PR DESCRIPTION
## Overview

Adds a CI job to run `kona-client` on `cannon64`.

Also upgrades the dep of `nybbles`; There was a bug that I introduced recently for big-endian targets, fix included in https://github.com/alloy-rs/nybbles/pull/35.