### PR TITLE
fix: add validation for file descriptors in unsafe I/O code

### DIFF
--- a/crates/proof/std-fpvm/src/io.rs
+++ b/crates/proof/std-fpvm/src/io.rs
@@ -19,19 +19,31 @@ cfg_if! {
 
         impl BasicKernelInterface for NativeClientIO {
             fn write(fd: FileDescriptor, buf: &[u8]) -> IOResult<usize> {
+                // Validate file descriptor before using it
+                if (fd as i32) < 0 {
+                    return Err(IOError(-9)); // EBADF
+                }
+                
                 unsafe {
                     let mut file = File::from_raw_fd(fd as i32);
-                    file.write_all(buf).map_err(|_| IOError(-9))?;
+                    let result = file.write_all(buf).map_err(|_| IOError(-9));
                     std::mem::forget(file);
+                    result?;
                     Ok(buf.len())
                 }
             }
 
             fn read(fd: FileDescriptor, buf: &mut [u8]) -> IOResult<usize> {
+                // Validate file descriptor before using it
+                if (fd as i32) < 0 {
+                    return Err(IOError(-9)); // EBADF
+                }
+                
                 unsafe {
                     let mut file = File::from_raw_fd(fd as i32);
-                    file.read_exact(buf).map_err(|_| IOError(-9))?;
+                    let result = file.read_exact(buf).map_err(|_| IOError(-9));
                     std::mem::forget(file);
+                    result?;
                     Ok(buf.len())
                 }
             }


### PR DESCRIPTION
Improve safety of unsafe file operations by validating file descriptors before use.

- Add validation to prevent negative file descriptor usage
- Return EBADF error for invalid file descriptors
- Maintain existing error handling while improving safety