### PR TITLE
docs(deposits): fix byte count in opaqueData packing table

### DIFF
--- a/crates/protocol/protocol/src/deposits.rs
+++ b/crates/protocol/protocol/src/deposits.rs
@@ -121,7 +121,7 @@ pub fn decode_deposit(block_hash: B256, index: usize, log: &Log) -> Result<Bytes
     // The opaqueData will be packed as shown below:
     //
     // ------------------------------------------------------------
-    // | offset | 256 byte content                                |
+    // | offset | 32 byte content                                 |
     // ------------------------------------------------------------
     // | 0      | [0; 24] . {U64 big endian, hex encoded offset}  |
     // ------------------------------------------------------------


### PR DESCRIPTION
Fix incorrect byte count in the opaqueData serialization table comment. The table describes two 32-byte words (offset 0 and offset 32), not 256-byte blocks. Each row represents a single 32-byte ABI-encoded word containing 24 bytes of padding and an 8-byte U64 value.
