### PR TITLE
docs: fix typos and grammar in node and rfc pages

### DIFF
--- a/docs/docs/pages/node/design/intro.mdx
+++ b/docs/docs/pages/node/design/intro.mdx
@@ -41,7 +41,7 @@ but are currently defined as follows.
 - **Network Actor**: Manages the P2P Network for the rollup
   node. The P2P stack consists of `discv5` peer discovery
   and block gossip through libp2p. Visit the [network][p2p]
-  docs for more detail.
+  docs for more details.
 - **Supervisor Actor (beta)**: The supervisor actor is an
   interop feature that allows the `kona-node` to be
   "managed" (or "indexed") by the supervisor - a new

--- a/docs/docs/pages/node/run/binary.mdx
+++ b/docs/docs/pages/node/run/binary.mdx
@@ -127,7 +127,7 @@ is set to `3`, which is the INFO level. The level ranges from `0`
 being no logs to `5` which includes trace logs. Log levels are
 listed below, with each level including the one below it.
 
-- `5`: `TRACE` - very verbose logs that provides a detailed trace
+- `5`: `TRACE` - very verbose logs that provide a detailed trace
 - `4`: `DEBUG` - logs meant to print debugging information
 - `3`: `INFO` - informational logs
 - `2`: `WARN` - includes warning and error logs

--- a/docs/docs/pages/rfc/archived/umbrellas.mdx
+++ b/docs/docs/pages/rfc/archived/umbrellas.mdx
@@ -54,7 +54,7 @@ directories all contain crates, and are not crates themselves - only directories
 #### Publishing Crates
 
 When crates in `kona` are published, they are all published individually, with no
-way to add all kona crates as a dependency. This make discoverability difficult
+way to add all kona crates as a dependency. This makes discoverability difficult
 without accurate and up-to-date documentation, adding overhead.
 
 ## Problem
@@ -63,7 +63,7 @@ As a monorepo, `kona` will likely have a growing number of crates that will make
 it increasingly difficult to discover new `kona` crates and manage `kona` as a
 dependency, for downstream consumers.
 
-Additionally, each crate has it's own independent version, which makes it more nuanced
+Additionally, each crate has its own independent version, which makes it more nuanced
 to manage `kona` dependencies and less clear which crate versions are compatible.
 
 ## Considered Options
@@ -113,7 +113,7 @@ Unfortunately this option now introduces `n + 1` number of crates where `n`
 is the number of subdirectories in `crates/`, but it still only requires
 updates to the subdirectory umbrellas when a crate is added or removed.
 
-The benefit of this is option is the top-level umbrella crate is very much
+The benefit of this option is the top-level umbrella crate is very much
 simplified, since it only needs to re-export the `n` umbrella crates and not
 every crate in the workspace. It also provides the single consumable `kona`
 crate for downstream users that greatly simplifies managing `kona` as a


### PR DESCRIPTION
- intro.mdx: "docs for more detail" → "docs for more details"
- binary.mdx: "provides a detailed trace" → "provide a detailed trace"
- umbrellas.mdx: 
  - "This make" → "This makes"
  - "each crate has it's" → "each crate has its"
  - "The benefit of this is option" → "The benefit of this option"