### PR TITLE
fix: avoid redundant hash computation in block_info_and_transactions_by_hash

### DIFF
--- a/crates/providers/providers-alloy/src/chain_provider.rs
+++ b/crates/providers/providers-alloy/src/chain_provider.rs
@@ -255,7 +255,7 @@ impl ChainProvider for AlloyChainProvider {
         self.verify_header_hash(&block.header, hash)?;
 
         let block_info = BlockInfo {
-            hash: block.header.hash_slow(),
+            hash, // Use the already verified hash instead of recomputing
             number: block.header.number,
             parent_hash: block.header.parent_hash,
             timestamp: block.header.timestamp,


### PR DESCRIPTION
Remove unnecessary `hash_slow()` call when creating BlockInfo in the alloy chain provider.

Since we already verify the header hash matches the requested hash in `verify_header_hash()`, we can directly use the input hash parameter instead of recomputing it.