### PR TITLE
Upload prestate bin files to permanent location on new release tags

### DIFF
--- a/.github/workflows/publish_artifacts.yaml
+++ b/.github/workflows/publish_artifacts.yaml
@@ -57,7 +57,7 @@ jobs:
 
           BRANCH_NAME=$(echo "${{ github.ref_name }}" | tr '/' '-') 
           echo "Publishing ${PRESTATE_HASH} as ${BRANCH_NAME}" 
-          if [[ "main" == "${{ github.ref_name }}" ]] 
+          if [[ "${{ github.ref_type }}" == 'branch' ]]
           then 
             echo "Publishing commit hash data" 
             INFO_FILE=$(mktemp) 


### PR DESCRIPTION
Added a new condition to run on tags that match `kona-client/v*`, fixed the conditional to only match when the branch is `main`, and changed the file suffix.

So now when this workflow runs on tags (e.g., kona-client/v1.2.3), the commit info file will NOT be uploaded, and the prestate hash variable will NOT be overridden with the branch name pattern. This means:

- For tags: Only ${PRESTATE_HASH}.bin.gz is uploaded
- For main branch: Both main-${VERSION}.bin.gz.txt (commit info) AND main-${VERSION}-prestate.bin.gz (prestate) are uploaded