### PR TITLE
Remove duplicate assertion for l2-block-data in HintType from_str test

### DIFF
--- a/crates/proof/proof-interop/src/hint.rs
+++ b/crates/proof/proof-interop/src/hint.rs
@@ -138,7 +138,6 @@ mod test {
             HintType::from_str("l2-account-storage-proof").unwrap(),
             HintType::L2AccountStorageProof
         );
-        assert_eq!(HintType::from_str("l2-block-data").unwrap(), HintType::L2BlockData);
         assert_eq!(HintType::from_str("l2-payload-witness").unwrap(), HintType::L2PayloadWitness);
         match HintType::from_str("invalid") {
             Ok(_) => {


### PR DESCRIPTION

### Summary
Remove a duplicate test assertion for the "l2-block-data" case in `test_hint_type_from_str` within `crates/proof/proof-interop/src/hint.rs`.

### Rationale
The duplicate assertion did not increase coverage and could confuse future maintenance. Keeping a single assertion preserves behavior while simplifying the test.

### Changes
- Delete the repeated line asserting `HintType::from_str("l2-block-data")` equals `HintType::L2BlockData`.

