### PR TITLE
remove redundant String import from gossip RPC types

### DIFF
--- a/crates/node/gossip/src/rpc/types.rs
+++ b/crates/node/gossip/src/rpc/types.rs
@@ -2,7 +2,6 @@
 
 use core::net::IpAddr;
 use derive_more::Display;
-use std::string::String;
 
 use alloy_primitives::{ChainId, map::HashMap};
 


### PR DESCRIPTION
Remove unnecessary `use std::string::String;` import since String is available in the Rust prelude by default