### PR TITLE
perf(ci/tests): parallelize action-tests

### DIFF
--- a/.github/workflows/proof.yaml
+++ b/.github/workflows/proof.yaml
@@ -8,17 +8,23 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   action-tests:
     name: FPP actions (${{ matrix.kind }})
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         kind: ["single", "interop"]
+        parallel: [4]
+        index: [0, 1, 2, 3]  # Remember to update step 'Merge reports' as well.
         exclude:
-          - kind: interop
+          - kind: "interop"  # See https://github.com/op-rs/kona/issues/3010
     steps:
       - name: Checkout sources
         uses: actions/checkout@v5
@@ -44,11 +50,44 @@ jobs:
         uses: autero1/action-gotestsum@v2.0.0
         with:
           gotestsum_version: 1.12.1
-      - name: Run Action Tests (${{ matrix.kind }})
+
+      - name: Download JUnit Summary from Previous Workflow
+        id: download-artifact
+        uses: dawidd6/action-download-artifact@v11
+        with:
+          workflow_conclusion: success
+          name: junit-test-summary
+          if_no_artifact_found: warn
+          use_unzip: true
+          # todo: uncomment this before merging to main
+          # branch: main
+
+      - name: Build Action Tests
         run: |
           source <(cargo llvm-cov show-env --export-prefix)
-          just "action-tests-${{ matrix.kind }}"
+          just "action-tests-${{ matrix.kind }}-build"
           cargo llvm-cov report --lcov --output-path actions_cov.lcov
+
+      - name: Split Action Tests
+        id: test_split
+        uses: hashicorp-forge/go-test-split-action@v2.0.0
+        with:
+          total: ${{ matrix.parallel }}
+          index: ${{ matrix.index }}
+          junit-summary: ./junit-test-summary.xml
+          working-directory: ./tests/optimism/op-e2e/actions/proofs
+
+      - name: Run Action Tests
+        run: |
+          just "action-tests-${{ matrix.kind }}-run" "${{ steps.test_split.outputs.run }}"
+
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-test-summary-${{ matrix.index }}
+          path: tests/optimism/op-e2e/actions/proofs/node-summary.xml
+          retention-days: 1
+
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v5
         with:
@@ -58,6 +97,32 @@ jobs:
           files: actions_cov.lcov
           flags: proof
           verbose: true
