### PR TITLE
fix: expected/received fields in Signer validation error

### DIFF
--- a/crates/node/gossip/src/block_validity.rs
+++ b/crates/node/gossip/src/block_validity.rs
@@ -253,7 +253,7 @@ impl BlockHandler {
 
         // The block is signed by the expected signer (the unsafe block signer).
         if msg_signer != block_signer {
-            return Err(BlockInvalidError::Signer { expected: msg_signer, received: block_signer });
+            return Err(BlockInvalidError::Signer { expected: block_signer, received: msg_signer });
         }
 
         self.seen_hashes


### PR DESCRIPTION
The Signer error constructed in block validation inverted the semantics of expected and received.
Expected should be the configured unsafe block signer, while received is the address recovered from the message signature.
This fix swaps the fields to match code comments and conventional error reporting, ensuring logs and diagnostics are accurate.