### PR TITLE
chore (supervisor): add observability to chain processor

### DIFF
--- a/crates/supervisor/core/src/chain_processor/chain.rs
+++ b/crates/supervisor/core/src/chain_processor/chain.rs
@@ -3,7 +3,7 @@ use super::{
         CrossSafeHandler, CrossUnsafeHandler, EventHandler, FinalizedHandler, InvalidationHandler,
         OriginHandler, ReplacementHandler, SafeBlockHandler, UnsafeBlockHandler,
     },
-    state::{ProcessorState, ProcesssorStateUpdate},
+    state::{ProcessorState, ProcessorStateUpdate},
 };
 use crate::{
     LogIndexer,
@@ -126,36 +126,36 @@ where
         let (result, head_update) = match event {
             ChainEvent::UnsafeBlock { block } => (
                 self.unsafe_handler.handle(block, &mut self.state).await,
-                ProcesssorStateUpdate::LocalUnsafe,
+                ProcessorStateUpdate::LocalUnsafe,
             ),
             ChainEvent::DerivedBlock { derived_ref_pair } => (
                 self.safe_handler.handle(derived_ref_pair, &mut self.state).await,
-                ProcesssorStateUpdate::LocalSafe,
+                ProcessorStateUpdate::LocalSafe,
             ),
             ChainEvent::DerivationOriginUpdate { origin } => (
                 self.origin_handler.handle(origin, &mut self.state).await,
-                ProcesssorStateUpdate::L1Source,
+                ProcessorStateUpdate::L1Source,
             ),
             ChainEvent::InvalidateBlock { block } => (
                 self.invalidation_handler.handle(block, &mut self.state).await,
-                ProcesssorStateUpdate::InvalidateBlock,
+                ProcessorStateUpdate::InvalidateBlock,
             ),
             ChainEvent::BlockReplaced { replacement } => (
                 self.replacement_handler.handle(replacement, &mut self.state).await,
-                ProcesssorStateUpdate::BlockReplaced,
+                ProcessorStateUpdate::BlockReplaced,
             ),
             ChainEvent::FinalizedSourceUpdate { finalized_source_block } => (
                 self.finalized_handler.handle(finalized_source_block, &mut self.state).await,
-                ProcesssorStateUpdate::Finalized, /* Finalized handler returns the derived block
-                                                   * on success */
+                ProcessorStateUpdate::Finalized, /* Finalized handler returns the derived block
+                                                  * on success */
             ),
             ChainEvent::CrossUnsafeUpdate { block } => (
                 self.cross_unsafe_handler.handle(block, &mut self.state).await,
-                ProcesssorStateUpdate::CrossUnsafe,
+                ProcessorStateUpdate::CrossUnsafe,
             ),
             ChainEvent::CrossSafeUpdate { derived_ref_pair } => (
                 self.cross_safe_handler.handle(derived_ref_pair, &mut self.state).await,
-                ProcesssorStateUpdate::CrossSafe,
+                ProcessorStateUpdate::CrossSafe,
             ),
         };
 
@@ -174,36 +174,36 @@ where
         }
     }
 
