### PR TITLE
feat(protocol): brotli compression using a shared buffer

### DIFF
--- a/crates/batcher/comp/src/brotli.rs
+++ b/crates/batcher/comp/src/brotli.rs
@@ -158,8 +158,7 @@ impl CompressorWriter for BrotliCompressor {
 
     fn close(&mut self) -> CompressorResult<()> {
         if let Some(writer) = self.writer.take() {
-            let mut buf = writer.into_inner();
-            buf.flush().map_err(|_| CompressorError::Brotli)?;
+            drop(writer);
         }
         self.closed = true;
         Ok(())

--- a/crates/batcher/comp/src/lib.rs
+++ b/crates/batcher/comp/src/lib.rs
@@ -27,7 +27,7 @@ pub use zlib::{ZlibCompressor, compress_zlib, decompress_zlib};
 #[cfg(feature = "std")]
 mod brotli;
 #[cfg(feature = "std")]
-pub use brotli::{BrotliCompressionError, BrotliCompressor, BrotliLevel, compress_brotli};
+pub use brotli::{BrotliCompressionError, BrotliCompressor, BrotliLevel};
 
 #[cfg(feature = "std")]
 mod variant;

--- a/crates/batcher/comp/src/mod.rs
+++ b/crates/batcher/comp/src/mod.rs
@@ -16,7 +16,7 @@ pub use zlib::{ZlibCompressor, compress_zlib, decompress_zlib};
 
 mod brotli;
 #[cfg(feature = "std")]
-pub use brotli::{BrotliCompressionError, compress_brotli, BrotliCompressor};
+pub use brotli::{BrotliCompressionError, BrotliCompressor};
 
 mod traits;
 pub use traits::{ChannelCompressor, CompressorWriter};


### PR DESCRIPTION
fixes #1081

#1133 almost had it right; I was unnecessarily flushing and then dropping the writer which was missing out writing the last compressed bit into the buffer, and failing tests.