### PR TITLE
chore(node): fix missing semicolons in return statements

### DIFF
--- a/bin/node/src/commands/node.rs
+++ b/bin/node/src/commands/node.rs
@@ -242,7 +242,7 @@ impl NodeCommand {
                         error!(
                             "Ensure that the JWT secret file specified is correct (by default it is `jwt.hex` in the current directory)"
                         );
-                        return Err(JwtValidationError::InvalidSignature.into())
+                        return Err(JwtValidationError::InvalidSignature.into());
                     }
                     Err(JwtValidationError::CapabilityExchange(e.to_string()).into())
                 }

--- a/crates/node/engine/src/attributes.rs
+++ b/crates/node/engine/src/attributes.rs
@@ -159,7 +159,7 @@ impl AttributesMatch {
             if &attr_tx != block_tx.inner.inner.inner() {
                 warn!(target: "engine", ?attr_tx, ?block_tx, "Transaction mismatch in derived attributes");
                 return AttributesMismatch::TransactionContent(attr_tx.tx_hash(), block_tx.tx_hash())
-                    .into()
+                    .into();
             }
         }
 
@@ -244,7 +244,7 @@ impl AttributesMatch {
                 BaseFeeParams { max_change_denominator: ad, elasticity_multiplier: ae },
                 BaseFeeParams { max_change_denominator: bd, elasticity_multiplier: be },
             )
-            .into()
+            .into();
         }
 
         Self::Match
@@ -290,7 +290,7 @@ impl AttributesMatch {
 
         // Check transactions
         if let mismatch @ Self::Mismatch(_) = Self::check_transactions(attributes_txs, block) {
-            return mismatch
+            return mismatch;
         }
 
         let Some(gas_limit) = attributes.inner().gas_limit else {

--- a/crates/node/gossip/src/driver.rs
+++ b/crates/node/gossip/src/driver.rs
@@ -392,7 +392,7 @@ where
     pub fn handle_event(&mut self, event: SwarmEvent<Event>) -> Option<OpNetworkPayloadEnvelope> {
         match event {
             SwarmEvent::Behaviour(behavior_event) => {
-                return self.handle_gossip_event(behavior_event)
+                return self.handle_gossip_event(behavior_event);
             }
             SwarmEvent::ConnectionEstablished { peer_id, .. } => {
                 let peer_count = self.swarm.connected_peers().count();


### PR DESCRIPTION
Added missing semicolons to return statements across multiple files. Found some instances where return statements were missing trailing semicolons, causing potential formatting inconsistencies.