### PR TITLE
docs: fix broken links

### DIFF
--- a/docs/docs/pages/sdk/proof/exec-ext.mdx
+++ b/docs/docs/pages/sdk/proof/exec-ext.mdx
@@ -199,8 +199,8 @@ For more complex customizations involving multiple precompiles, custom opcodes, 
 [l2-output-root]: https://specs.optimism.io/protocol/proposals.html#l2-output-commitment-construction
 [op-succinct]: https://github.com/succinctlabs/op-succinct
 [revm]: https://github.com/bluealloy/revm
-[alloy-evm]: https://github.com/alloy-rs/alloy/tree/main/crates/evm
-[evm-factory]: https://docs.rs/alloy-evm/latest/alloy_evm/trait.EvmFactory.html
+[alloy-evm]: https://github.com/alloy-rs/evm
+[evm-factory]: https://docs.rs/alloy-evm/latest/alloy_evm/eth/struct.EthEvmFactory.html
 
 [kona]: https://github.com/op-rs/kona
 [issues]: https://github.com/op-rs/kona/issues


### PR DESCRIPTION
https://github.com/alloy-rs/alloy/tree/main/crates/evm - old link
https://github.com/alloy-rs/evm - actual link

https://docs.rs/alloy-evm/latest/alloy_evm/trait.EvmFactory.html - old link
https://docs.rs/alloy-evm/latest/alloy_evm/eth/struct.EthEvmFactory.html - actual link