### PR TITLE
chore(release): update submodule to enable permissions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/ethereum-optimism/optimism
 [submodule "tests/reth"]
 	path = tests/reth
-	url = git@github.com:paradigmxyz/reth.git
+	url = git@github.com:theochap/reth.git


### PR DESCRIPTION
## Description

Github didn't have permissions to automatically build a docker image with a reth submodule. I am using a fork instead to try and fix it