### PR TITLE
chore: fix typo in Isthmus L1 block info comment

### DIFF
--- a/crates/protocol/protocol/src/info/isthmus.rs
+++ b/crates/protocol/protocol/src/info/isthmus.rs
@@ -1,4 +1,4 @@
-//! Isthmus L1 Bl{format, ock Info transaction types.
+//! Isthmus L1 Block Info transaction types.
 
 use alloc::vec::Vec;
 use alloy_primitives::{Address, B256, Bytes, U256};


### PR DESCRIPTION
Corrected a formatting artifact in the module documentation comment that had "Bl{format, ock" instead of "Block". 

This was likely caused by an editor formatting issue that inserted unwanted text into the comment.
