### PR TITLE
fix(hardforks/bpo): add bpo activation timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b16ee6b2c7d39da592d30a5f9607a83f50ee5ec2a2c301746cc81e91891f4ca"
+checksum = "cd78f8e1c274581c663d7949c863b10c8b015e48f2774a4b8e8efc82d43ea95c"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -365,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-op-hardforks"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8bb236fc008fd3b83b2792e30ae79617a99ffc4c3f584f0c9b4ce0a2da52de"
+checksum = "777759314eaa14fb125c1deba5cbc06eee953bbe77bc7cc60b4e8685bd03479e"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",
@@ -2546,7 +2546,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2797,7 +2797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6433,7 +6433,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8653,7 +8653,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9498,7 +9498,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10479,7 +10479,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,7 @@ alloy-chains = { version = "0.2.7", default-features = false }
 alloy-network = { version = "1.0.38", default-features = false }
 alloy-genesis = { version = "1.0.38", default-features = false }
 alloy-provider = { version = "1.0.38", default-features = false }
-alloy-hardforks = { version = "0.4.0", default-features = false }
+alloy-hardforks = { version = "0.4.1", default-features = false }
 alloy-sol-types = { version = "1.3.1", default-features = false }
 alloy-consensus = { version = "1.0.38", default-features = false }
 alloy-transport = { version = "1.0.38", default-features = false }
@@ -151,7 +151,7 @@ alloy-network-primitives = { version = "1.0.38", default-features = false }
 # OP Alloy
 op-alloy-network = { version = "0.21.0", default-features = false }
 op-alloy-provider = { version = "0.21.0", default-features = false }
-alloy-op-hardforks = { version = "0.4.0", default-features = false }
+alloy-op-hardforks = { version = "0.4.1", default-features = false }
 op-alloy-consensus = { version = "0.21.0", default-features = false }
 op-alloy-rpc-types = { version = "0.21.0", default-features = false }
 op-alloy-rpc-jsonrpsee = { version = "0.21.0", default-features = false }

--- a/crates/protocol/registry/src/l1/mod.rs
+++ b/crates/protocol/registry/src/l1/mod.rs
@@ -62,11 +62,26 @@ impl L1Config {
 
     fn default_blob_schedule() -> BTreeMap<String, BlobParams> {
         BTreeMap::from([
-            (alloy_hardforks::EthereumHardfork::Cancun.name().to_string(), BlobParams::cancun()),
-            (alloy_hardforks::EthereumHardfork::Prague.name().to_string(), BlobParams::prague()),
-            (alloy_hardforks::EthereumHardfork::Osaka.name().to_string(), BlobParams::osaka()),
-            (alloy_hardforks::EthereumHardfork::Bpo1.name().to_string(), BlobParams::bpo1()),
-            (alloy_hardforks::EthereumHardfork::Bpo2.name().to_string(), BlobParams::bpo2()),
+            (
+                alloy_hardforks::EthereumHardfork::Cancun.name().to_string().to_lowercase(),
+                BlobParams::cancun(),
+            ),
+            (
+                alloy_hardforks::EthereumHardfork::Prague.name().to_string().to_lowercase(),
+                BlobParams::prague(),
+            ),
+            (
+                alloy_hardforks::EthereumHardfork::Osaka.name().to_string().to_lowercase(),
+                BlobParams::osaka(),
+            ),
+            (
+                alloy_hardforks::EthereumHardfork::Bpo1.name().to_string().to_lowercase(),
+                BlobParams::bpo1(),
+            ),
+            (
+                alloy_hardforks::EthereumHardfork::Bpo2.name().to_string().to_lowercase(),
+                BlobParams::bpo2(),
+            ),
         ])
     }
 
@@ -258,6 +273,8 @@ impl From<serde_json::Error> for L1GenesisGetterErrors {
 
 #[cfg(test)]
 mod tests {
+    use alloy_hardforks::EthereumHardfork;
+
     use super::*;
 
     #[test]
@@ -273,5 +290,61 @@ mod tests {
 
         let l1_config = L1Config::get_l1_genesis(1000000).unwrap_err();
         assert!(matches!(l1_config, L1GenesisGetterErrors::ChainIDDoesNotExist(1000000)));
+    }
+
+    #[test]
+    fn test_get_l1_bpo_sepolia() {
+        /// BPO1 hardfork activation timestamp
+        const SEPOLIA_BPO1_TIMESTAMP: u64 = 1761017184;
+
+        /// BPO2 hardfork activation timestamp
+        const SEPOLIA_BPO2_TIMESTAMP: u64 = 1761607008;
+
+        let sepolia = L1Config::sepolia();
+
+        assert_eq!(sepolia.blob_schedule.len(), 5);
+        assert_eq!(
+            sepolia.blob_schedule.get(&EthereumHardfork::Bpo1.name().to_lowercase()).unwrap(),
+            &BlobParams::bpo1()
+        );
+        assert_eq!(
+            sepolia.blob_schedule.get(&EthereumHardfork::Bpo2.name().to_lowercase()).unwrap(),
+            &BlobParams::bpo2()
+        );
+
+        let blob_schedule = sepolia.blob_schedule_blob_params();
+        assert_eq!(blob_schedule.scheduled.len(), 2);
+        assert_eq!(blob_schedule.scheduled[0].0, SEPOLIA_BPO1_TIMESTAMP);
+        assert_eq!(blob_schedule.scheduled[1].0, SEPOLIA_BPO2_TIMESTAMP);
+        assert_eq!(blob_schedule.scheduled[0].1, BlobParams::bpo1());
+        assert_eq!(blob_schedule.scheduled[1].1, BlobParams::bpo2());
+    }
+
+    #[test]
+    fn test_get_l1_bpo_holesky() {
+        /// BPO1 hardfork activation timestamp
+        const HOLESKY_BPO1_TIMESTAMP: u64 = 1759800000;
+
+        /// BPO2 hardfork activation timestamp
+        const HOLESKY_BPO2_TIMESTAMP: u64 = 1760389824;
+
+        let holesky = L1Config::holesky();
+
+        assert_eq!(holesky.blob_schedule.len(), 5);
+        assert_eq!(
+            holesky.blob_schedule.get(&EthereumHardfork::Bpo1.name().to_lowercase()).unwrap(),
+            &BlobParams::bpo1()
+        );
+        assert_eq!(
+            holesky.blob_schedule.get(&EthereumHardfork::Bpo2.name().to_lowercase()).unwrap(),
+            &BlobParams::bpo2()
+        );
+
+        let blob_schedule = holesky.blob_schedule_blob_params();
+        assert_eq!(blob_schedule.scheduled.len(), 2);
+        assert_eq!(blob_schedule.scheduled[0].0, HOLESKY_BPO1_TIMESTAMP);
+        assert_eq!(blob_schedule.scheduled[1].0, HOLESKY_BPO2_TIMESTAMP);
+        assert_eq!(blob_schedule.scheduled[0].1, BlobParams::bpo1());
+        assert_eq!(blob_schedule.scheduled[1].1, BlobParams::bpo2());
     }
 }


### PR DESCRIPTION
## Description

The BPO activation timestamps were not correctly propagated from `alloy-rs/hardforks`