### PR TITLE
Clean up serde quantity imports

### DIFF
--- a/crates/utilities/serde/src/quantity.rs
+++ b/crates/utilities/serde/src/quantity.rs
@@ -3,7 +3,7 @@
 use alloc::string::ToString;
 use core::str::FromStr;
 use private::ConvertRuint;
-use serde::{self, Deserialize, Deserializer, Serialize, Serializer, de};
+use serde::{Deserializer, Serializer, de};
 use serde_json::Value;
 
 /// Serializes a primitive number as a "quantity" hex string.


### PR DESCRIPTION
remove unused serde imports from `crates/utilities/serde/src/quantity.rs` keep only Deserializer/Serializer/de to match the actual usage and avoid needless warnings