### PR TITLE
chore: sync reth version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,7 @@ op-revm = { version = "9.0.1", default-features = false }
 alloy-evm = { version = "0.18.3", default-features = false }
 alloy-op-evm = { version = "0.18.3", default-features = false }
 
-# Reth (pinned to v1.4.8 for kona-supervisor-storage)
+# Reth (pinned to v1.6.0 for kona-supervisor-storage)
 reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.6.0" }
 reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.6.0" }
 reth-codecs = { git = "https://github.com/paradigmxyz/reth", tag = "v1.6.0" }


### PR DESCRIPTION
Sync reth version, apparently the version is v1.6.0 now