### PR TITLE
docs(book): update executor customization for alloy-evm

### DIFF
--- a/docs/docs/pages/sdk/proof/exec-ext.mdx
+++ b/docs/docs/pages/sdk/proof/exec-ext.mdx
@@ -1,42 +1,154 @@
 # `kona-executor` Extensions
 
 The `kona-executor` crate offers a to-spec, stateless implementation of the OP Stack STF. However, due to the
-power of [`revm`][revm]'s Handler abstractions, the logic of the STF can be easily modified.
+power of [`alloy-evm`][alloy-evm]'s factory abstractions, the logic of the STF can be easily customized.
 
-To register a custom handler, for example to add a custom precompile, modify the behavior of an EVM opcode,
-or change the fee handling, `StatelessL2BlockExecutorBuilder::with_handle_register` is your friend. It accepts a
-handle register function that can be used to take full advantage of [`revm`'s Handler API](https://github.com/bluealloy/revm/blob/f57e3e639ee157c7e659e740bd175a7357003570/documentation/src/crates/revm/handler.md#handler).
+To customize the EVM behavior, for example to add a custom precompile, modify the behavior of an EVM opcode,
+or change the fee handling, you can implement a custom [`EvmFactory`][evm-factory]. The factory is responsible
+for creating EVM instances with your desired customizations.
 
 ## Example - Custom Precompile
 
 ```rust
+use alloy_evm::{Database, EvmEnv, EvmFactory};
+use alloy_op_evm::OpEvm;
+use alloy_primitives::{Address, Bytes, u64_to_address};
+use kona_executor::StatelessL2Builder;
+use kona_genesis::RollupConfig;
+use op_revm::{
+    DefaultOp, OpContext, OpEvm as RevmOpEvm, OpHaltReason, OpSpecId, OpTransaction,
+    OpTransactionError,
+};
+use revm::{
+    Context, Inspector,
+    context::{Evm as RevmEvm, FrameStack, TxEnv, result::EVMError},
+    handler::instructions::EthInstructions,
+    inspector::NoOpInspector,
+    precompile::{PrecompileResult, PrecompileOutput, Precompiles},
+};
+
 const MY_PRECOMPILE_ADDRESS: Address = u64_to_address(0xFF);
 
 fn my_precompile(input: &Bytes, gas_limit: u64) -> PrecompileResult {
    Ok(PrecompileOutput::new(50, "hello, world!".as_bytes().into()))
 }
 
-fn custom_handle_register<F, H>(
-    handler: &mut EvmHandler<'_, (), &mut State<&mut TrieDB<F, H>>>,
-) where
-   F: TrieProvider,
-   H: TrieHinter,
+#[derive(Debug, Clone)]
+pub struct CustomEvmFactory;
+
+impl EvmFactory for CustomEvmFactory {
+    type Evm<DB: Database, I: Inspector<OpContext<DB>>> = OpEvm<DB, I, CustomPrecompiles>;
+    type Context<DB: Database> = OpContext<DB>;
+    type Tx = OpTransaction<TxEnv>;
+    type Error<DBError: core::error::Error + Send + Sync + 'static> =
+        EVMError<DBError, OpTransactionError>;
+    type HaltReason = OpHaltReason;
+    type Spec = OpSpecId;
+    type Precompiles = CustomPrecompiles;
+
+    fn create_evm<DB: Database>(
+        &self,
+        db: DB,
+        input: EvmEnv<OpSpecId>,
+    ) -> Self::Evm<DB, NoOpInspector> {
+        let spec_id = *input.spec_id();
+        let ctx = Context::op().with_db(db).with_block(input.block_env).with_cfg(input.cfg_env);
+        
+        // Create custom precompiles with our added precompile
+        let mut precompiles = op_revm::precompiles::granite();
+        precompiles.insert(MY_PRECOMPILE_ADDRESS, my_precompile);
+        let custom_precompiles = CustomPrecompiles { precompiles };
+
+        let revm_evm = RevmOpEvm(RevmEvm {
+            ctx,
+            inspector: NoOpInspector {},
+            instruction: EthInstructions::new_mainnet(),
+            precompiles: custom_precompiles,
+            frame_stack: FrameStack::new(),
+        });
+
+        OpEvm::new(revm_evm, false)
+    }
+
+    fn create_evm_with_inspector<DB: Database, I: Inspector<Self::Context<DB>>>(
+        &self,
+        db: DB,
+        input: EvmEnv<OpSpecId>,
+        inspector: I,
+    ) -> Self::Evm<DB, I> {
+        let spec_id = *input.spec_id();
+        let ctx = Context::op().with_db(db).with_block(input.block_env).with_cfg(input.cfg_env);
+        
+        // Create custom precompiles with our added precompile
+        let mut precompiles = op_revm::precompiles::granite();
+        precompiles.insert(MY_PRECOMPILE_ADDRESS, my_precompile);
+        let custom_precompiles = CustomPrecompiles { precompiles };
+
+        let revm_evm = RevmOpEvm(RevmEvm {
+            ctx,
+            inspector,
+            instruction: EthInstructions::new_mainnet(),
+            precompiles: custom_precompiles,
+            frame_stack: FrameStack::new(),
+        });
+
+        OpEvm::new(revm_evm, true)
+    }
+}
+
+// Custom precompiles wrapper
+#[derive(Debug)]
+pub struct CustomPrecompiles {
+    precompiles: Precompiles,
+}
+
+impl<CTX> revm::handler::PrecompileProvider<CTX> for CustomPrecompiles
+where
+    CTX: revm::context::ContextTr<Cfg: revm::context::Cfg<Spec = OpSpecId>>,
 {
-   let spec_id = handler.cfg.spec_id;
+    type Output = revm::interpreter::InterpreterResult;
 
-   handler.pre_execution.load_precompiles = Arc::new(move || {
-      let mut ctx_precompiles = spec_to_generic!(spec_id, {
-         revm::optimism::load_precompiles::<SPEC, (), &mut State<&mut TrieDB<F, H>>>()
-      });
+    fn set_spec(&mut self, spec: OpSpecId) -> bool {
+        // Update precompiles based on spec if needed
+        false
+    }
 
-      let precompile = PrecompileWithAddress(
-         MY_PRECOMPILE_ADDRESS,
-         Precompile::Standard(my_precompile)
-      );
-      ctx_precompiles.extend([precompile]);
+    fn run(
+        &mut self,
+        _context: &mut CTX,
+        address: &Address,
+        inputs: &revm::interpreter::InputsImpl,
+        _is_static: bool,
+        gas_limit: u64,
+    ) -> Result<Option<Self::Output>, String> {
+        use revm::interpreter::{Gas, InstructionResult, InterpreterResult};
+        
+        let input = match &inputs.input {
+            revm::interpreter::CallInput::Bytes(bytes) => bytes.clone(),
+            revm::interpreter::CallInput::SharedBuffer(range) => {
+                // Handle shared buffer case - simplified for example
+                Bytes::new()
+            }
+        };
 
-      ctx_precompiles
-   });
+        if let Some(precompile) = self.precompiles.get(address) {
+            let result = (*precompile)(&input, gas_limit);
+            match result {
+                Ok(output) => Ok(Some(InterpreterResult {
+                    result: InstructionResult::Return,
+                    gas: Gas::new(gas_limit - output.gas_used),
+                    output: output.bytes,
+                })),
+                Err(_) => Ok(Some(InterpreterResult {
+                    result: InstructionResult::PrecompileError,
+                    gas: Gas::new(0),
+                    output: Bytes::new(),
+                })),
+            }
+        } else {
+            Ok(None)
+        }
+    }
 }
 
 // - snip -
@@ -44,12 +156,36 @@ fn custom_handle_register<F, H>(
 let cfg = RollupConfig::default();
 let provider = ...;
 let hinter = ...;
+let parent_header = ...;
 
-let executor = StatelessL2BlockExecutor::builder(&cfg, provider, hinter)
-   .with_parent_header(...)
-   .with_handle_register(custom_handle_register)
-   .build();
+let executor = StatelessL2Builder::new(
+    &cfg,
+    CustomEvmFactory,
+    provider,
+    hinter,
+    parent_header,
+);
 ```
+
+## Migration from the old API
+
+Prior to the integration of `alloy-evm`, `kona-executor` used a builder pattern with `StatelessL2BlockExecutorBuilder::with_handle_register` for EVM customization. The new approach using `EvmFactory` provides better composability and aligns with the broader Alloy ecosystem.
+
+### Key Changes:
+
+1. **Direct construction**: Use `StatelessL2Builder::new()` instead of a builder pattern
+2. **Factory-based customization**: Implement `EvmFactory` instead of registering handlers
+3. **Type safety**: The factory approach provides better compile-time guarantees
+4. **Ecosystem alignment**: Leverages the standard `alloy-evm` interfaces
+
+### Benefits:
+
+- **Composability**: Custom EVM factories can be easily shared and reused
+- **Flexibility**: Full control over EVM creation and configuration
+- **Performance**: Reduced indirection compared to the handler approach
+- **Maintainability**: Cleaner separation of concerns between execution and customization
+
+For more complex customizations involving multiple precompiles, custom opcodes, or specialized execution logic, refer to the [`FpvmOpEvmFactory`](https://github.com/op-rs/kona/blob/main/bin/client/src/fpvm_evm/factory.rs) implementation in the `kona-client` for a comprehensive example.
 
 [op-stack]: https://github.com/ethereum-optimism/optimism
 [op-program]: https://github.com/ethereum-optimism/optimism/tree/develop/op-program
@@ -63,6 +199,8 @@ let executor = StatelessL2BlockExecutor::builder(&cfg, provider, hinter)
 [l2-output-root]: https://specs.optimism.io/protocol/proposals.html#l2-output-commitment-construction
 [op-succinct]: https://github.com/succinctlabs/op-succinct
 [revm]: https://github.com/bluealloy/revm
+[alloy-evm]: https://github.com/alloy-rs/alloy/tree/main/crates/evm
+[evm-factory]: https://docs.rs/alloy-evm/latest/alloy_evm/trait.EvmFactory.html
 
 [kona]: https://github.com/op-rs/kona
 [issues]: https://github.com/op-rs/kona/issues


### PR DESCRIPTION
Align the “executor customization” section with the changes from PR #1400 (switch to alloy-evm for stateless block building).

close https://github.com/op-rs/kona/issues/1427
