### PR TITLE
feat: add inflight task metrics to engine queue

### DIFF
--- a/crates/node/engine/src/metrics/mod.rs
+++ b/crates/node/engine/src/metrics/mod.rs
@@ -72,6 +72,10 @@ impl Metrics {
     /// Identifier for the counter that tracks the number of times the engine has been reset.
     pub const ENGINE_RESET_COUNT: &str = "kona_node_engine_reset_count";
 
+    /// Identifier for the gauge that tracks the number of inflight engine tasks by type.
+    /// This metric helps monitor task queue backlog and identify bottlenecks.
+    pub const ENGINE_INFLIGHT_TASKS: &str = "kona_node_engine_inflight_tasks";
+
     /// Initializes metrics for the engine.
     ///
     /// This does two things:
@@ -106,6 +110,13 @@ impl Metrics {
             metrics::Unit::Count,
             "Engine reset count"
         );
+
+        // Engine inflight tasks gauge
+        metrics::describe_gauge!(
+            Self::ENGINE_INFLIGHT_TASKS,
+            metrics::Unit::Count,
+            "Number of inflight engine tasks by type"
+        );
     }
 
     /// Initializes metrics to `0` so they can be queried immediately by consumers of prometheus
@@ -125,5 +136,11 @@ impl Metrics {
 
         // Engine reset count
         kona_macros::set!(counter, Self::ENGINE_RESET_COUNT, 0);
+
+        // Engine inflight tasks (initialize all task types to 0)
+        kona_macros::set!(gauge, Self::ENGINE_INFLIGHT_TASKS, "type", Self::INSERT_TASK_LABEL, 0.0);
+        kona_macros::set!(gauge, Self::ENGINE_INFLIGHT_TASKS, "type", Self::CONSOLIDATE_TASK_LABEL, 0.0);
+        kona_macros::set!(gauge, Self::ENGINE_INFLIGHT_TASKS, "type", Self::BUILD_TASK_LABEL, 0.0);
+        kona_macros::set!(gauge, Self::ENGINE_INFLIGHT_TASKS, "type", Self::FINALIZE_TASK_LABEL, 0.0);
     }
 }

--- a/crates/node/engine/src/task_queue/core.rs
+++ b/crates/node/engine/src/task_queue/core.rs
@@ -3,9 +3,11 @@
 use super::EngineTaskExt;
 use crate::{
     EngineClient, EngineState, EngineSyncStateUpdate, EngineTask, EngineTaskError,
-    EngineTaskErrorSeverity, Metrics, SynchronizeTask, SynchronizeTaskError,
+    EngineTaskErrorSeverity, SynchronizeTask, SynchronizeTaskError,
     task_queue::EngineTaskErrors,
 };
+#[cfg(feature = "metrics")]
+use crate::Metrics;
 use alloy_provider::Provider;
 use alloy_rpc_types_eth::Transaction;
 use kona_genesis::{RollupConfig, SystemConfig};
@@ -69,6 +71,10 @@ impl Engine {
     /// Enqueues a new [`EngineTask`] for execution.
     /// Updates the queue length and notifies listeners of the change.
     pub fn enqueue(&mut self, task: EngineTask) {
+        // Increment the inflight task metric for this task type
+        #[cfg(feature = "metrics")]
+        metrics::gauge!(Metrics::ENGINE_INFLIGHT_TASKS, "type" => task.task_metrics_label()).increment(1.0);
+        
         self.tasks.push(task);
         self.task_queue_length.send_replace(self.tasks.len());
     }
@@ -146,6 +152,15 @@ impl Engine {
 
     /// Clears the task queue.
     pub fn clear(&mut self) {
+        // Decrement metrics for each task being cleared
+        #[cfg(feature = "metrics")]
+        {
+            while let Some(task) = self.tasks.pop() {
+                metrics::gauge!(Metrics::ENGINE_INFLIGHT_TASKS, "type" => task.task_metrics_label()).decrement(1.0);
+            }
+        }
+        
+        #[cfg(not(feature = "metrics"))]
         self.tasks.clear();
     }
 
@@ -162,7 +177,15 @@ impl Engine {
             self.state_sender.send_replace(self.state);
 
             // Pop the task from the queue now that it's been executed.
-            self.tasks.pop();
+            let completed_task = self.tasks.pop().expect("Task should exist since we peeked it");
+            
+            // Decrement the inflight task metric for this task type
+            #[cfg(feature = "metrics")]
+            metrics::gauge!(Metrics::ENGINE_INFLIGHT_TASKS, "type" => completed_task.task_metrics_label()).decrement(1.0);
+            
+            // Avoid unused variable warning when metrics feature is disabled
+            #[cfg(not(feature = "metrics"))]
+            let _ = completed_task;
 
             self.task_queue_length.send_replace(self.tasks.len());
         }

--- a/crates/node/engine/src/task_queue/tasks/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/task.rs
@@ -109,7 +109,9 @@ impl EngineTask {
         Ok(())
     }
 
-    const fn task_metrics_label(&self) -> &'static str {
+    /// Returns the metrics label for this task type.
+    /// Used for categorizing inflight task metrics by task type.
+    pub const fn task_metrics_label(&self) -> &'static str {
         match self {
             Self::Insert(_) => crate::Metrics::INSERT_TASK_LABEL,
             Self::Consolidate(_) => crate::Metrics::CONSOLIDATE_TASK_LABEL,


### PR DESCRIPTION
 track inflight tasks by type in task queue

- Add ENGINE_INFLIGHT_TASKS gauge metric with task type labels
- Increment on enqueue, decrement on completion and queue clear
- Conditionally compiled with 'metrics' feature

Seeing occasional slowdowns during high load periods
but couldn't tell if it was build tasks backing up or derivation
falling behind. This gives us per-task-type visibility to identify
which part of the pipeline is the bottleneck.