### PR TITLE
feat(node/test): add long running background tests

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,2 +1,3 @@
 devnets/specs/*
 optimism-package
+kona-test-logs

--- a/tests/justfile
+++ b/tests/justfile
@@ -1,4 +1,5 @@
 SOURCE := source_directory()
+CURRENT_DIR := `pwd`
 DEFAULT_DEVNET_PATH := source_directory() + "/devnets/simple-kona.yaml"
 DEFAULT_OP_PACKAGE_PATH := "github.com/ethpandaops/optimism-package@998796c0f3bb478d63d729e65f0b76e24112e00d"
 
@@ -16,7 +17,7 @@ build-devnet BINARY:
 # The CUSTOM_DEVNET_PATH variable can be used to specify a custom devnet path.
 # If not specified, the default devnet path will be used.
 # The ENCLAVE variable can be used to specify a custom enclave name to use for kurtosis.
-devnet DEVNET OP_PACKAGE_PATH="" CUSTOM_DEVNET_PATH="":
+devnet DEVNET CUSTOM_DEVNET_PATH="":
   #!/bin/bash
   export DEVNET="--enclave {{DEVNET}}"
 
@@ -25,13 +26,7 @@ devnet DEVNET OP_PACKAGE_PATH="" CUSTOM_DEVNET_PATH="":
     export DEVNET_PATH="{{SOURCE}}/devnets/{{DEVNET}}.yaml"
   fi
 
-  export OP_PACKAGE_PATH="{{OP_PACKAGE_PATH}}"
-  if [ -z "{{OP_PACKAGE_PATH}}" ]; then
-    export OP_PACKAGE_PATH="{{DEFAULT_OP_PACKAGE_PATH}}"
-  # if the OP_PACKAGE_PATH is a local path, use mise to install it
-  elif [ -d "{{OP_PACKAGE_PATH}}" ]; then
-    cd $OP_PACKAGE_PATH && mise install
-  fi
+  export OP_PACKAGE_PATH="{{DEFAULT_OP_PACKAGE_PATH}}"
 
   # Run the kurtosis test
   kurtosis run $OP_PACKAGE_PATH --args-file $DEVNET_PATH $DEVNET
@@ -100,11 +95,37 @@ test-e2e-kurtosis DEVNET GO_PKG_NAME="" FILTER="" DEVNET_CUSTOM_PATH="" :
     # Run the test with count=1 to avoid caching the test results.
     cd {{SOURCE}} && go test -count=1 -timeout 40m -v ./$GO_PKG_NAME $FILTER 
 
-build-deploy-devnet BINARY DEVNET OP_PACKAGE_PATH="": (build-devnet BINARY) (devnet DEVNET OP_PACKAGE_PATH)
-  
-deploy-devnet-and-test-e2e DEVNET GO_PKG_NAME OP_PACKAGE_PATH="": (devnet DEVNET OP_PACKAGE_PATH) (test-e2e-kurtosis DEVNET GO_PKG_NAME)
+long-running-test DEVNET FILTER DEVNET_CUSTOM_PATH="" OUTPUT_LOGS_DIR="":
+    #!/bin/bash
+    if ! [ -z "{{FILTER}}" ]; then
+        export FILTER="-run {{FILTER}}"
+    fi
+    
+    export OP_TESTLOG_FILE_LOGGER_OUTDIR="{{OUTPUT_LOGS_DIR}}"
+    if [ -z "{{OUTPUT_LOGS_DIR}}" ]; then
+        export OP_TESTLOG_FILE_LOGGER_OUTDIR="{{CURRENT_DIR}}/kona-test-logs"
+    fi
 
-build-devnet-and-test-e2e BINARY DEVNET GO_PKG_NAME OP_PACKAGE_PATH="": (build-devnet BINARY) (deploy-devnet-and-test-e2e DEVNET GO_PKG_NAME OP_PACKAGE_PATH)
+    mkdir -p $OP_TESTLOG_FILE_LOGGER_OUTDIR
+
+    export DEVNET_CUSTOM_PATH="{{DEVNET_CUSTOM_PATH}}"
+    if [ -z "{{DEVNET_CUSTOM_PATH}}" ]; then
+        export DEVNET_CUSTOM_PATH="{{SOURCE}}/devnets/{{DEVNET}}.yaml"
+    fi
+
+    export OP_DEPLOYER_ARTIFACTS="{{SOURCE}}/artifacts"
+    export DEVNET_ENV_URL="ktnative://{{DEVNET}}$DEVNET_CUSTOM_PATH"
+    export DISABLE_OP_E2E_LEGACY=true
+    export DEVSTACK_ORCHESTRATOR=sysext
+
+    # Run the test with count=1 to avoid caching the test results.
+    cd {{SOURCE}} && go test -count=1 -timeout 0 -v ./node/long-running $FILTER 
+
+build-deploy-devnet BINARY DEVNET CUSTOM_DEVNET_PATH="": (build-devnet BINARY) (devnet DEVNET CUSTOM_DEVNET_PATH)
+  
+deploy-devnet-and-test-e2e DEVNET GO_PKG_NAME CUSTOM_DEVNET_PATH="": (devnet DEVNET CUSTOM_DEVNET_PATH) (test-e2e-kurtosis DEVNET GO_PKG_NAME)
+
+build-devnet-and-test-e2e BINARY DEVNET GO_PKG_NAME CUSTOM_DEVNET_PATH="": (build-devnet BINARY) (deploy-devnet-and-test-e2e DEVNET GO_PKG_NAME CUSTOM_DEVNET_PATH)
 
 # Updates the devnet with the latest local changes. This is useful to
 # rapidly iterate on the devnet without having to redeploy the whole kurtosis network.

--- a/tests/node/long-running/README.md
+++ b/tests/node/long-running/README.md
@@ -1,0 +1,5 @@
+## Long-running system tests
+
+Those tests are meant to be *long-running*, meaning that they're not going to stop unless user input is received.
+
+These tests are useful to simulate realistic network conditions in kurtosis networks.

--- a/tests/node/long-running/init_test.go
+++ b/tests/node/long-running/init_test.go
@@ -1,0 +1,23 @@
+package node
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	node_utils "github.com/op-rs/kona/node/utils"
+)
+
+var (
+	num_threads           = flag.Int("num-threads", 10, "number of threads to use for the test")
+	percentageNewAccounts = flag.Int("percentage-new-accounts", 20, "percentage of new accounts to produce transactions for")
+	fundAmount            = flag.Int("fund-amount", 10, "eth amount to fund each new account with")
+	initNumAccounts       = flag.Int("init-num-accounts", 10, "initial number of accounts to fund")
+)
+
+// TestMain creates the test-setups against the shared backend
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	presets.DoMain(m, node_utils.WithMixedOpKona(0, 1, 0, 2))
+}

--- a/tests/node/long-running/tx_producer_test.go
+++ b/tests/node/long-running/tx_producer_test.go
@@ -1,0 +1,182 @@
+package node
+
+import (
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	node_utils "github.com/op-rs/kona/node/utils"
+)
+
+// Define a global atomic counter for the number of transactions produced.
+var (
+	txProduced = atomic.Int64{}
+)
+
+type TxProducer struct {
+	t        devtest.T
+	out      *node_utils.MixedOpKonaPreset
+	accounts []*dsl.EOA
+	// Unique identifier for the producer/receiver pair
+	idx         int
+	pending_txs chan<- *txplan.PlannedTx
+}
+
+type TxReceiver struct {
+	t   devtest.T
+	out *node_utils.MixedOpKonaPreset
+	// Unique identifier for the producer/receiver pair
+	idx int
+	txs <-chan *txplan.PlannedTx
+}
+
+func (tp *TxProducer) NewFunder() *dsl.Funder {
+	return dsl.NewFunder(tp.out.Wallet, tp.out.Faucet, tp.out.L2ELSequencerNodes()[0])
+}
+
+func (tp *TxProducer) NewAccounts(count int, fundAmount eth.ETH) []*dsl.EOA {
+	new_accounts := tp.NewFunder().NewFundedEOAs(count, fundAmount)
+	tp.accounts = append(tp.accounts, new_accounts...)
+
+	return new_accounts
+}
+
+func (tp *TxProducer) NewAccount(fundAmount eth.ETH) *dsl.EOA {
+	new_account := tp.NewFunder().NewFundedEOA(fundAmount)
+	tp.accounts = append(tp.accounts, new_account)
+
+	return new_account
+}
+
+func NewTxProducer(t devtest.T, out *node_utils.MixedOpKonaPreset, txs chan<- *txplan.PlannedTx, idx int) *TxProducer {
+	return &TxProducer{
+		out:         out,
+		t:           t,
+		accounts:    []*dsl.EOA{},
+		pending_txs: txs,
+		idx:         idx,
+	}
+}
+
+func (tp *TxProducer) Start(wg *sync.WaitGroup) {
+	// Initialize the accounts
+	tp.NewAccounts(*initNumAccounts, eth.Ether(uint64(*fundAmount)))
+	tp.t.Logf("%d accounts initialized", *initNumAccounts)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			var toAccount *dsl.EOA
+			if rand.Intn(100) < *percentageNewAccounts {
+				toAccount = tp.NewAccount(eth.Ether(uint64(*fundAmount)))
+			} else {
+				toAccount = tp.accounts[rand.Intn(len(tp.accounts))]
+			}
+
+			fromAccount := tp.accounts[rand.Intn(len(tp.accounts))]
+
+			if fromAccount.GetBalance().Lt(eth.HalfEther) {
+				tp.NewFunder().FundAtLeast(fromAccount, eth.HalfEther)
+			}
+
+			amount := fromAccount.GetBalance().Mul(uint64(rand.Intn(100))).Div(100)
+
+			tp.t.Logf("producer %d: producing transaction from %s to %s with amount %s", tp.idx, fromAccount.Address(), toAccount.Address(), amount)
+
+			new_planned_txs := fromAccount.Transact(fromAccount.PlanTransfer(toAccount.Address(), amount))
+
+			tp.t.Logf("producer %d: transaction produced with hash: %s", tp.idx, new_planned_txs.Signed.Value().Hash())
+
+			tp.pending_txs <- new_planned_txs
+		}
+	}()
+}
+
+func NewTxReceiver(t devtest.T, out *node_utils.MixedOpKonaPreset, txs <-chan *txplan.PlannedTx, idx int) *TxReceiver {
+	return &TxReceiver{
+		t:   t,
+		txs: txs,
+		idx: idx,
+		out: out,
+	}
+}
+
+func (tr *TxReceiver) processTx(tx *txplan.PlannedTx) {
+	inclusionBlock, err := tx.IncludedBlock.Eval(tr.t.Ctx())
+	if err != nil {
+		tr.t.Errorf("producer %d: transaction (hash %s) receipt not found. error: %s", tr.idx, tx.Signed.Value().Hash(), err)
+		return
+	}
+
+	_, err = tx.Success.Eval(tr.t.Ctx())
+	if err != nil {
+		tr.t.Errorf("producer %d: transaction (hash %s) failed. error: %s", tr.idx, tx.Signed.Value().Hash(), err)
+	}
+
+	// Ensure the block containing the transaction has propagated to the rest of the network.
+	for _, node := range tr.out.L2ELNodes() {
+		block := node.WaitForBlockNumber(inclusionBlock.Number)
+		blockID := block.ID()
+
+		// It's possible that the block has already been included, and `WaitForBlockNumber` returns a block
+		// at a taller height.
+		if block.Number > inclusionBlock.Number {
+			blockID = node.BlockRefByNumber(inclusionBlock.Number).ID()
+		}
+
+		// Ensure that the block ID matches the expected inclusion block hash.
+		if blockID.Hash != inclusionBlock.Hash {
+			tr.t.Errorf("producer %d: transaction (hash %s) not included in block %d with hash %s.", tr.idx, tx.Signed.Value().Hash(), inclusionBlock.Number, inclusionBlock.Hash)
+		}
+	}
+
+	txProduced.Add(1)
+	tr.t.Logf("producer %d: transaction (hash %s) included in block %d with hash %s. %d transactions produced.", tr.idx, tx.Signed.Value().Hash(), inclusionBlock.Number, inclusionBlock.Hash, txProduced.Load())
+}
+
+func (tr *TxReceiver) Start(wg *sync.WaitGroup) {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-tr.t.Ctx().Done():
+				tr.t.Logf("receiver context done")
+				return
+			case tx := <-tr.txs:
+				tr.processTx(tx)
+			}
+		}
+	}()
+
+}
+
+// Produces transactions in a loop. Ensures that...
+// - transactions get included
+// - transactions get gossiped
+func TestTxProducer(gt *testing.T) {
+	t := devtest.SerialT(gt)
+
+	out := node_utils.NewMixedOpKona(t)
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < *num_threads; i++ {
+		txs := make(chan *txplan.PlannedTx)
+		txProducer := NewTxProducer(t, out, txs, i)
+		txReceiver := NewTxReceiver(t, out, txs, i)
+
+		txProducer.Start(&wg)
+		txReceiver.Start(&wg)
+	}
+
+	wg.Wait()
+
+	t.Logf("producer and receiver threads finished")
+}


### PR DESCRIPTION
## Description

This PR adds a test and an associated just recipe that can act as a background transaction generator to simulate network load under realistic conditions