### PR TITLE
docs: clean up main documentation title

### DIFF
--- a/docs/docs/pages/intro/overview.mdx
+++ b/docs/docs/pages/intro/overview.mdx
@@ -1,6 +1,6 @@
 import { Callout } from 'vocs/components'
 
-# Kona  [Documentation for Kona users and developers]
+# Kona
 
 Kona is an implementation of the [OP Stack][op-stack] written in Rust,
 designed to be modular and extensible. `no_std` support is prioritized


### PR DESCRIPTION
The bracketed comment `[Documentation for Kona users and developers]` in the title appears to be leftover from drafting and should not be part of the final documentation header.

If I'm mistaken, please close the PR, thanks