### PR TITLE
chore(test): fixes pre-interop supervisor test

### DIFF
--- a/tests/supervisor/pre_interop/pre_test.go
+++ b/tests/supervisor/pre_interop/pre_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop"
@@ -21,87 +20,6 @@ import (
 	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/core/types"
 )
-
-func TestPreInteropComprehensive(gt *testing.T) {
-	gt.Skip()
-	t := devtest.ParallelT(gt)
-	sys := presets.NewSimpleInterop(t)
-
-	testPreInteropNoSyncStatus(t, sys)
-
-	testPreInteropCheckAccessList(t, sys)
-}
-
-func testPreInteropNoSyncStatus(t devtest.T, sys *presets.SimpleInterop) {
-	t.Logger().Info("Starting pre-interop no sync status test")
-	require := t.Require()
-
-	devtest.RunParallel(t, sys.L2Networks(), func(t devtest.T, net *dsl.L2Network) {
-		interopTime := net.Escape().ChainConfig().InteropTime
-		t.Require().NotNil(interopTime)
-
-		require.False(net.IsActivated(*interopTime), "Test requires pre-interop state")
-		t.Logger().Info("Timestamps", "interopTime", *interopTime, "now", time.Now().Unix())
-
-		_, err := sys.Supervisor.Escape().QueryAPI().SyncStatus(t.Ctx())
-		require.ErrorContains(err, "chain database is not initialized")
-	})
-	t.Logger().Info("Done pre-interop no sync status test")
-}
-
-func testPreInteropCheckAccessList(t devtest.T, sys *presets.SimpleInterop) {
-	t.Logger().Info("Starting pre-interop check access list test")
-	require := t.Require()
-
-	alice := sys.FunderA.NewFundedEOA(eth.OneHundredthEther)
-	bob := sys.FunderB.NewFundedEOA(eth.OneHundredthEther)
-
-	eventLoggerAddress := alice.DeployEventLogger()
-	sys.L2ChainB.CatchUpTo(sys.L2ChainA)
-
-	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-	_, initReceipt := alice.SendInitMessage(
-		interop.RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(3), rng.Intn(10)),
-	)
-
-	logToAccess := func(chainID eth.ChainID, log *types.Log, timestamp uint64) stypes.Access {
-		msgPayload := make([]byte, 0)
-		for _, topic := range log.Topics {
-			msgPayload = append(msgPayload, topic.Bytes()...)
-		}
-		msgPayload = append(msgPayload, log.Data...)
-
-		msgHash := crypto.Keccak256Hash(msgPayload)
-		args := stypes.ChecksumArgs{
-			BlockNumber: log.BlockNumber,
-			Timestamp:   timestamp,
-			LogIndex:    uint32(log.Index),
-			ChainID:     chainID,
-			LogHash:     stypes.PayloadHashToLogHash(msgHash, log.Address),
-		}
-		return args.Access()
-	}
-
-	blockRef := sys.L2ChainA.PublicRPC().BlockRefByNumber(initReceipt.BlockNumber.Uint64())
-
-	var accessEntries []stypes.Access
-	for _, evLog := range initReceipt.Logs {
-		accessEntries = append(accessEntries, logToAccess(alice.ChainID(), evLog, blockRef.Time))
-	}
-
-	sys.L2ChainB.WaitForBlock()
-
-	accessList := stypes.EncodeAccessList(accessEntries)
-	timestamp := uint64(time.Now().Unix())
-	ed := stypes.ExecutingDescriptor{
-		Timestamp: timestamp,
-		ChainID:   bob.ChainID(),
-	}
-
-	err := sys.Supervisor.Escape().QueryAPI().CheckAccessList(t.Ctx(), accessList, stypes.LocalUnsafe, ed)
-	require.Error(err, "CheckAccessList should fail before interop")
-	t.Logger().Info("Done pre-interop check access list test")
-}
 
 // Acceptance Test: https://github.com/ethereum-optimism/optimism/blob/develop/op-acceptance-tests/tests/interop/upgrade/pre_test.go
 func TestPreNoInbox(gt *testing.T) {


### PR DESCRIPTION
# Description

- Removes the duplicate test for pre-interop.
- This resolves issues with the sysgo test run, which appears to have a limitation on how many tests can run in parallel. Since the pre-interop test is timing-dependent, it’s important that it executes first.

Closes #2465 