### PR TITLE
refactor(supervisor/core): DerivationOriginUpdate

### DIFF
--- a/crates/protocol/interop/src/event.rs
+++ b/crates/protocol/interop/src/event.rs
@@ -35,7 +35,7 @@ pub struct ManagedEvent {
 
     /// Signals that an L2 block is now local-safe because of the given L1 traversal.
     /// This would be accompanied with [`Self::derivation_update`].
-    pub derivation_origin_update: Option<BlockInfo>,
+    pub derivation_current_l1_update: Option<DerivedRefPair>,
 }
 
 impl core::fmt::Display for ManagedEvent {
@@ -56,8 +56,8 @@ impl core::fmt::Display for ManagedEvent {
         if let Some(ref replacement) = self.replace_block {
             parts.push(format!("replace_block: {replacement}"));
         }
-        if let Some(ref origin) = self.derivation_origin_update {
-            parts.push(format!("derivation_origin_update: {origin}"));
+        if let Some(ref pair) = self.derivation_current_l1_update {
+            parts.push(format!("derivation_origin_update: {pair}"));
         }
 
         if parts.is_empty() { write!(f, "none") } else { write!(f, "{}", parts.join(", ")) }

--- a/crates/supervisor/core/src/chain_processor/chain.rs
+++ b/crates/supervisor/core/src/chain_processor/chain.rs
@@ -114,8 +114,8 @@ where
             ChainEvent::DerivedBlock { derived_ref_pair } => {
                 self.safe_handler.handle(derived_ref_pair, &mut self.state).await
             }
-            ChainEvent::DerivationOriginUpdate { origin } => {
-                self.origin_handler.handle(origin, &mut self.state).await
+            ChainEvent::DerivationCurrentL1Update { derived_ref_pair } => {
+                self.origin_handler.handle(derived_ref_pair.source, &mut self.state).await
             }
             ChainEvent::InvalidateBlock { block } => {
                 self.invalidation_handler.handle(block, &mut self.state).await

--- a/crates/supervisor/core/src/event/chain.rs
+++ b/crates/supervisor/core/src/event/chain.rs
@@ -21,9 +21,9 @@ pub enum ChainEvent {
     },
 
     /// A derivation origin update event, indicating that the origin for derived blocks has changed.
-    DerivationOriginUpdate {
-        /// The [`BlockInfo`] of the block that is the new derivation origin.
-        origin: BlockInfo,
+    DerivationCurrentL1Update {
+        /// The [`DerivedRefPair`] containing the Newly observed L1 and its L2's BlockRef.
+        derived_ref_pair: DerivedRefPair,
     },
 
     /// An invalidate Block event, indicating that a block has been invalidated.

--- a/crates/supervisor/core/src/syncnode/traits.rs
+++ b/crates/supervisor/core/src/syncnode/traits.rs
@@ -37,7 +37,7 @@ pub trait SubscriptionHandler: Send + Sync {
     /// Handles the derivation origin update event from the node.
     async fn handle_derivation_origin_update(
         &self,
-        origin: &BlockInfo,
+        origin: &DerivedRefPair,
     ) -> Result<(), ManagedNodeError>;
 }
 

--- a/crates/supervisor/service/src/actors/node.rs
+++ b/crates/supervisor/service/src/actors/node.rs
@@ -204,7 +204,7 @@ async fn handle_subscription_event<N: SubscriptionHandler>(handler: &Arc<N>, eve
     }
 
     if let Some(derived_ref_pair) = &event.derivation_update {
-        if event.derivation_origin_update.is_none() {
+        if event.derivation_current_l1_update.is_none() {
             if let Err(err) = handler.handle_derivation_update(derived_ref_pair).await {
                 warn!(
                     target: "supervisor::syncnode",
@@ -216,7 +216,7 @@ async fn handle_subscription_event<N: SubscriptionHandler>(handler: &Arc<N>, eve
         }
     }
 
-    if let Some(origin) = &event.derivation_origin_update {
+    if let Some(origin) = &event.derivation_current_l1_update {
         if let Err(err) = handler.handle_derivation_origin_update(origin).await {
             warn!(
                 target: "supervisor::syncnode",
@@ -296,7 +296,7 @@ mod tests {
             async fn handle_unsafe_block(&self, block: &BlockInfo) -> Result<(), ManagedNodeError>;
             async fn handle_derivation_update(&self, derived_ref_pair: &DerivedRefPair) -> Result<(), ManagedNodeError>;
             async fn handle_replace_block(&self, replacement: &BlockReplacement) -> Result<(), ManagedNodeError>;
-            async fn handle_derivation_origin_update(&self, origin: &BlockInfo) -> Result<(), ManagedNodeError>;
+            async fn handle_derivation_origin_update(&self, origin: &DerivedRefPair) -> Result<(), ManagedNodeError>;
         }
     }
 


### PR DESCRIPTION
Fixes #2252

- Renames `DerivationOriginUpdate` to `DerivationCurrentL1Update`
- Updates the event to hold a `DerivedRefPair` instead of a `BlockInfo`