### PR TITLE
fix(protocol/derivation): ensure that conversion to deposit only payload correctly filters user transactions

### DIFF
--- a/crates/node/engine/src/task_queue/tasks/build/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/build/task.rs
@@ -110,17 +110,17 @@ impl BuildTask {
 
         let forkchoice_version = EngineForkchoiceVersion::from_cfg(
             &self.cfg,
-            attributes_envelope.inner.payload_attributes.timestamp,
+            attributes_envelope.attributes.payload_attributes.timestamp,
         );
         let update = match forkchoice_version {
             EngineForkchoiceVersion::V3 => {
                 engine_client
-                    .fork_choice_updated_v3(new_forkchoice, Some(attributes_envelope.inner))
+                    .fork_choice_updated_v3(new_forkchoice, Some(attributes_envelope.attributes))
                     .await
             }
             EngineForkchoiceVersion::V2 => {
                 engine_client
-                    .fork_choice_updated_v2(new_forkchoice, Some(attributes_envelope.inner))
+                    .fork_choice_updated_v2(new_forkchoice, Some(attributes_envelope.attributes))
                     .await
             }
         }
@@ -156,7 +156,7 @@ impl EngineTaskExt for BuildTask {
     async fn execute(&self, state: &mut EngineState) -> Result<PayloadId, BuildTaskError> {
         debug!(
             target: "engine_builder",
-            txs = self.attributes.inner().transactions.as_ref().map_or(0, |txs| txs.len()),
+            txs = self.attributes.attributes().transactions.as_ref().map_or(0, |txs| txs.len()),
             is_deposits = self.attributes.is_deposits_only(),
             "Starting new build job"
         );

--- a/crates/node/engine/src/task_queue/tasks/seal/task.rs
+++ b/crates/node/engine/src/task_queue/tasks/seal/task.rs
@@ -63,7 +63,7 @@ impl SealTask {
         payload_id: PayloadId,
         payload_attrs: OpAttributesWithParent,
     ) -> Result<OpExecutionPayloadEnvelope, SealTaskError> {
-        let payload_timestamp = payload_attrs.inner().payload_attributes.timestamp;
+        let payload_timestamp = payload_attrs.attributes().payload_attributes.timestamp;
 
         debug!(
             target: "engine",
@@ -146,9 +146,9 @@ impl SealTask {
                 return Err(SealTaskError::DepositOnlyPayloadFailed);
             }
             Err(InsertTaskError::UnexpectedPayloadStatus(e))
-                if self
-                    .cfg
-                    .is_holocene_active(self.attributes.inner().payload_attributes.timestamp) =>
+                if self.cfg.is_holocene_active(
+                    self.attributes.attributes().payload_attributes.timestamp,
+                ) =>
             {
                 warn!(target: "engine", error = ?e, "Re-attempting payload import with deposits only.");
 
@@ -202,7 +202,7 @@ impl SealTask {
 
         let new_block_ref = L2BlockInfo::from_payload_and_genesis(
             new_payload.execution_payload.clone(),
-            self.attributes.inner().payload_attributes.parent_beacon_block_root,
+            self.attributes.attributes().payload_attributes.parent_beacon_block_root,
             &self.cfg.genesis,
         )
         .map_err(SealTaskError::FromBlock)?;
@@ -256,7 +256,7 @@ impl EngineTaskExt for SealTask {
     async fn execute(&self, state: &mut EngineState) -> Result<(), SealTaskError> {
         debug!(
             target: "engine",
-            txs = self.attributes.inner().transactions.as_ref().map_or(0, |txs| txs.len()),
+            txs = self.attributes.attributes().transactions.as_ref().map_or(0, |txs| txs.len()),
             is_deposits = self.attributes.is_deposits_only(),
             "Starting new seal job"
         );

--- a/crates/protocol/derive/src/pipeline/core.rs
+++ b/crates/protocol/derive/src/pipeline/core.rs
@@ -188,7 +188,7 @@ where
                 kona_macros::set!(
                     gauge,
                     crate::metrics::Metrics::PIPELINE_LATEST_PAYLOAD_TX_COUNT,
-                    a.inner.transactions.as_ref().map_or(0.0, |txs| txs.len() as f64)
+                    a.attributes.transactions.as_ref().map_or(0.0, |txs| txs.len() as f64)
                 );
                 if !a.is_last_in_span {
                     kona_macros::inc!(gauge, crate::metrics::Metrics::PIPELINE_DERIVED_SPAN_SIZE);
@@ -236,7 +236,7 @@ mod tests {
 
     fn default_test_payload_attributes() -> OpAttributesWithParent {
         OpAttributesWithParent {
-            inner: OpPayloadAttributes {
+            attributes: OpPayloadAttributes {
                 payload_attributes: PayloadAttributes {
                     timestamp: 0,
                     prev_randao: Default::default(),

--- a/crates/protocol/derive/src/stages/attributes_queue.rs
+++ b/crates/protocol/derive/src/stages/attributes_queue.rs
@@ -393,7 +393,7 @@ mod tests {
         let attributes = aq.next_attributes(L2BlockInfo::default()).await.unwrap();
         pa.no_tx_pool = Some(true);
         let populated_attributes = OpAttributesWithParent {
-            inner: pa,
+            attributes: pa,
             parent: L2BlockInfo::default(),
             derived_from: Some(BlockInfo::default()),
             is_last_in_span: true,

--- a/crates/protocol/protocol/src/attributes.rs
+++ b/crates/protocol/protocol/src/attributes.rs
@@ -9,7 +9,7 @@ use op_alloy_rpc_types_engine::OpPayloadAttributes;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OpAttributesWithParent {
     /// The payload attributes.
-    pub inner: OpPayloadAttributes,
+    pub attributes: OpPayloadAttributes,
     /// The parent block reference.
     pub parent: L2BlockInfo,
     /// The L1 block that the attributes were derived from.
@@ -21,12 +21,12 @@ pub struct OpAttributesWithParent {
 impl OpAttributesWithParent {
     /// Create a new [`OpAttributesWithParent`] instance.
     pub const fn new(
-        inner: OpPayloadAttributes,
+        attributes: OpPayloadAttributes,
         parent: L2BlockInfo,
         derived_from: Option<BlockInfo>,
         is_last_in_span: bool,
     ) -> Self {
-        Self { inner, parent, derived_from, is_last_in_span }
+        Self { attributes, parent, derived_from, is_last_in_span }
     }
 
     /// Returns the L2 block number for the payload attributes if made canonical.
@@ -37,12 +37,12 @@ impl OpAttributesWithParent {
 
     /// Consumes `self` and returns the inner [`OpPayloadAttributes`].
     pub fn take_inner(self) -> OpPayloadAttributes {
-        self.inner
+        self.attributes
     }
 
     /// Returns the payload attributes.
-    pub const fn inner(&self) -> &OpPayloadAttributes {
-        &self.inner
+    pub const fn attributes(&self) -> &OpPayloadAttributes {
+        &self.attributes
     }
 
     /// Returns the parent block reference.
@@ -62,7 +62,7 @@ impl OpAttributesWithParent {
 
     /// Returns `true` if all transactions in the payload are deposits.
     pub fn is_deposits_only(&self) -> bool {
-        self.inner
+        self.attributes
             .transactions
             .iter()
             .all(|tx| tx.first().is_some_and(|tx| tx[0] == OpTxType::Deposit as u8))
@@ -70,15 +70,15 @@ impl OpAttributesWithParent {
 
     /// Converts the [`OpAttributesWithParent`] into a deposits-only payload.
     pub fn as_deposits_only(&self) -> Self {
-        let mut inner = self.inner.clone();
+        let mut attributes = self.attributes.clone();
 
-        inner
+        attributes
             .transactions
             .iter_mut()
             .for_each(|txs| txs.retain(|tx| tx.first().cloned() == Some(OpTxType::Deposit as u8)));
 
         Self {
-            inner,
+            attributes,
             parent: self.parent,
             derived_from: self.derived_from,
             is_last_in_span: self.is_last_in_span,
@@ -99,7 +99,7 @@ mod tests {
         let op_attributes_with_parent =
             OpAttributesWithParent::new(attributes.clone(), parent, None, is_last_in_span);
 
-        assert_eq!(op_attributes_with_parent.inner(), &attributes);
+        assert_eq!(op_attributes_with_parent.attributes(), &attributes);
         assert_eq!(op_attributes_with_parent.parent(), &parent);
         assert_eq!(op_attributes_with_parent.is_last_in_span(), is_last_in_span);
         assert_eq!(op_attributes_with_parent.derived_from(), None);
@@ -127,8 +127,102 @@ mod tests {
         let deposits_only_attributes = op_attributes_with_parent.as_deposits_only();
 
         assert_eq!(
-            deposits_only_attributes.inner().transactions,
+            deposits_only_attributes.attributes().transactions,
             Some(vec![vec![OpTxType::Deposit as u8, 0x0, 0x10, 0x20].into()])
         );
+    }
+
+    #[test]
+    fn test_op_attributes_with_parent_as_deposits_multi_deposits() {
+        let attributes = OpPayloadAttributes {
+            transactions: Some(vec![
+                vec![OpTxType::Deposit as u8, 0x0, 0x10, 0x20].into(),
+                vec![OpTxType::Legacy as u8, 0x0, 0x11, 0x21].into(),
+                vec![OpTxType::Eip2930 as u8, 0x0, 0x12, 0x22].into(),
+                vec![OpTxType::Deposit as u8, 0x98, 0x21, 0x31].into(),
+                vec![OpTxType::Eip1559 as u8, 0x0, 0x13, 0x23].into(),
+                vec![OpTxType::Eip7702 as u8, 0x0, 0x14, 0x24].into(),
+                vec![OpTxType::Deposit as u8, 0x56, 0x31, 0x41].into(),
+                vec![].into(),
+            ]),
+            ..OpPayloadAttributes::default()
+        };
+        let parent = L2BlockInfo::default();
+        let is_last_in_span = true;
+        let op_attributes_with_parent =
+            OpAttributesWithParent::new(attributes, parent, None, is_last_in_span);
+        let deposits_only_attributes = op_attributes_with_parent.as_deposits_only();
+
+        assert_eq!(
+            deposits_only_attributes.attributes().transactions,
+            Some(vec![
+                vec![OpTxType::Deposit as u8, 0x0, 0x10, 0x20].into(),
+                vec![OpTxType::Deposit as u8, 0x98, 0x21, 0x31].into(),
+                vec![OpTxType::Deposit as u8, 0x56, 0x31, 0x41].into(),
+            ])
+        );
+    }
+
+    /// Test that the [`OpAttributesWithParent::as_deposits_only`] method strips out all
+    /// transactions that are not deposits.
+    #[test]
+    fn test_op_attributes_with_parent_as_deposits_no_deposits() {
+        let attributes = OpPayloadAttributes {
+            transactions: Some(vec![
+                vec![OpTxType::Legacy as u8, 0x0, 0x11, 0x21].into(),
+                vec![OpTxType::Eip2930 as u8, 0x0, 0x12, 0x22].into(),
+                vec![OpTxType::Eip1559 as u8, 0x0, 0x13, 0x23].into(),
+                vec![OpTxType::Eip7702 as u8, 0x0, 0x14, 0x24].into(),
+                vec![].into(),
+            ]),
+            ..OpPayloadAttributes::default()
+        };
+        let parent = L2BlockInfo::default();
+        let is_last_in_span = true;
+        let op_attributes_with_parent =
+            OpAttributesWithParent::new(attributes, parent, None, is_last_in_span);
+        let deposits_only_attributes = op_attributes_with_parent.as_deposits_only();
+
+        assert_eq!(deposits_only_attributes.attributes().transactions, Some(vec![]));
+    }
+
+    #[test]
+    fn test_op_attributes_with_parent_as_deposits_only_deposits() {
+        let attributes = OpPayloadAttributes {
+            transactions: Some(vec![
+                vec![OpTxType::Deposit as u8, 0x0, 0x10, 0x20].into(),
+                vec![OpTxType::Deposit as u8, 0x98, 0x21, 0x31].into(),
+                vec![OpTxType::Deposit as u8, 0x56, 0x31, 0x41].into(),
+                vec![].into(),
+            ]),
+            ..OpPayloadAttributes::default()
+        };
+        let parent = L2BlockInfo::default();
+        let is_last_in_span = true;
+        let op_attributes_with_parent =
+            OpAttributesWithParent::new(attributes, parent, None, is_last_in_span);
+        let deposits_only_attributes = op_attributes_with_parent.as_deposits_only();
+
+        assert_eq!(
+            deposits_only_attributes.attributes().transactions,
+            Some(vec![
+                vec![OpTxType::Deposit as u8, 0x0, 0x10, 0x20].into(),
+                vec![OpTxType::Deposit as u8, 0x98, 0x21, 0x31].into(),
+                vec![OpTxType::Deposit as u8, 0x56, 0x31, 0x41].into(),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_op_attributes_with_parent_as_deposits_no_txs() {
+        let attributes =
+            OpPayloadAttributes { transactions: None, ..OpPayloadAttributes::default() };
+        let parent = L2BlockInfo::default();
+        let is_last_in_span = true;
+        let op_attributes_with_parent =
+            OpAttributesWithParent::new(attributes, parent, None, is_last_in_span);
+        let deposits_only_attributes = op_attributes_with_parent.as_deposits_only();
+
+        assert_eq!(deposits_only_attributes.attributes().transactions, None);
     }
 }

--- a/crates/protocol/registry/etc/chainList.json
+++ b/crates/protocol/registry/etc/chainList.json
@@ -1327,5 +1327,47 @@
     "faultProofs": {
       "status": "permissioned"
     }
+  },
+  {
+    "name": "test1",
+    "identifier": "test1/testnet",
+    "chainId": 123999119,
+    "rpc": [
+      "https://rpc.test1.com"
+    ],
+    "explorers": [
+      "https://explorer.test1.com"
+    ],
+    "superchainLevel": 0,
+    "governedByOptimism": false,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "testnet"
+    },
+    "faultProofs": {
+      "status": "none"
+    }
+  },
+  {
+    "name": "test2",
+    "identifier": "test2/testnet",
+    "chainId": 223999119,
+    "rpc": [
+      "https://rpc.test2.com"
+    ],
+    "explorers": [
+      "https://explorer.test2.com"
+    ],
+    "superchainLevel": 0,
+    "governedByOptimism": false,
+    "dataAvailabilityType": "eth-da",
+    "parent": {
+      "type": "L2",
+      "chain": "testnet"
+    },
+    "faultProofs": {
+      "status": "none"
+    }
   }
 ]

--- a/crates/protocol/registry/etc/configs.json
+++ b/crates/protocol/registry/etc/configs.json
@@ -5187,6 +5187,178 @@
           }
         },
         {
+          "Name": "test1",
+          "PublicRPC": "https://rpc.test1.com",
+          "SequencerRPC": "https://test1-sequencer.com",
+          "Explorer": "https://explorer.test1.com",
+          "SuperchainLevel": 2,
+          "GovernedByOptimism": false,
+          "SuperchainTime": 0,
+          "DataAvailabilityType": "eth-da",
+          "l2_chain_id": 123999119,
+          "batch_inbox_address": "0xff00000000000000000000000000000000000099",
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "GasPayingToken": null,
+          "hardfork_configuration": {
+            "canyon_time": 1704992401,
+            "delta_time": 1708560000,
+            "ecotone_time": 1710374401,
+            "fjord_time": 1720627201,
+            "granite_time": 1726070401,
+            "holocene_time": 1736445601,
+            "isthmus_time": 1746806401,
+            "jovian_time": 1764691201
+          },
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 17422590,
+              "hash": "0x438335a20d98863a4c0c97999eb2481921ccd28553eac6f913af7c12aec04108"
+            },
+            "l2": {
+              "number": 105235063,
+              "hash": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+            },
+            "l2_time": 1686068903,
+            "system_config": {
+              "batcherAddr": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null,
+              "minBaseFee": null,
+              "daFootprintGasScalar": null
+            }
+          },
+          "Roles": {
+            "SystemConfigOwner": null,
+            "ProxyAdminOwner": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            "Guardian": null,
+            "Challenger": null,
+            "Proposer": null,
+            "UnsafeBlockSigner": null,
+            "BatchSubmitter": null
+          },
+          "Addresses": {
+            "AddressManager": null,
+            "L1CrossDomainMessengerProxy": null,
+            "L1Erc721BridgeProxy": null,
+            "L1StandardBridgeProxy": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            "L2OutputOracleProxy": null,
+            "OptimismMintableErc20FactoryProxy": null,
+            "OptimismPortalProxy": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            "SystemConfigProxy": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            "ProxyAdmin": null,
+            "SuperchainConfig": null,
+            "AnchorStateRegistryProxy": null,
+            "DelayedWethProxy": null,
+            "DisputeGameFactoryProxy": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            "FaultDisputeGame": null,
+            "Mips": null,
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": null,
+            "DataAvailabilityChallenge": null
+          }
+        },
+        {
+          "Name": "test2",
+          "PublicRPC": "https://rpc.test2.com",
+          "SequencerRPC": "https://test2-sequencer.com",
+          "Explorer": "https://explorer.test2.com",
+          "SuperchainLevel": 2,
+          "GovernedByOptimism": false,
+          "SuperchainTime": 0,
+          "DataAvailabilityType": "eth-da",
+          "l2_chain_id": 223999119,
+          "batch_inbox_address": "0xff00000000000000000000000000000000000099",
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "GasPayingToken": null,
+          "hardfork_configuration": {
+            "canyon_time": 1704992401,
+            "delta_time": 1708560000,
+            "ecotone_time": 1710374401,
+            "fjord_time": 1720627201,
+            "granite_time": 1726070401,
+            "holocene_time": 1736445601,
+            "isthmus_time": 1746806401,
+            "jovian_time": 1764691201
+          },
+          "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50,
+            "eip1559DenominatorCanyon": 250
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 17422590,
+              "hash": "0x438335a20d98863a4c0c97999eb2481921ccd28553eac6f913af7c12aec04108"
+            },
+            "l2": {
+              "number": 105235063,
+              "hash": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+            },
+            "l2_time": 1686068903,
+            "system_config": {
+              "batcherAddr": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+              "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null,
+              "minBaseFee": null,
+              "daFootprintGasScalar": null
+            }
+          },
+          "Roles": {
+            "SystemConfigOwner": null,
+            "ProxyAdminOwner": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            "Guardian": null,
+            "Challenger": null,
+            "Proposer": null,
+            "UnsafeBlockSigner": null,
+            "BatchSubmitter": null
+          },
+          "Addresses": {
+            "AddressManager": null,
+            "L1CrossDomainMessengerProxy": null,
+            "L1Erc721BridgeProxy": null,
+            "L1StandardBridgeProxy": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            "L2OutputOracleProxy": null,
+            "OptimismMintableErc20FactoryProxy": null,
+            "OptimismPortalProxy": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            "SystemConfigProxy": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            "ProxyAdmin": null,
+            "SuperchainConfig": null,
+            "AnchorStateRegistryProxy": null,
+            "DelayedWethProxy": null,
+            "DisputeGameFactoryProxy": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            "FaultDisputeGame": null,
+            "Mips": null,
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": null,
+            "DataAvailabilityChallenge": null
+          }
+        },
+        {
           "Name": "Zora Sepolia Testnet",
           "PublicRPC": "https://sepolia.rpc.zora.energy",
           "SequencerRPC": "https://sepolia.rpc.zora.energy",


### PR DESCRIPTION
## Description

This fixes payload derivation for holocene by ensuring that filtering `OpPayloadAttributes` for deposit-only payloads correctly filters non-deposit payloads. Adds a unit test