### PR TITLE
rpc: add spec link for supervisor_localSafe method

### DIFF
--- a/crates/supervisor/rpc/src/jsonrpsee.rs
+++ b/crates/supervisor/rpc/src/jsonrpsee.rs
@@ -41,8 +41,9 @@ pub trait SupervisorApi {
 
     /// Returns the [`LocalSafe`] block for given chain.
     ///
+    /// Spec: <https://github.com/ethereum-optimism/specs/blob/main/specs/interop/supervisor.md#supervisor_localsafe>
+    ///
     /// [`LocalSafe`]: SafetyLevel::LocalSafe
-    // todo: link to spec after PR(https://github.com/ethereum-optimism/specs/pull/753) is merged
     #[method(name = "localSafe")]
     async fn local_safe(&self, chain_id: HexStringU64) -> RpcResult<DerivedIdPair>;
 


### PR DESCRIPTION
Replace TODO comment with proper spec link for the `localSafe` method in supervisor RPC API.

The spec link follows the same pattern as other supervisor methods and points to the official interop supervisor documentation.