### PR TITLE
chore(supervisor-storage): remove unused Debug import from log_provider

### DIFF
--- a/crates/supervisor/storage/src/providers/log_provider.rs
+++ b/crates/supervisor/storage/src/providers/log_provider.rs
@@ -25,7 +25,7 @@ use reth_db_api::{
     cursor::{DbCursorRO, DbDupCursorRO, DbDupCursorRW},
     transaction::{DbTx, DbTxMut},
 };
-use std::fmt::Debug;
+
 use tracing::{debug, error, info, trace, warn};
 
 const DEFAULT_LOG_INTERVAL: u64 = 100;


### PR DESCRIPTION
Remove unused `std::fmt::Debug` import from `log_provider.rs`.