-    fn apply_state_update(&mut self, update: ProcesssorStateUpdate, block: BlockInfo) {
+    fn apply_state_update(&mut self, update: ProcessorStateUpdate, block: BlockInfo) {
         match update {
-            ProcesssorStateUpdate::LocalUnsafe => {
+            ProcessorStateUpdate::LocalUnsafe => {
                 self.state.super_head.local_unsafe = block;
                 self.log_state_update("LocalUnsafe", &block);
             }
-            ProcesssorStateUpdate::LocalSafe => {
+            ProcessorStateUpdate::LocalSafe => {
                 self.state.super_head.local_safe = Some(block);
                 self.log_state_update("LocalSafe", &block);
             }
-            ProcesssorStateUpdate::CrossUnsafe => {
+            ProcessorStateUpdate::CrossUnsafe => {
                 self.state.super_head.cross_unsafe = Some(block);
                 self.log_state_update("CrossUnsafe", &block);
             }
-            ProcesssorStateUpdate::CrossSafe => {
+            ProcessorStateUpdate::CrossSafe => {
                 self.state.super_head.cross_safe = Some(block);
                 self.log_state_update("CrossSafe", &block);
             }
-            ProcesssorStateUpdate::Finalized => {
+            ProcessorStateUpdate::Finalized => {
                 self.state.super_head.finalized = Some(block);
                 self.log_state_update("Finalized", &block);
             }
-            ProcesssorStateUpdate::L1Source => {
+            ProcessorStateUpdate::L1Source => {
                 self.state.super_head.l1_source = Some(block);
                 self.log_state_update("L1Source", &block);
             }
-            ProcesssorStateUpdate::InvalidateBlock => {
+            ProcessorStateUpdate::InvalidateBlock => {
                 self.log_state_update("InvalidateBlock", &block);
             }
-            ProcesssorStateUpdate::BlockReplaced => {
+            ProcessorStateUpdate::BlockReplaced => {
                 self.log_state_update("BlockReplaced", &block);
             }
         }

--- a/crates/supervisor/core/src/chain_processor/mod.rs
+++ b/crates/supervisor/core/src/chain_processor/mod.rs
@@ -12,6 +12,6 @@ mod metrics;
 pub(crate) use metrics::Metrics;
 
 mod state;
-pub use state::{ProcessorState, ProcesssorStateUpdate};
+pub use state::{ProcessorState, ProcessorStateUpdate};
 
 pub mod handlers;

--- a/crates/supervisor/core/src/chain_processor/mod.rs
+++ b/crates/supervisor/core/src/chain_processor/mod.rs
@@ -12,6 +12,6 @@ mod metrics;
 pub(crate) use metrics::Metrics;
 
 mod state;
-pub use state::ProcessorState;
+pub use state::{ProcessorState, ProcesssorStateUpdate};
 
 pub mod handlers;

--- a/crates/supervisor/core/src/chain_processor/state/mod.rs
+++ b/crates/supervisor/core/src/chain_processor/state/mod.rs
@@ -1,2 +1,2 @@
 mod processor;
-pub use processor::{ProcessorState, ProcesssorStateUpdate};
+pub use processor::{ProcessorState, ProcessorStateUpdate};

--- a/crates/supervisor/core/src/chain_processor/state/mod.rs
+++ b/crates/supervisor/core/src/chain_processor/state/mod.rs
@@ -1,2 +1,2 @@
 mod processor;
-pub use processor::ProcessorState;
+pub use processor::{ProcessorState, ProcesssorStateUpdate};

--- a/crates/supervisor/core/src/chain_processor/state/processor.rs
+++ b/crates/supervisor/core/src/chain_processor/state/processor.rs
@@ -1,10 +1,14 @@
 use kona_interop::DerivedRefPair;
+use kona_supervisor_types::SuperHead;
 
 /// This module contains the state management for the chain processor.
 /// It provides a way to track the invalidated blocks and manage the state of the chain processor
 #[derive(Debug, Default)]
 pub struct ProcessorState {
-    invalidated_block: Option<DerivedRefPair>,
+    /// Tracks current invalidated block.
+    pub invalidated_block: Option<DerivedRefPair>,
+    /// Tracks the super head of the chain.
+    pub super_head: SuperHead,
 }
 
 impl ProcessorState {
@@ -37,4 +41,25 @@ impl ProcessorState {
     pub const fn clear_invalidated(&mut self) {
         self.invalidated_block = None;
     }
+}
+
+/// Represents the different types of state updates that can be applied to the chain processor.
+#[derive(Debug)]
+pub enum ProcesssorStateUpdate {
+    /// Local unsafe update.
+    LocalUnsafe,
+    /// Local safe update.
+    LocalSafe,
+    /// Cross unsafe update.
+    CrossUnsafe,
+    /// Cross safe update.
+    CrossSafe,
+    /// Finalized update.
+    Finalized,
+    /// Invalidate block update.
+    InvalidateBlock,
+    /// Block replaced update.
+    BlockReplaced,
+    /// L1 source update.
+    L1Source,
 }

--- a/crates/supervisor/core/src/chain_processor/state/processor.rs
+++ b/crates/supervisor/core/src/chain_processor/state/processor.rs
@@ -45,7 +45,7 @@ impl ProcessorState {
 
 /// Represents the different types of state updates that can be applied to the chain processor.
 #[derive(Debug)]
-pub enum ProcesssorStateUpdate {
+pub enum ProcessorStateUpdate {
     /// Local unsafe update.
     LocalUnsafe,
     /// Local safe update.

--- a/crates/supervisor/service/src/actors/processor.rs
+++ b/crates/supervisor/service/src/actors/processor.rs
@@ -315,7 +315,7 @@ mod tests {
         let mut mock_db = MockDb::new();
         let validator = MockValidator::new();
         let (mn_sender, _mn_receiver) = mpsc::channel(1);
-        
+
         mock_db.expect_get_super_head().returning(|| Ok(SuperHead::default()));
 
         let processor = ChainProcessor::new(


### PR DESCRIPTION
Closes #2743 

If the logging is too verbose, I can enable only for `local_safe` and `finalized`.