### PR TITLE
chore(node/p2p): Use libp2p Allow Block List

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4592,6 +4592,7 @@ dependencies = [
  "kona-peers",
  "lazy_static",
  "libp2p",
+ "libp2p-allow-block-list",
  "libp2p-identity",
  "libp2p-stream",
  "metrics",

--- a/crates/node/gossip/Cargo.toml
+++ b/crates/node/gossip/Cargo.toml
@@ -41,6 +41,7 @@ discv5 = { workspace = true, features = ["libp2p"] }
 openssl = { workspace = true, features = ["vendored"] }
 libp2p-identity = { workspace = true, features = ["secp256k1"] }
 libp2p = { workspace = true, features = ["macros", "tokio", "tcp", "noise", "gossipsub", "ping", "yamux", "identify"] }
+libp2p-allow-block-list = "0.6.0"
 ipnet = { workspace = true, features = ["serde"] }
 
 # Misc

--- a/crates/node/gossip/src/event.rs
+++ b/crates/node/gossip/src/event.rs
@@ -1,6 +1,7 @@
 //! Event Handling Module.
 
 use libp2p::{gossipsub, identify, ping};
+use std::convert::Infallible;
 
 /// High-level events emitted by the gossip networking system.
 ///
@@ -62,6 +63,16 @@ impl From<()> for Event {
     /// Converts () to [Event]
     fn from(_value: ()) -> Self {
         Self::Stream
+    }
+}
+
+impl From<Infallible> for Event {
+    /// Converts Infallible to [Event]
+    /// This is needed for the allow_block_list behavior which generates no events
+    fn from(_value: Infallible) -> Self {
+        // This can never be called since Infallible has no values,
+        // but we need it to satisfy the NetworkBehaviour trait bounds
+        unreachable!()
     }
 }
 


### PR DESCRIPTION
Closes #2111

Replaces manual peer blocking implementation with libp2p's standardized `allow_block_list::Behaviour` for better integration and reduced code complexity.

🤖 Generated with [Claude Code](https://claude.ai/code)