### PR TITLE
fix(node/engine): fix new payload error type

### DIFF
--- a/crates/node/engine/src/task_queue/tasks/insert/error.rs
+++ b/crates/node/engine/src/task_queue/tasks/insert/error.rs
@@ -40,7 +40,7 @@ impl EngineTaskError for InsertTaskError {
         match self {
             Self::FromBlockError(_) => EngineTaskErrorSeverity::Critical,
             Self::InsertFailed(_) => EngineTaskErrorSeverity::Temporary,
-            Self::UnexpectedPayloadStatus(_) => EngineTaskErrorSeverity::Critical,
+            Self::UnexpectedPayloadStatus(_) => EngineTaskErrorSeverity::Temporary,
             Self::L2BlockInfoConstruction(_) => EngineTaskErrorSeverity::Critical,
             Self::InconsistentForkchoiceState => EngineTaskErrorSeverity::Reset,
             Self::ForkchoiceUpdateFailed(inner) => inner.severity(),


### PR DESCRIPTION
## Description

When the engine tries to insert a payload and receives an unexpected status, it should gracefully recover instead of panicking. This falls in line with the level of the errors returned from the `BuildTask` and the `SynchronizeTask`