### PR TITLE
fix(docs): correct return type documentation for header_by_hash

### DIFF
--- a/crates/proof/executor/src/db/traits.rs
+++ b/crates/proof/executor/src/db/traits.rs
@@ -27,7 +27,7 @@ pub trait TrieDBProvider: TrieProvider {
     /// - `hash`: The hash of the RLP-encoded [Header].
     ///
     /// ## Returns
-    /// - Ok(Bytes): The [Header].
+    /// - Ok(Header): The [Header].
     /// - Err(Self::Error): If the [Header] could not be fetched.
     ///
     /// [TrieDB]: crate::TrieDB


### PR DESCRIPTION
Fix incorrect return type documentation in TrieDBProvider::header_by_hash

The function signature returns `Result<Header, Self::Error>` but the documentation
incorrectly stated `Ok(Bytes): The [Header]`. This was inconsistent with the
established pattern in the codebase where documentation must exactly match