### PR TITLE
fix: standardize hex address formatting with 0x prefix

### DIFF
--- a/crates/protocol/hardforks/src/isthmus.rs
+++ b/crates/protocol/hardforks/src/isthmus.rs
@@ -42,7 +42,7 @@ impl Isthmus {
     /// The new L1 Block Address
     /// This is computed by using go-ethereum's `crypto.CreateAddress` function,
     /// with the L1 Block Deployer Address and nonce 0.
-    pub const NEW_L1_BLOCK: Address = address!("ff256497d61dcd71a9e9ff43967c13fde1f72d12");
+    pub const NEW_L1_BLOCK: Address = address!("0xff256497d61dcd71a9e9ff43967c13fde1f72d12");
 
     /// The Gas Price Oracle Address
     /// This is computed by using go-ethereum's `crypto.CreateAddress` function,
@@ -52,7 +52,7 @@ impl Isthmus {
     /// The Operator Fee Vault Address
     /// This is computed by using go-ethereum's `crypto.CreateAddress` function,
     /// with the Operator Fee Vault Deployer Address and nonce 0.
-    pub const OPERATOR_FEE_VAULT: Address = address!("4fa2be8cd41504037f1838bce3bcc93bc68ff537");
+    pub const OPERATOR_FEE_VAULT: Address = address!("0x4fa2be8cd41504037f1838bce3bcc93bc68ff537");
 
     /// The Isthmus L1 Block Deployer Code Hash
     /// See: <https://specs.optimism.io/protocol/isthmus/derivation.html#l1block-deployment>

--- a/crates/protocol/hardforks/src/isthmus.rs
+++ b/crates/protocol/hardforks/src/isthmus.rs
@@ -18,7 +18,7 @@ pub struct Isthmus;
 
 impl Isthmus {
     /// The depositor account address.
-    pub const DEPOSITOR_ACCOUNT: Address = address!("DeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001");
+    pub const DEPOSITOR_ACCOUNT: Address = address!("0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001");
 
     /// The Enable Isthmus Input Method 4Byte Signature.
     ///
@@ -26,10 +26,10 @@ impl Isthmus {
     pub const ENABLE_ISTHMUS_INPUT: [u8; 4] = hex!("291b0383");
 
     /// EIP-2935 From Address
-    pub const EIP2935_FROM: Address = address!("3462413Af4609098e1E27A490f554f260213D685");
+    pub const EIP2935_FROM: Address = address!("0x3462413Af4609098e1E27A490f554f260213D685");
 
     /// L1 Block Deployer Address
-    pub const L1_BLOCK_DEPLOYER: Address = address!("4210000000000000000000000000000000000003");
+    pub const L1_BLOCK_DEPLOYER: Address = address!("0x4210000000000000000000000000000000000003");
 
     /// The Gas Price Oracle Deployer Address
     pub const GAS_PRICE_ORACLE_DEPLOYER: Address =
@@ -47,7 +47,7 @@ impl Isthmus {
     /// The Gas Price Oracle Address
     /// This is computed by using go-ethereum's `crypto.CreateAddress` function,
     /// with the Gas Price Oracle Deployer Address and nonce 0.
-    pub const GAS_PRICE_ORACLE: Address = address!("93e57a196454cb919193fa9946f14943cf733845");
+    pub const GAS_PRICE_ORACLE: Address = address!("0x93e57a196454cb919193fa9946f14943cf733845");
 
     /// The Operator Fee Vault Address
     /// This is computed by using go-ethereum's `crypto.CreateAddress` function,


### PR DESCRIPTION

```markdown
## Summary
Standardizes hexadecimal address formatting by adding the `0x` prefix to constant address definitions in `crates/protocol/hardforks/src/isthmus.rs`.

## Changes
- **DEPOSITOR_ACCOUNT**: `DeaDDEaD...0001` → `0xDeaDDEaD...0001`
- **EIP2935_FROM**: `3462413A...D685` → `0x3462413A...D685`
- **L1_BLOCK_DEPLOYER**: `42100000...0003` → `0x42100000...0003`
- **GAS_PRICE_ORACLE**: `93e57a19...33845` → `0x93e57a19...33845`

```