### PR TITLE
fix(mpt): enable thread_rng feature for rand in tests

### DIFF
--- a/crates/proof/mpt/Cargo.toml
+++ b/crates/proof/mpt/Cargo.toml
@@ -32,7 +32,7 @@ alloy-transport-http.workspace = true
 alloy-rpc-types = { workspace = true, features = ["eth", "debug"] }
 
 # General
-rand.workspace = true
+rand = { workspace = true, features = ["thread_rng"] }
 reqwest.workspace = true
 proptest.workspace = true
 tokio = { workspace = true, features = ["full"] }


### PR DESCRIPTION
Fixes compilation error when running `cargo test` in the `kona-mpt` crate.