### PR TITLE
Update setup-go to v6

### DIFF
--- a/.github/workflows/node_e2e_sysgo_tests.yaml
+++ b/.github/workflows/node_e2e_sysgo_tests.yaml
@@ -38,7 +38,7 @@ jobs:
       - uses: jdx/mise-action@v3       # installs Mise + runs `mise install`
 
       - name: Setup Go 1.24.3
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           # Semantic version range syntax or exact version of Go
           go-version: '1.24.3'
@@ -105,7 +105,7 @@ jobs:
       - uses: jdx/mise-action@v3       # installs Mise + runs `mise install`
 
       - name: Setup Go 1.24.3
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           # Semantic version range syntax or exact version of Go
           go-version: '1.24.3'

--- a/.github/workflows/proof.yaml
+++ b/.github/workflows/proof.yaml
@@ -35,7 +35,7 @@ jobs:
           prefix-key: ${{ matrix.kind }}
       - uses: taiki-e/install-action@cargo-llvm-cov
       - name: Setup Go toolchain
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.22.7"
           cache-dependency-path: |
@@ -92,14 +92,14 @@ jobs:
           git clone https://github.com/ethereum-optimism/optimism.git
       - name: Setup Go toolchain (asterisc cache)
         if: "contains(matrix.target, 'asterisc')"
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.23.8"
           cache-dependency-path: |
             asterisc/go.sum
       - name: Setup Go toolchain (cannon cache)
         if: "contains(matrix.target, 'cannon')"
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.23.8"
           cache-dependency-path: |

--- a/.github/workflows/supervisor_e2e_kurtosis.yaml
+++ b/.github/workflows/supervisor_e2e_kurtosis.yaml
@@ -42,7 +42,7 @@ jobs:
           toolchain: 1.88
       
       - name: Setup Go 1.24.3
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           # Semantic version range syntax or exact version of Go
           go-version: '1.24.3'

--- a/.github/workflows/supervisor_e2e_sysgo.yaml
+++ b/.github/workflows/supervisor_e2e_sysgo.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: jdx/mise-action@v3       # installs Mise + runs `mise install`
 
       - name: Setup Go 1.24.3
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           # Semantic version range syntax or exact version of Go
           go-version: '1.24.3'


### PR DESCRIPTION
Replaced actions/setup-go@v5 with @v6 in all workflows to use the latest stable version.

Reason:https://github.com/actions/setup-go/releases/tag/v6.0.0