### PR TITLE
kona-host: Support websocket RPC connections

### DIFF
--- a/bin/host/src/eth/mod.rs
+++ b/bin/host/src/eth/mod.rs
@@ -1,16 +1,11 @@
 //! Ethereum utilities for the host binary.
 
 use alloy_provider::{Network, RootProvider};
-use alloy_rpc_client::RpcClient;
-use alloy_transport_http::Http;
-use reqwest::Client;
 
 mod precompiles;
 pub(crate) use precompiles::execute;
 
 /// Returns an HTTP provider for the given URL.
-pub fn http_provider<N: Network>(url: &str) -> RootProvider<N> {
-    let url = url.parse().unwrap();
-    let http = Http::<Client>::new(url);
-    RootProvider::new(RpcClient::new(http, true))
+pub async fn rpc_provider<N: Network>(url: &str) -> RootProvider<N> {
+    RootProvider::connect(url).await.unwrap()
 }


### PR DESCRIPTION
Use `RootProvider::connect` so it automatically detects the URL scheme and sets up the appropriate clients. This enables support for web sockets rather than only supporting http/https URLs.