### PR TITLE
docs: fix incorrect crates.io link path

### DIFF
--- a/docs/docs/pages/sdk/protocol/protocol/frames.mdx
+++ b/docs/docs/pages/sdk/protocol/protocol/frames.mdx
@@ -72,7 +72,7 @@ provide ways to decode single and multiple frames, respectively.
 [parse_frame]: https://docs.rs/kona-protocol/latest/kona_protocol/struct.Frame.html#method.parse_frame
 [parse_frames]: https://docs.rs/kona-protocol/latest/kona_protocol/struct.Frame.html#method.parse_frames
 
-[protocol]: https://crates.io/crate/kona-protocol
+[protocol]: https://crates.io/crates/kona-protocol
 
 [id]: https://docs.rs/kona-protocol/latest/kona_protocol/struct.Frame.html#structfield.id
 [number]: https://docs.rs/kona-protocol/latest/kona_protocol/struct.Frame.html#structfield.number


### PR DESCRIPTION
incorrect: https://crates.io/crate/kona-protocol
correct: https://crates.io/crates/kona-protocol

before:
<img width="1471" height="642" alt="image" src="https://github.com/user-attachments/assets/a42a1b37-8038-4b96-a68c-045cfac0baa3" />

after:
<img width="1551" height="843" alt="image" src="https://github.com/user-attachments/assets/ac32bd36-f265-415f-8b36-b1de35dc5295" />
