### PR TITLE
fix: remove is_zero check from blob_data as 4844 allows zeros blob submitted to L1

### DIFF
--- a/crates/protocol/derive/src/sources/blob_data.rs
+++ b/crates/protocol/derive/src/sources/blob_data.rs
@@ -197,7 +197,8 @@ mod tests {
     fn test_fill_zero_blob() {
         let mut blob_data = BlobData::default();
         let blobs = vec![Box::new(Blob::ZERO)];
-        assert_eq!(blob_data.fill(&blobs, 0), Err(BlobDecodingError::MissingData));
+        // consider a blob made entirely of zero bytes a regular blob
+        assert_eq!(blob_data.fill(&blobs, 0), Ok(true));
     }
 
     #[test]


### PR DESCRIPTION
 Problem

Kona blob source checks if the entire blob is zero, see [here](https://github.com/op-rs/kona/blob/15cf172fa4086ad81da8a46704d67fea31b5cbf6/crates/protocol/derive/src/sources/blob_data.rs#L159).

If it is zero, `BlobDecodingError::MissingData` is converted into a critical error [here](https://github.com/op-rs/kona/blob/15cf172fa4086ad81da8a46704d67fea31b5cbf6/crates/protocol/derive/src/errors/sources.rs#L48).

But it is fine for a 4844 blob to have all 0 field elements, its kzg commitment would be a point at infinity.

The check isn't enforced by [go-implementation](https://github.com/ethereum-optimism/optimism/blob/247b3992554fa6868c5718945f09d2bb85adfb2b/op-node/rollup/derive/blob_data_source.go#L154).

For an all-zero blob, it satisfies the encoding scheme described [here](https://specs.optimism.io/protocol/ecotone/derivation.html?highlight=encoding#blob-encoding) and [here](https://specs.optimism.io/protocol/ecotone/derivation.html?highlight=encoding#ecotone-blob-retrieval), as the length bytes are 0. By the time of decoding, all the data is [truncated](https://github.com/op-rs/kona/blob/e41d8c20c5badf2fc960ae9e6b4029fab4160b96/crates/protocol/derive/src/sources/blob_data.rs#L92). Then the empty array would be safely dropped by frame_queue in the [parse_frames](https://github.com/op-rs/kona/blob/8bba740643d5542f49c71bd015fa057b8eb1f3a4/crates/protocol/protocol/src/frame.rs#L231) function, which returns Ok when there is error. 

