### PR TITLE
chore(docs): unify casing to "OP Stack"

### DIFF
--- a/bin/supervisor/README.md
+++ b/bin/supervisor/README.md
@@ -1,6 +1,6 @@
 # `kona-supervisor`
 
-A supervisor implementation for the OP stack built in rust.
+A supervisor implementation for the OP Stack built in rust.
 
 ## Installation
 

--- a/crates/node/peers/src/nodes.rs
+++ b/crates/node/peers/src/nodes.rs
@@ -71,7 +71,7 @@ lazy_static! {
         .collect();
 }
 
-/// OP stack mainnet boot nodes.
+/// OP Stack mainnet boot nodes.
 pub static OP_RAW_BOOTNODES: &[&str] = &[
     // OP Mainnet Bootnodes
     "enr:-J64QBbwPjPLZ6IOOToOLsSjtFUjjzN66qmBZdUexpO32Klrc458Q24kbty2PdRaLacHM5z-cZQr8mjeQu3pik6jPSOGAYYFIqBfgmlkgnY0gmlwhDaRWFWHb3BzdGFja4SzlAUAiXNlY3AyNTZrMaECmeSnJh7zjKrDSPoNMGXoopeDF4hhpj5I0OsQUUt4u8uDdGNwgiQGg3VkcIIkBg",
@@ -103,7 +103,7 @@ pub static OP_RAW_BOOTNODES: &[&str] = &[
     "enode://77b6b1e72984d5d50e00ae934ffea982902226fe92fa50da42334c2750d8e405b55a5baabeb988c88125368142a64eda5096d0d4522d3b6eef75d166c7d303a9@3.148.100.173:30303",
 ];
 
-/// OP stack testnet boot nodes.
+/// OP Stack testnet boot nodes.
 pub static OP_RAW_TESTNET_BOOTNODES: &[&str] = &[
     // OP Labs
     "enode://2bd2e657bb3c8efffb8ff6db9071d9eb7be70d7c6d7d980ff80fc93b2629675c5f750bc0a5ef27cd788c2e491b8795a7e9a4a6e72178c14acc6753c0e5d77ae4@34.65.205.244:30305",

--- a/crates/proof/executor/README.md
+++ b/crates/proof/executor/README.md
@@ -5,4 +5,4 @@
 <a href="https://github.com/op-rs/kona/blob/main/LICENSE.md"><img src="https://img.shields.io/badge/License-MIT-d1d1f6.svg?label=license&labelColor=2a2f35" alt="License"></a>
 <a href="https://img.shields.io/codecov/c/github/op-rs/kona"><img src="https://img.shields.io/codecov/c/github/op-rs/kona" alt="Codecov"></a>
 
-A `no_std` implementation of a stateless block executor for the OP stack, backed by [`kona-mpt`](../mpt)'s `TrieDB`.
+A `no_std` implementation of a stateless block executor for the OP Stack, backed by [`kona-mpt`](../mpt)'s `TrieDB`.

--- a/crates/supervisor/core/src/logindexer/util.rs
+++ b/crates/supervisor/core/src/logindexer/util.rs
@@ -18,7 +18,7 @@ pub fn payload_hash_to_log_hash(payload_hash: B256, addr: Address) -> B256 {
 /// Converts an L2 log into its raw message payload for hashing.
 ///
 /// This payload is defined as the concatenation of all log topics followed by the log data,
-/// in accordance with the OP stack interop messaging spec.
+/// in accordance with the OP Stack interop messaging spec.
 ///
 /// This data is what is hashed to produce the `payloadHash`.
 pub fn log_to_message_payload(log: &Log) -> Bytes {


### PR DESCRIPTION
Consistently use "OP Stack" across the repo. Some places used "OP stack" before.