### PR TITLE
chore: Remove stale TODOs in derivation_provider

### DIFF
--- a/crates/supervisor/storage/src/providers/derivation_provider.rs
+++ b/crates/supervisor/storage/src/providers/derivation_provider.rs
@@ -136,8 +136,6 @@ where
               source_block_number,
               "source block not found"
             );
-
-            // todo: replace with a more specific error
             EntryNotFoundError::SourceBlockNotFound(source_block_number)
         })?)
     }
@@ -298,7 +296,6 @@ where
         &self,
         incoming_pair: DerivedRefPair,
     ) -> Result<(), StorageError> {
-        // todo: use cursor to get the last block(performance improvement)
         let latest_derivation_state = match self.latest_derivation_state() {
             Ok(pair) => pair,
             Err(StorageError::EntryNotFound(_)) => {


### PR DESCRIPTION
- Delete outdated TODO about “more specific error” in get_block_traversal (already returns EntryNotFoundError::SourceBlockNotFound).
- Remove misleading performance TODO in save_derived_block (latest_derivation_state already uses cursor.last() and provides required state).