### PR TITLE
perf: avoid unnecessary HashMap collection in L1 watcher tests

### DIFF
--- a/crates/supervisor/core/src/l1_watcher/watcher.rs
+++ b/crates/supervisor/core/src/l1_watcher/watcher.rs
@@ -329,7 +329,8 @@ mod tests {
     #[tokio::test]
     async fn test_handle_new_finalized_block_updates_and_broadcasts() {
         let (tx, mut rx) = mpsc::channel(1);
-        let event_txs = [(1, tx)].into_iter().collect();
+        let mut event_txs = HashMap::new();
+        event_txs.insert(1, tx);
 
         let mut mock_storage = Mockfinalized_l1_storage::new();
         mock_storage.expect_update_finalized_l1().returning(|_block| Ok(()));
@@ -376,7 +377,8 @@ mod tests {
     #[tokio::test]
     async fn test_handle_new_finalized_block_storage_error() {
         let (tx, mut rx) = mpsc::channel(1);
-        let event_txs = [(1, tx)].into_iter().collect();
+        let mut event_txs = HashMap::new();
+        event_txs.insert(1, tx);
 
         let mut mock_storage = Mockfinalized_l1_storage::new();
         mock_storage
@@ -415,7 +417,8 @@ mod tests {
     #[tokio::test]
     async fn test_handle_new_latest_block_updates() {
         let (tx, mut rx) = mpsc::channel(1);
-        let event_txs = [(1, tx)].into_iter().collect();
+        let mut event_txs = HashMap::new();
+        event_txs.insert(1, tx);
 
         let watcher = L1Watcher {
             rpc_client: mock_rpc_client(),
@@ -448,7 +451,8 @@ mod tests {
     #[tokio::test]
     async fn test_trigger_reorg_handler() {
         let (tx, mut rx) = mpsc::channel(1);
-        let event_txs = [(1, tx)].into_iter().collect();
+        let mut event_txs = HashMap::new();
+        event_txs.insert(1, tx);
 
         let watcher = L1Watcher {
             rpc_client: mock_rpc_client(),


### PR DESCRIPTION
Replace `[(1, tx)].into_iter().collect()` with direct HashMap construction in L1 watcher test setup.

The current pattern creates an intermediate iterator just to collect into a HashMap with a single entry. This can be simplified to direct construction, reducing allocations and improving readability.