### PR TITLE
fix(node/test): lower finalization threshold for TestSyncFinalized

### DIFF
--- a/tests/node/common/sync_ws_test.go
+++ b/tests/node/common/sync_ws_test.go
@@ -194,7 +194,7 @@ func TestSyncFinalized(gt *testing.T) {
 
 			output := node_utils.GetKonaWs(t, node, "finalized_head", time.After(4*time.Minute))
 
-			// We should check that we received at least 1 finalized blocks within 4 minutes!
+			// We should check that we received at least 1 finalized block within 4 minutes!
 			require.GreaterOrEqual(t, len(output), 1, "we didn't receive enough finalized gossip blocks!")
 			t.Log("Number of finalized blocks received within 4 minutes:", len(output))
 


### PR DESCRIPTION
## Description

The finalization test was flaking because we didn't get enough new blocks finalized. This test ensures we are receiving at least one finalized block within 4 mins.