### PR TITLE
fix: standardize TODO comment formatting

### DIFF
--- a/crates/supervisor/rpc/src/jsonrpsee.rs
+++ b/crates/supervisor/rpc/src/jsonrpsee.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 /// Supervisor API for interop.
 ///
 /// See spec <https://github.com/ethereum-optimism/specs/blob/main/specs/interop/supervisor.md#methods>.
-// TODO:: add all the methods
+// TODO: add all the methods
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "supervisor"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "supervisor"))]
 pub trait SupervisorApi {

--- a/crates/supervisor/types/src/types.rs
+++ b/crates/supervisor/types/src/types.rs
@@ -8,8 +8,8 @@ use alloy_primitives::B256;
 use kona_interop::ManagedEvent;
 use serde::{Deserialize, Serialize};
 
-// todo:: Determine appropriate locations for these structs and move them accordingly.
-// todo:: Link these structs to the spec documentation after the related PR is merged.
+// TODO: Determine appropriate locations for these structs and move them accordingly.
+// TODO: Link these structs to the spec documentation after the related PR is merged.
 
 /// Represents a sealed block with its hash, number, and timestamp.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
Normalize TODO comment format across codebase by replacing non-standard `TODO::` and `todo::` prefixes with the conventional `TODO:` format.

This improves consistency and ensures better compatibility with IDE TODO tracking tools and linters.

Changes:
- supervisor/rpc: Fix `TODO::` → `TODO:` in jsonrpsee.rs
- supervisor/types: Fix `todo::` → `TODO:` in types.rs (2 instances)