### PR TITLE
Avoid cloning client_cert when starting the remote signer watcher

### DIFF
--- a/crates/node/sources/src/signer/remote/cert.rs
+++ b/crates/node/sources/src/signer/remote/cert.rs
@@ -104,7 +104,7 @@ impl RemoteSigner {
         &self,
         client: Arc<RwLock<RpcClient>>,
     ) -> Result<Option<RecommendedWatcher>, notify::Error> {
-        let Some(ref client_cert) = self.client_cert.clone() else {
+        let Some(client_cert) = &self.client_cert else {
             return Ok(None);
         };
 


### PR DESCRIPTION
Borrow self.client_cert directly instead of cloning the Option, eliminating an unnecessary heap allocation while leaving behavior unchanged. Keep the watcher logic identical by reusing the existing builder clone for closure ownership.