### PR TITLE
Change uploaded prestate url and info file format

### DIFF
--- a/.github/workflows/publish_artifacts.yaml
+++ b/.github/workflows/publish_artifacts.yaml
@@ -62,19 +62,19 @@ jobs:
             INFO_FILE=$(mktemp) 
 
             # Upload the git commit info for each prestate since this won't be recorded in releases.json 
-            (echo "Commit=${{ github.sha }}" && echo "Prestate: ${PRESTATE_HASH}") > "${INFO_FILE}" 
+            echo "Commit=${{ github.sha }}" > "${INFO_FILE}"
+            echo "Prestate: ${PRESTATE_HASH}" >> "${INFO_FILE}"
+            echo "Kind: ${{ matrix.kind }}" >> "${INFO_FILE}"
+            echo "Version: ${{ matrix.version }}" >> "${INFO_FILE}"
 
             gsutil cp "${INFO_FILE}" "gs://kona-proof-prestates/${{ matrix.kind }}/${BRANCH_NAME}-${{ matrix.version }}-prestate.bin.gz.txt" 
             echo "Published commit hash data successfully" # So we know if any uploads worked 
 
             rm "${INFO_FILE}" # keep things tidy 
             echo "All commit info published" 
-
-            # Use the branch name for branches to provide a consistent URL 
-            PRESTATE_HASH="${BRANCH_NAME}-${{ matrix.version }}" 
           fi 
 
 
-          gsutil cp ./prestate-artifacts-${{ matrix.kind }}/prestate.bin.gz "gs://kona-proof-prestates/${{ matrix.kind }}/${PRESTATE_HASH}-prestate.bin.gz" 
+          gsutil cp ./prestate-artifacts-${{ matrix.kind }}/prestate.bin.gz "gs://kona-proof-prestates/${{ matrix.kind }}/${PRESTATE_HASH}.bin.gz" 
 
           echo "Successfully published prestates artifacts to GCS"


### PR DESCRIPTION
`op-challenger` expects to find the prestate binary in `$OP_CHALLENGER_CANNON_KONA_PRESTATES_URL/$PRESTATE_HASH.bin.gz`. This changes the URL of the uploaded file to match that.

Also fixes whitespace in a separate commit.

And one more commit I'd like to add here is to remove `if [[ "" != "${{ github.ref_name }}" ]]`. I'm not sure what the purpose of that is, especially since the upload of the binary is outside of it and the info file is inside it. (This workflow only runs on pushes to `main`.) Or let me know why that's not a good idea. 🙂