### PR TITLE
fix(node): use canonical --l2-engine-jwt-secret in CLI example

### DIFF
--- a/bin/node/src/commands/node.rs
+++ b/bin/node/src/commands/node.rs
@@ -60,7 +60,7 @@ pub(super) enum JwtValidationError {
 ///           --l1-eth-rpc http://localhost:8545 \
 ///           --l1-beacon http://localhost:5052 \
 ///           --l2-engine-rpc http://localhost:8551 \
-///           --l2-jwt-secret /path/to/jwt.hex
+///           --l2-engine-jwt-secret /path/to/jwt.hex
 /// ```
 #[derive(Parser, PartialEq, Debug, Clone)]
 #[command(about = "Runs the consensus node")]


### PR DESCRIPTION
Replace incorrect --l2-jwt-secret in the inline example with the canonical --l2-engine-jwt-secret. This aligns the comment with the actual Clap flag (l2_engine_jwt_secret) and the CLI reference/README/docker examples, preventing confusion for users copying the example.