### PR TITLE
Build for generic CPU instead of native CPU

### DIFF
--- a/docker/apps/kona_app_generic.dockerfile
+++ b/docker/apps/kona_app_generic.dockerfile
@@ -72,13 +72,13 @@ FROM build-entrypoint AS builder
 COPY --from=planner /app/recipe.json recipe.json
 
 # Build dependencies - this is the caching Docker layer!
-RUN RUSTFLAGS="-C target-cpu=native" cargo chef cook --bin "${BIN_TARGET}" --profile "${BUILD_PROFILE}" --recipe-path recipe.json
+RUN RUSTFLAGS="-C target-cpu=generic" cargo chef cook --bin "${BIN_TARGET}" --profile "${BUILD_PROFILE}" --recipe-path recipe.json
 
 # Build application. This step will systematically trigger a cache invalidation if the source code changes.
 COPY --from=app-setup kona .
 # Build the application binary on the selected tag. Since we build the external dependencies in the previous step,
 # this step will reuse the target directory from the previous step.
-RUN RUSTFLAGS="-C target-cpu=native" cargo build --bin "${BIN_TARGET}" --profile "${BUILD_PROFILE}"
+RUN RUSTFLAGS="-C target-cpu=generic" cargo build --bin "${BIN_TARGET}" --profile "${BUILD_PROFILE}"
 
 # Export stage
 FROM ubuntu:22.04 AS export-stage


### PR DESCRIPTION
I'd like to test this to see if this fixes building images for macs. The arm64 build tries to use the `cntw` instruction which is part of the [SVE instruction set](https://developer.arm.com/documentation/ddi0602/2025-06/SVE-Instructions) but apple does not support the full SVE extension.

Fixes #2815