### PR TITLE
feat(node/sequencer): spike attempt to unblock engine when building on a sequencer payload

### DIFF
--- a/crates/node/engine/src/lib.rs
+++ b/crates/node/engine/src/lib.rs
@@ -42,8 +42,8 @@ mod task_queue;
 pub use task_queue::{
     BuildTask, BuildTaskError, ConsolidateTask, ConsolidateTaskError, Engine, EngineBuildError,
     EngineResetError, EngineTask, EngineTaskError, EngineTaskErrorSeverity, EngineTaskErrors,
-    EngineTaskExt, FinalizeTask, FinalizeTaskError, InsertTask, InsertTaskError, SynchronizeTask,
-    SynchronizeTaskError,
+    EngineTaskExt, FinalizeTask, FinalizeTaskError, InsertTask, InsertTaskError, LastPayloadData,
+    SynchronizeTask, SynchronizeTaskError,
 };
 
 mod attributes;

--- a/crates/node/engine/src/task_queue/tasks/build/error.rs
+++ b/crates/node/engine/src/task_queue/tasks/build/error.rs
@@ -4,7 +4,7 @@ use crate::{
     EngineTaskError, InsertTaskError, SynchronizeTaskError,
     task_queue::tasks::task::EngineTaskErrorSeverity,
 };
-use alloy_rpc_types_engine::PayloadStatusEnum;
+use alloy_rpc_types_engine::{PayloadId, PayloadStatusEnum};
 use alloy_transport::{RpcError, TransportErrorKind};
 use kona_protocol::FromBlockError;
 use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
@@ -80,7 +80,10 @@ pub enum BuildTaskError {
     FromBlock(#[from] FromBlockError),
     /// Error sending the built payload envelope.
     #[error(transparent)]
-    MpscSend(#[from] Box<mpsc::error::SendError<OpExecutionPayloadEnvelope>>),
+    MpscSendEnvelope(#[from] Box<mpsc::error::SendError<OpExecutionPayloadEnvelope>>),
+    /// Error sending the built payload ID.
+    #[error(transparent)]
+    MpscSendId(#[from] Box<mpsc::error::SendError<PayloadId>>),
     /// The clock went backwards.
     #[error("The clock went backwards")]
     ClockWentBackwards,
@@ -114,7 +117,8 @@ impl EngineTaskError for BuildTaskError {
             Self::DepositOnlyPayloadReattemptFailed => EngineTaskErrorSeverity::Critical,
             Self::DepositOnlyPayloadFailed => EngineTaskErrorSeverity::Critical,
             Self::FromBlock(_) => EngineTaskErrorSeverity::Critical,
-            Self::MpscSend(_) => EngineTaskErrorSeverity::Critical,
+            Self::MpscSendEnvelope(_) => EngineTaskErrorSeverity::Critical,
+            Self::MpscSendId(_) => EngineTaskErrorSeverity::Critical,
             Self::ClockWentBackwards => EngineTaskErrorSeverity::Critical,
         }
     }

--- a/crates/node/engine/src/task_queue/tasks/build/mod.rs
+++ b/crates/node/engine/src/task_queue/tasks/build/mod.rs
@@ -1,7 +1,7 @@
 //! Task and its associated types for building and importing a new block.
 
 mod task;
-pub use task::BuildTask;
+pub use task::{BuildTask, LastPayloadData};
 
 mod error;
 pub use error::{BuildTaskError, EngineBuildError};

--- a/crates/node/engine/src/task_queue/tasks/consolidate/error.rs
+++ b/crates/node/engine/src/task_queue/tasks/consolidate/error.rs
@@ -21,6 +21,9 @@ pub enum ConsolidateTaskError {
     /// The consolidation forkchoice update call to the engine api failed.
     #[error(transparent)]
     ForkchoiceUpdateFailed(#[from] SynchronizeTaskError),
+    /// Failed to receive the built payload.
+    #[error("Failed to receive the built payload")]
+    FailedToReceiveBuiltPayload,
 }
 
 impl EngineTaskError for ConsolidateTaskError {
@@ -30,6 +33,7 @@ impl EngineTaskError for ConsolidateTaskError {
             Self::FailedToFetchUnsafeL2Block => EngineTaskErrorSeverity::Temporary,
             Self::BuildTaskFailed(inner) => inner.severity(),
             Self::ForkchoiceUpdateFailed(inner) => inner.severity(),
+            Self::FailedToReceiveBuiltPayload => EngineTaskErrorSeverity::Critical,
         }
     }
 }

--- a/crates/node/engine/src/task_queue/tasks/mod.rs
+++ b/crates/node/engine/src/task_queue/tasks/mod.rs
@@ -12,7 +12,7 @@ mod insert;
 pub use insert::{InsertTask, InsertTaskError};
 
 mod build;
-pub use build::{BuildTask, BuildTaskError, EngineBuildError};
+pub use build::{BuildTask, BuildTaskError, EngineBuildError, LastPayloadData};
 
 mod consolidate;
 pub use consolidate::{ConsolidateTask, ConsolidateTaskError};

--- a/crates/node/service/src/actors/engine/mod.rs
+++ b/crates/node/service/src/actors/engine/mod.rs
@@ -1,7 +1,7 @@
 //! The [`EngineActor`] and its components.
 
 mod actor;
-pub use actor::{EngineActor, EngineBuilder, EngineContext, EngineInboundData};
+pub use actor::{BuildRequest, EngineActor, EngineBuilder, EngineContext, EngineInboundData};
 
 mod error;
 pub use error::EngineError;

--- a/crates/node/service/src/actors/mod.rs
+++ b/crates/node/service/src/actors/mod.rs
@@ -7,7 +7,8 @@ pub use traits::{CancellableContext, NodeActor};
 
 mod engine;
 pub use engine::{
-    EngineActor, EngineBuilder, EngineContext, EngineError, EngineInboundData, L2Finalizer,
+    BuildRequest, EngineActor, EngineBuilder, EngineContext, EngineError, EngineInboundData,
+    L2Finalizer,
 };
 
 mod rpc;

--- a/crates/node/service/src/lib.rs
+++ b/crates/node/service/src/lib.rs
@@ -14,7 +14,7 @@ pub use service::{InteropMode, NodeMode, RollupNode, RollupNodeBuilder, RollupNo
 
 mod actors;
 pub use actors::{
-    AttributesBuilderConfig, CancellableContext, ConductorClient, ConductorError,
+    AttributesBuilderConfig, BuildRequest, CancellableContext, ConductorClient, ConductorError,
     DelayedL1OriginSelectorProvider, DerivationActor, DerivationBuilder, DerivationContext,
     DerivationError, DerivationInboundChannels, DerivationState, EngineActor, EngineBuilder,
     EngineContext, EngineError, EngineInboundData, InboundDerivationMessage, L1OriginSelector,


### PR DESCRIPTION
## Description

We are currently blocking the engine from processing other tasks when payloads are being built. Instead we may want to be able to let the EL build payloads in the background and process requests in the meantime.

The changes to get this working are not that big, but it seems there is some race condition between the l1 blocks and the sequencer which may cause issues.