### PR TITLE
feat(blob/verification): manually compute blob commitment and verify commitment integrity.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5135,6 +5135,7 @@ dependencies = [
  "alloy-transport",
  "alloy-transport-http",
  "async-trait",
+ "c-kzg",
  "http-body-util",
  "kona-derive",
  "kona-genesis",

--- a/bin/client/src/single.rs
+++ b/bin/client/src/single.rs
@@ -148,6 +148,7 @@ where
             target: "client",
             number = safe_head.block_info.number,
             output_root = ?output_root,
+            claimed_output_root = ?boot.claimed_l2_output_root,
             "Failed to validate L2 block",
         );
         return Err(FaultProofProgramError::InvalidClaim(output_root, boot.claimed_l2_output_root));

--- a/bin/host/src/interop/handler.rs
+++ b/bin/host/src/interop/handler.rs
@@ -8,7 +8,7 @@ use crate::{
 use alloy_consensus::{Header, Sealed};
 use alloy_eips::{
     eip2718::Encodable2718,
-    eip4844::{FIELD_ELEMENTS_PER_BLOB, IndexedBlobHash},
+    eip4844::{BlobTransactionSidecarItem, FIELD_ELEMENTS_PER_BLOB, IndexedBlobHash},
 };
 use alloy_op_evm::OpEvmFactory;
 use alloy_primitives::{Address, B256, Bytes, keccak256};
@@ -107,13 +107,20 @@ impl HintHandler for InteropHintHandler {
                 // Fetch the blob sidecar from the blob provider.
                 let mut sidecars = providers
                     .blobs
-                    .fetch_filtered_sidecars(&partial_block_ref, &[indexed_hash])
+                    .fetch_filtered_blob_sidecars(&partial_block_ref, &[indexed_hash])
                     .await
                     .map_err(|e| anyhow!("Failed to fetch blob sidecars: {e}"))?;
+
                 if sidecars.len() != 1 {
                     anyhow::bail!("Expected 1 sidecar, got {}", sidecars.len());
                 }
-                let sidecar = sidecars.remove(0);
+
+                let BlobTransactionSidecarItem {
+                    blob,
+                    kzg_proof: proof,
+                    kzg_commitment: commitment,
+                    ..
+                } = sidecars.pop().expect("Expected 1 sidecar");
 
                 // Acquire a lock on the key-value store and set the preimages.
                 let mut kv_lock = kv.write().await;
@@ -121,14 +128,14 @@ impl HintHandler for InteropHintHandler {
                 // Set the preimage for the blob commitment.
                 kv_lock.set(
                     PreimageKey::new(*hash, PreimageKeyType::Sha256).into(),
-                    sidecar.kzg_commitment.to_vec(),
+                    commitment.to_vec(),
                 )?;
 
                 // Write all the field elements to the key-value store. There should be 4096.
                 // The preimage oracle key for each field element is the keccak256 hash of
                 // `abi.encodePacked(sidecar.KZGCommitment, bytes32(ROOTS_OF_UNITY[i]))`.
                 let mut blob_key = [0u8; 80];
-                blob_key[..48].copy_from_slice(sidecar.kzg_commitment.as_ref());
+                blob_key[..48].copy_from_slice(commitment.as_ref());
                 for i in 0..FIELD_ELEMENTS_PER_BLOB {
                     blob_key[48..].copy_from_slice(
                         ROOTS_OF_UNITY[i as usize].into_bigint().to_bytes_be().as_ref(),
@@ -139,7 +146,7 @@ impl HintHandler for InteropHintHandler {
                         .set(PreimageKey::new_keccak256(*blob_key_hash).into(), blob_key.into())?;
                     kv_lock.set(
                         PreimageKey::new(*blob_key_hash, PreimageKeyType::Blob).into(),
-                        sidecar.blob[(i as usize) << 5..(i as usize + 1) << 5].to_vec(),
+                        blob[(i as usize) << 5..(i as usize + 1) << 5].to_vec(),
                     )?;
                 }
 
@@ -152,7 +159,7 @@ impl HintHandler for InteropHintHandler {
                 kv_lock.set(PreimageKey::new_keccak256(*blob_key_hash).into(), blob_key.into())?;
                 kv_lock.set(
                     PreimageKey::new(*blob_key_hash, PreimageKeyType::Blob).into(),
-                    sidecar.kzg_proof.to_vec(),
+                    proof.to_vec(),
                 )?;
             }
             HintType::L1Precompile => {

--- a/bin/host/src/single/handler.rs
+++ b/bin/host/src/single/handler.rs
@@ -7,7 +7,7 @@ use crate::{
 use alloy_consensus::Header;
 use alloy_eips::{
     eip2718::Encodable2718,
-    eip4844::{FIELD_ELEMENTS_PER_BLOB, IndexedBlobHash},
+    eip4844::{BlobTransactionSidecarItem, FIELD_ELEMENTS_PER_BLOB, IndexedBlobHash},
 };
 use alloy_primitives::{Address, B256, Bytes, keccak256};
 use alloy_provider::Provider;
@@ -87,16 +87,21 @@ impl HintHandler for SingleChainHintHandler {
                 let partial_block_ref = BlockInfo { timestamp, ..Default::default() };
                 let indexed_hash = IndexedBlobHash { index, hash };
 
-                // Fetch the blob sidecar from the blob provider.
-                let mut sidecars = providers
+                // Fetch the blobs from the blob provider.
+                let mut blobs = providers
                     .blobs
-                    .fetch_filtered_sidecars(&partial_block_ref, &[indexed_hash])
+                    .fetch_filtered_blob_sidecars(&partial_block_ref, &[indexed_hash])
                     .await
                     .map_err(|e| anyhow!("Failed to fetch blob sidecars: {e}"))?;
-                if sidecars.len() != 1 {
-                    anyhow::bail!("Expected 1 sidecar, got {}", sidecars.len());
+                if blobs.len() != 1 {
+                    anyhow::bail!("Expected 1 blob, got {}", blobs.len());
                 }
-                let sidecar = sidecars.remove(0);
+                let BlobTransactionSidecarItem {
+                    blob,
+                    kzg_proof: proof,
+                    kzg_commitment: commitment,
+                    ..
+                } = blobs.pop().expect("Expected 1 blob");
 
                 // Acquire a lock on the key-value store and set the preimages.
                 let mut kv_lock = kv.write().await;
@@ -104,14 +109,14 @@ impl HintHandler for SingleChainHintHandler {
                 // Set the preimage for the blob commitment.
                 kv_lock.set(
                     PreimageKey::new(*hash, PreimageKeyType::Sha256).into(),
-                    sidecar.kzg_commitment.to_vec(),
+                    commitment.to_vec(),
                 )?;
 
                 // Write all the field elements to the key-value store. There should be 4096.
                 // The preimage oracle key for each field element is the keccak256 hash of
                 // `abi.encodePacked(sidecar.KZGCommitment, bytes32(ROOTS_OF_UNITY[i]))`.
                 let mut blob_key = [0u8; 80];
-                blob_key[..48].copy_from_slice(sidecar.kzg_commitment.as_ref());
+                blob_key[..48].copy_from_slice(commitment.as_ref());
                 for i in 0..FIELD_ELEMENTS_PER_BLOB {
                     blob_key[48..].copy_from_slice(
                         ROOTS_OF_UNITY[i as usize].into_bigint().to_bytes_be().as_ref(),
@@ -122,7 +127,7 @@ impl HintHandler for SingleChainHintHandler {
                         .set(PreimageKey::new_keccak256(*blob_key_hash).into(), blob_key.into())?;
                     kv_lock.set(
                         PreimageKey::new(*blob_key_hash, PreimageKeyType::Blob).into(),
-                        sidecar.blob[(i as usize) << 5..(i as usize + 1) << 5].to_vec(),
+                        blob[(i as usize) << 5..(i as usize + 1) << 5].to_vec(),
                     )?;
                 }
 
@@ -135,7 +140,7 @@ impl HintHandler for SingleChainHintHandler {
                 kv_lock.set(PreimageKey::new_keccak256(*blob_key_hash).into(), blob_key.into())?;
                 kv_lock.set(
                     PreimageKey::new(*blob_key_hash, PreimageKeyType::Blob).into(),
-                    sidecar.kzg_proof.to_vec(),
+                    proof.to_vec(),
                 )?;
             }
             HintType::L1Precompile => {

--- a/crates/proof/preimage/src/errors.rs
+++ b/crates/proof/preimage/src/errors.rs
@@ -19,6 +19,9 @@ pub enum PreimageOracleError {
     /// Key not found.
     #[error("Key not found.")]
     KeyNotFound,
+    /// Timeout while waiting for preimage.
+    #[error("Timeout while waiting for preimage.")]
+    Timeout,
     /// Buffer length mismatch.
     #[error("Buffer length mismatch. Expected {0}, got {1}.")]
     BufferLengthMismatch(usize, usize),

--- a/crates/proof/proof/src/l1/blob_provider.rs
+++ b/crates/proof/proof/src/l1/blob_provider.rs
@@ -89,7 +89,7 @@ impl<T: CommsClient> OracleBlobProvider<T> {
 impl<T: CommsClient + Sync + Send> BlobProvider for OracleBlobProvider<T> {
     type Error = OracleProviderError;
 
-    async fn get_blobs(
+    async fn get_and_validate_blobs(
         &mut self,
         block_ref: &BlockInfo,
         blob_hashes: &[IndexedBlobHash],

--- a/crates/protocol/derive/src/sources/blobs.rs
+++ b/crates/protocol/derive/src/sources/blobs.rs
@@ -137,10 +137,13 @@ where
             return Ok(());
         }
 
-        let blobs = self.blob_fetcher.get_blobs(block_ref, &blob_hashes).await.map_err(|e| {
-            warn!(target: "blob_source", "Failed to fetch blobs: {e}");
-            BlobProviderError::Backend(e.to_string())
-        })?;
+        let blobs =
+            self.blob_fetcher.get_and_validate_blobs(block_ref, &blob_hashes).await.map_err(
+                |e| {
+                    warn!(target: "blob_source", "Failed to fetch blobs: {e}");
+                    BlobProviderError::Backend(e.to_string())
+                },
+            )?;
 
         // Fill the blob pointers.
         let mut blob_index = 0;

--- a/crates/protocol/derive/src/test_utils/blob_provider.rs
+++ b/crates/protocol/derive/src/test_utils/blob_provider.rs
@@ -32,7 +32,7 @@ impl TestBlobProvider {
 impl BlobProvider for TestBlobProvider {
     type Error = BlobProviderError;
 
-    async fn get_blobs(
+    async fn get_and_validate_blobs(
         &mut self,
         _block_ref: &BlockInfo,
         blob_hashes: &[IndexedBlobHash],

--- a/crates/protocol/derive/src/traits/data_sources.rs
+++ b/crates/protocol/derive/src/traits/data_sources.rs
@@ -16,7 +16,7 @@ pub trait BlobProvider {
     type Error: Display + ToString + Into<PipelineErrorKind>;
 
     /// Fetches blobs for a given block ref and the blob hashes.
-    async fn get_blobs(
+    async fn get_and_validate_blobs(
         &mut self,
         block_ref: &BlockInfo,
         blob_hashes: &[IndexedBlobHash],

--- a/crates/providers/providers-alloy/Cargo.toml
+++ b/crates/providers/providers-alloy/Cargo.toml
@@ -47,6 +47,8 @@ reqwest = { workspace = true, features = ["json"] }
 tower.workspace = true
 http-body-util.workspace = true
 
+c-kzg.workspace = true
+
 # `metrics` feature
 metrics = { workspace = true, optional = true }
 

--- a/crates/providers/providers-alloy/src/beacon_client.rs
+++ b/crates/providers/providers-alloy/src/beacon_client.rs
@@ -2,11 +2,12 @@
 
 #[cfg(feature = "metrics")]
 use crate::Metrics;
-use alloy_eips::eip4844::IndexedBlobHash;
-use alloy_rpc_types_beacon::sidecar::{BeaconBlobBundle, BlobData};
+use alloy_consensus::Blob;
+use alloy_eips::eip4844::{IndexedBlobHash, deserialize_blob};
+use alloy_rpc_types_beacon::sidecar::BeaconBlobBundle;
 use async_trait::async_trait;
 use reqwest::Client;
-use std::{boxed::Box, format, string::String, vec::Vec};
+use std::{boxed::Box, format, ops::Deref, string::String, vec::Vec};
 
 /// The config spec engine api method.
 const SPEC_METHOD: &str = "eth/v1/config/spec";
@@ -15,7 +16,7 @@ const SPEC_METHOD: &str = "eth/v1/config/spec";
 const GENESIS_METHOD: &str = "eth/v1/beacon/genesis";
 
 /// The blob sidecars engine api method prefix.
-const SIDECARS_METHOD_PREFIX: &str = "eth/v1/beacon/blob_sidecars";
+const SIDECARS_METHOD_PREFIX_DEPRECATED: &str = "eth/v1/beacon/blob_sidecars";
 
 /// A reduced genesis data.
 #[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -75,14 +76,13 @@ pub trait BeaconClient {
     /// Returns the beacon genesis.
     async fn beacon_genesis(&self) -> Result<APIGenesisResponse, Self::Error>;
 
-    /// Fetches blob sidecars that were confirmed in the specified L1 block with the given indexed
-    /// hashes. Order of the returned sidecars is guaranteed to be that of the hashes. Blob data is
-    /// not checked for validity.
-    async fn beacon_blob_side_cars(
+    /// Fetches blobs that were confirmed in the specified L1 block with the given slot.
+    /// Blob data is not checked for validity.
+    async fn filtered_beacon_blobs(
         &self,
         slot: u64,
-        hashes: &[IndexedBlobHash],
-    ) -> Result<Vec<BlobData>, Self::Error>;
+        blob_hashes: &[IndexedBlobHash],
+    ) -> Result<Vec<BoxedBlobWithIndex>, Self::Error>;
 }
 
 /// An online implementation of the [BeaconClient] trait.
@@ -102,6 +102,44 @@ impl OnlineBeaconClient {
             base.remove(base.len() - 1);
         }
         Self { base, inner: Client::new() }
+    }
+}
+
+/// A boxed blob. This is used to deserialize the blobs endpoint response.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct BoxedBlob {
+    /// The blob data.
+    #[serde(deserialize_with = "deserialize_blob")]
+    pub blob: Box<Blob>,
+}
+
+/// A boxed blob with index.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BoxedBlobWithIndex {
+    /// The index of the blob.
+    pub index: u64,
+    /// The blob data.
+    pub blob: Box<Blob>,
+}
+
+impl Deref for BoxedBlob {
+    type Target = Blob;
+
+    fn deref(&self) -> &Self::Target {
+        &self.blob
+    }
+}
+
+/// A blobs bundle. This is used to deserialize the blobs endpoint response.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+struct BlobsBundle {
+    pub data: Vec<BoxedBlob>,
+}
+
+impl From<BeaconBlobBundle> for BlobsBundle {
+    fn from(value: BeaconBlobBundle) -> Self {
+        let blobs = value.data.into_iter().map(|blob| BoxedBlob { blob: blob.blob }).collect();
+        Self { data: blobs }
     }
 }
 
@@ -143,40 +181,30 @@ impl BeaconClient for OnlineBeaconClient {
         result
     }
 
-    async fn beacon_blob_side_cars(
+    async fn filtered_beacon_blobs(
         &self,
         slot: u64,
-        hashes: &[IndexedBlobHash],
-    ) -> Result<Vec<BlobData>, Self::Error> {
+        blob_hashes: &[IndexedBlobHash],
+    ) -> Result<Vec<BoxedBlobWithIndex>, Self::Error> {
         kona_macros::inc!(gauge, Metrics::BEACON_CLIENT_REQUESTS, "method" => "blob_sidecars");
 
-        let result = async {
-            let raw_response = self
-                .inner
-                .get(format!("{}/{}/{}", self.base, SIDECARS_METHOD_PREFIX, slot))
-                .send()
-                .await?;
-            let raw_response = raw_response.json::<BeaconBlobBundle>().await?;
+        let blob_indexes = blob_hashes.iter().map(|blob| blob.index).collect::<Vec<_>>();
 
-            // Filter the sidecars by the hashes, in-order.
-            let mut sidecars = Vec::with_capacity(hashes.len());
-            hashes.iter().for_each(|hash| {
-                if let Some(sidecar) =
-                    raw_response.data.iter().find(|sidecar| sidecar.index == hash.index)
-                {
-                    sidecars.push(sidecar.clone());
-                }
-            });
+        let raw_response = self
+            .inner
+            .get(format!("{}/{}/{}", self.base, SIDECARS_METHOD_PREFIX_DEPRECATED, slot))
+            .send()
+            .await?;
 
-            Ok(sidecars)
-        }
-        .await;
-
-        #[cfg(feature = "metrics")]
-        if result.is_err() {
-            kona_macros::inc!(gauge, Metrics::BEACON_CLIENT_ERRORS, "method" => "blob_sidecars");
-        }
-
-        result
+        Ok(raw_response
+            .json::<BeaconBlobBundle>()
+            .await?
+            .into_iter()
+            .filter_map(|blob| {
+                blob_indexes
+                    .contains(&blob.index)
+                    .then_some(BoxedBlobWithIndex { index: blob.index, blob: blob.blob })
+            })
+            .collect::<Vec<_>>())
     }
 }

--- a/crates/providers/providers-alloy/src/lib.rs
+++ b/crates/providers/providers-alloy/src/lib.rs
@@ -11,12 +11,12 @@ pub use metrics::Metrics;
 
 mod beacon_client;
 pub use beacon_client::{
-    APIConfigResponse, APIGenesisResponse, BeaconClient, OnlineBeaconClient, ReducedConfigData,
-    ReducedGenesisData,
+    APIConfigResponse, APIGenesisResponse, BeaconClient, BoxedBlob, BoxedBlobWithIndex,
+    OnlineBeaconClient, ReducedConfigData, ReducedGenesisData,
 };
 
 mod blobs;
-pub use blobs::{BlobSidecarProvider, OnlineBlobProvider};
+pub use blobs::OnlineBlobProvider;
 
 mod chain_provider;
 pub use chain_provider::{AlloyChainProvider, AlloyChainProviderError};

--- a/tests/justfile
+++ b/tests/justfile
@@ -189,7 +189,7 @@ action-tests-single test_name='Test_ProgramAction' *args='':
   # https://github.com/gotestyourself/gotestsum/blob/b4b13345fee56744d80016a20b760d3599c13504/testjson/format.go#L442-L444
   echo "Running action tests for the client program on the native target"
 
-  cd {{SOURCE}}/optimism/op-e2e/actions/proofs && GITHUB_ACTIONS=false gotestsum --format=testname -- -run "{{test_name}}" {{args}} -count=1 ./...
+  cd {{SOURCE}}/optimism/op-e2e/actions/proofs && GITHUB_ACTIONS=false gotestsum --format=testname -- -timeout 60m -run "{{test_name}}" {{args}} -count=1 ./...
 
 # Run action tests for the interop client program on the native target
 action-tests-interop test_name='TestInteropFaultProofs' *args='':


### PR DESCRIPTION
## Description

Manually computes blob commitment instead of relying on the deprecated `sidecar_blobs` endpoint for Fusaka. Update action tests. Relevant PR in monorepo https://github.com/ethereum-optimism/optimism/pull/17725/files