### PR TITLE
chore: fix spelling issues

### DIFF
--- a/crates/supervisor/core/src/reorg/task.rs
+++ b/crates/supervisor/core/src/reorg/task.rs
@@ -69,7 +69,7 @@ where
         info!(
             target: "supervisor::reorg_handler",
             chain_id = %self.chain_id,
-            "Processed reorged successfully"
+            "Reorg processed successfully"
         );
         Ok(())
     }
@@ -86,7 +86,7 @@ where
         );
 
         // Call the rewinder to handle the DB rewinding
-        let derived_block_rewounded =
+        let derived_block_rewound =
             self.db.rewind_to_source(&rewind_target_source.id()).inspect_err(|err| {
                 warn!(
                     target: "supervisor::reorg_handler::db",
@@ -96,7 +96,7 @@ where
                 );
             })?;
 
-        Ok(RewoundState { source: rewind_target_source, derived: derived_block_rewounded })
+        Ok(RewoundState { source: rewind_target_source, derived: derived_block_rewound })
     }
 
     async fn rewind_to_activation_block(&self) -> Result<Option<RewoundState>, ReorgHandlerError> {


### PR DESCRIPTION
Processed reorged successfully  -> Reorg processed successfully
derived_block_rewounded -> derived_block_rewound,