### PR TITLE
docs: fix some typos

### DIFF
--- a/crates/proof/preimage/src/oracle.rs
+++ b/crates/proof/preimage/src/oracle.rs
@@ -115,7 +115,7 @@ where
     where
         F: PreimageFetcher + Send + Sync,
     {
-        // Read the preimage request from the client, and throw early if there isn't is any.
+        // Read the preimage request from the client, and throw early if there isn't any.
         let mut buf = [0u8; 32];
         self.channel.read_exact(&mut buf).await?;
         let preimage_key = PreimageKey::try_from(buf)?;

--- a/crates/supervisor/service/src/service.rs
+++ b/crates/supervisor/service/src/service.rs
@@ -409,7 +409,7 @@ impl Service {
         self.initialise().await?;
 
         // todo: refactor this to only run the tasks completion loop
-        // and handle admin requests elewhere
+        // and handle admin requests elsewhere
         loop {
             tokio::select! {
                 // Admin requests (if admin_receiver was initialized)


### PR DESCRIPTION
if there isn't is any. -> if there isn't any.
elewhere -> elsewhere