### PR TITLE
Remove redundant temp-dir clone in P2P args test PR Description

### DIFF
--- a/bin/node/src/flags/p2p.rs
+++ b/bin/node/src/flags/p2p.rs
@@ -476,9 +476,8 @@ mod tests {
     #[test]
     fn test_p2p_args_keypair_from_path() {
         // Create a temporary directory.
-        let dir = std::env::temp_dir();
-        let mut source_path = dir.clone();
-        assert!(std::env::set_current_dir(dir).is_ok());
+        let mut source_path = std::env::temp_dir();
+        assert!(std::env::set_current_dir(&source_path).is_ok());
 
         // Write a private key to a file.
         let key = b256!("1d2b0bda21d56b8bd12d4f94ebacffdfb35f5e226f84b461103bb8beab6353be");


### PR DESCRIPTION
Drop the extra PathBuf clone in test_p2p_args_keypair_from_path keep the test logic identical while skipping an unnecessary allocation