+
+
+  tests-combine-summaries:
+    name: Combine Test Reports
+    needs: [action-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+
+      - name: Install junit-report-merger
+        run: npm install -g junit-report-merger
+
+      - name: Merge reports
+        run: jrm ./junit-test-summary.xml "junit-test-summary-0/*.xml" "junit-test-summary-1/*.xml" "junit-test-summary-2/*.xml" "junit-test-summary-3/*.xml"
+
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-test-summary
+          path: ./junit-test-summary.xml
+
 
   host-client-offline-runs:
     name: FPP e2e - ${{ matrix.target}} | ${{ matrix.name }}

--- a/tests/justfile
+++ b/tests/justfile
@@ -129,7 +129,7 @@ test-e2e-sysgo BINARY GO_PKG_NAME="" DEVNET="simple-kona" FILTER="" : unzip-cont
         export OP_SEQUENCER_WITH_GETH=0
         export OP_VALIDATOR_WITH_GETH=0
     fi
-    
+
     if [ "{{BINARY}}" = "node" ]; then
         export KONA_NODE_EXEC_PATH="{{SOURCE}}/../target/debug/kona-node"
         export OP_RETH_EXEC_PATH="{{SOURCE}}/reth/target/debug/op-reth"
@@ -174,7 +174,7 @@ test-e2e-kurtosis DEVNET GO_PKG_NAME="" FILTER="" DEVNET_CUSTOM_PATH="" :
     export DEVSTACK_ORCHESTRATOR=sysext
 
     # Run the test with count=1 to avoid caching the test results.
-    cd {{SOURCE}} && go test -count=1 -timeout 40m -v ./$GO_PKG_NAME $FILTER 
+    cd {{SOURCE}} && go test -count=1 -timeout 40m -v ./$GO_PKG_NAME $FILTER
 
 long-running-test FILTER="" OUTPUT_LOGS_DIR="":
     #!/bin/bash
@@ -199,7 +199,7 @@ long-running-test FILTER="" OUTPUT_LOGS_DIR="":
     just build-kona
     echo "Building op-reth..."
     just build-reth
-    
+
     export OP_TESTLOG_FILE_LOGGER_OUTDIR="{{OUTPUT_LOGS_DIR}}"
     if [ -z "{{OUTPUT_LOGS_DIR}}" ]; then
         export OP_TESTLOG_FILE_LOGGER_OUTDIR="{{CURRENT_DIR}}/kona-test-logs"
@@ -211,23 +211,29 @@ long-running-test FILTER="" OUTPUT_LOGS_DIR="":
     export DISABLE_OP_E2E_LEGACY=true
 
     # Run the test with count=1 to avoid caching the test results.
-    cd {{SOURCE}} && go test -count=1 -timeout 0 -v ./node/long-running $FILTER 
+    cd {{SOURCE}} && go test -count=1 -timeout 0 -v ./node/long-running $FILTER
 
 # Run action tests for the single-chain client program on the native target
-action-tests-single test_name='Test_ProgramAction' *args='':
+action-tests-single test_name='Test_ProgramAction' *args='': action-tests-single-build (action-tests-single-run test_name args)
+
+# Build action tests for the single-chain client program on the native target
+action-tests-single-build:
   #!/bin/bash
   echo "Building contract artifacts for the optimism"
   just unzip-contract-artifacts {{SOURCE}}/optimism/packages/contracts-bedrock
 
   echo "Building host program for the native target"
   just build-native --bin kona-host
-  export KONA_HOST_PATH="{{SOURCE}}/../target/debug/kona-host"
 
+# Run action tests for the single-chain client program on the native target
+action-tests-single-run test_name='Test_ProgramAction' *args='':
+  #!/bin/bash
+  export KONA_HOST_PATH="{{SOURCE}}/../target/debug/kona-host"
   # GitHub actions patch - do not print logs.
   # https://github.com/gotestyourself/gotestsum/blob/b4b13345fee56744d80016a20b760d3599c13504/testjson/format.go#L442-L444
   echo "Running action tests for the client program on the native target"
 
-  cd {{SOURCE}}/optimism/op-e2e/actions/proofs && GITHUB_ACTIONS=false gotestsum --format=testname -- -timeout 60m -run "{{test_name}}" {{args}} -count=1 ./...
+  cd {{SOURCE}}/optimism/op-e2e/actions/proofs && GITHUB_ACTIONS=false gotestsum --junitfile node-summary.xml --format=short-verbose -- -count=1 -timeout 60m -run "{{test_name}}" {{args}}
 
 # Run action tests for the interop client program on the native target
 action-tests-interop test_name='TestInteropFaultProofs' *args='':
@@ -245,8 +251,16 @@ action-tests-interop test_name='TestInteropFaultProofs' *args='':
 
   cd {{SOURCE}}/optimism/op-e2e/actions/interop && GITHUB_ACTIONS=false gotestsum --format=testname -- -run "{{test_name}}" {{args}} -count=1 ./...
 
+action-tests-interop-build test_name='TestInteropFaultProofs' *args='':
+  #!/bin/bash
+  echo "Not implemented. See https://github.com/op-rs/kona/issues/3010"
+
+action-tests-interop-run test_name='TestInteropFaultProofs' *args='':
+  #!/bin/bash
+  echo "Not implemented.  See https://github.com/op-rs/kona/issues/3010"
+
 build-deploy-devnet BINARY DEVNET CUSTOM_DEVNET_PATH="": (build-devnet BINARY) (devnet DEVNET CUSTOM_DEVNET_PATH)
-  
+
 deploy-devnet-and-test-e2e DEVNET GO_PKG_NAME CUSTOM_DEVNET_PATH="": (devnet DEVNET CUSTOM_DEVNET_PATH) (test-e2e-kurtosis DEVNET GO_PKG_NAME)
 
 build-devnet-and-test-e2e BINARY DEVNET GO_PKG_NAME CUSTOM_DEVNET_PATH="": (build-devnet BINARY) (deploy-devnet-and-test-e2e DEVNET GO_PKG_NAME CUSTOM_DEVNET_PATH)
@@ -283,7 +297,7 @@ unzip-contract-artifacts DEST_DIR="":
     tar --zstd -xf {{SOURCE}}/artifacts/compressed/artifacts.tzst -C $DEST_DIR
 
 
-update-packages: 
+update-packages:
     #!/bin/bash
     cd {{SOURCE}}/optimism/op-deployer && just build-contracts copy-contract-artifacts
     cp {{SOURCE}}/optimism/op-deployer/pkg/deployer/artifacts/forge-artifacts/artifacts.tzst {{SOURCE}}/artifacts/compressed/artifacts.tzst


### PR DESCRIPTION
Resolves #2983 

Warnings about missing cache keys are expect outside of `main`.