### PR TITLE
chore(ci): Set lower bound for `codecov` to 80

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -6,7 +6,7 @@
 # Reference: https://docs.codecov.com/docs/codecovyml-reference
 
 coverage:
-  range: 90..100
+  range: 80..100
   round: down
   precision: 1
   status:


### PR DESCRIPTION
Decreases lower bound of `codecov` from 90 to 80