### PR TITLE
fix(ci/proof): fix prestate proof job

### DIFF
--- a/.github/workflows/publish_artifacts.yaml
+++ b/.github/workflows/publish_artifacts.yaml
@@ -62,7 +62,7 @@ jobs:
                INFO_FILE=$(mktemp) 
 
                # Upload the git commit info for each prestate since this won't be recorded in releases.json 
-               (echo "Commit=${{ github.ref_name }}" && echo "Prestate: ${PRESTATE_HASH}") > "${INFO_FILE}" 
+               (echo "Commit=${{ github.sha }}" && echo "Prestate: ${PRESTATE_HASH}") > "${INFO_FILE}" 
 
                gsutil cp "${INFO_FILE}" "gs://kona-proof-prestates/${{ matrix.kind }}/${BRANCH_NAME}-${{ matrix.version }}-prestate.bin.gz.txt" 
                echo "Published commit hash data successfully" # So we know if any uploads worked 


### PR DESCRIPTION
## Description

Fixes the CI job to publish proof prestates. We were not properly storing the branch's commit hash