### PR TITLE
fix: correct typos in docs and address formatting

### DIFF
--- a/crates/proof/mpt/src/noop.rs
+++ b/crates/proof/mpt/src/noop.rs
@@ -1,5 +1,5 @@
 //! Trait implementations for `kona-mpt` traits that are effectively a no-op.
-//! Providers trait implementations for downstream users who do not require hinting.
+//! Provides trait implementations for downstream users who do not require hinting.
 
 use crate::{TrieHinter, TrieNode, TrieProvider};
 use alloc::string::String;

--- a/crates/protocol/protocol/src/predeploys.rs
+++ b/crates/protocol/protocol/src/predeploys.rs
@@ -131,7 +131,7 @@ impl Predeploys {
     pub const BEACON_BLOCK_ROOT: Address = address!("0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02");
 
     /// The Operator Fee Vault proxy address.
-    pub const OPERATOR_FEE_VAULT: Address = address!("420000000000000000000000000000000000001B");
+    pub const OPERATOR_FEE_VAULT: Address = address!("0x420000000000000000000000000000000000001B");
 
     /// The CrossL2Inbox proxy address.
     pub const CROSS_L2_INBOX: Address = address!("0x4200000000000000000000000000000000000022");


### PR DESCRIPTION
ixed typo in doc comment (Providers → Provides).

updated OPERATOR_FEE_VAULT address to include 0x prefix for consistency.