### PR TITLE
build: update checkout action to v6

### DIFF
--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -27,7 +27,7 @@ jobs:
             engine: op-reth
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: true
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -40,7 +40,7 @@ jobs:
       bin_target: ${{ steps.target-spec.outputs.bin_target }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Get Valid Targets
         id: get-targets
@@ -116,7 +116,7 @@ jobs:
         platform: ${{ fromJson(needs.prepare.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Prepare
         run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: "24.4.0"

--- a/.github/workflows/lychee.yaml
+++ b/.github/workflows/lychee.yaml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: true
 

--- a/.github/workflows/node_e2e_sysgo_tests.yaml
+++ b/.github/workflows/node_e2e_sysgo_tests.yaml
@@ -17,7 +17,7 @@ jobs:
         devnet-config: ["simple-kona", "simple-kona-geth", "simple-kona-sequencer", "large-kona-sequencer"]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -95,7 +95,7 @@ jobs:
     name: sysgo-restart-tests
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: true
 

--- a/.github/workflows/proof.yaml
+++ b/.github/workflows/proof.yaml
@@ -27,7 +27,7 @@ jobs:
           - kind: "interop"  # See https://github.com/op-rs/kona/issues/3010
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: true
       - name: Free Disk Space (Ubuntu)
@@ -94,7 +94,7 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:

--- a/.github/workflows/publish_artifacts.yaml
+++ b/.github/workflows/publish_artifacts.yaml
@@ -23,7 +23,7 @@ jobs:
         version: ["kona-client", "kona-client-int"]
     steps: 
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Authenticate to GCP
         id: 'auth'

--- a/.github/workflows/rust_ci.yaml
+++ b/.github/workflows/rust_ci.yaml
@@ -16,7 +16,7 @@ jobs:
     name: test
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: true
       - name: Free Disk Space (Ubuntu)
@@ -39,7 +39,7 @@ jobs:
     name: lint-${{ matrix.target }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: true
       - name: Free Disk Space (Ubuntu)
@@ -77,7 +77,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: true
       - name: Free Disk Space (Ubuntu)
@@ -108,7 +108,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: true
       - name: Free Disk Space (Ubuntu)
@@ -128,7 +128,7 @@ jobs:
     name: check-udeps
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: true
       - name: Free Disk Space (Ubuntu)
@@ -148,7 +148,7 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: true
       - name: Free Disk Space (Ubuntu)
@@ -164,7 +164,7 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: true
       - name: Free Disk Space (Ubuntu)
@@ -179,7 +179,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: crate-ci/typos@v1
 
   cargo-hack:
@@ -187,7 +187,7 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: true
       - name: Free Disk Space (Ubuntu)
@@ -205,7 +205,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - name: Install mold linker
@@ -225,7 +225,7 @@ jobs:
     runs-on: ubuntu-latest
     name: coverage
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - name: Free Disk Space (Ubuntu)
@@ -263,7 +263,7 @@ jobs:
   deny:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - uses: EmbarkStudios/cargo-deny-action@v2
@@ -273,7 +273,7 @@ jobs:
   zepter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - name: Install zepter

--- a/.github/workflows/supervisor_e2e_kurtosis.yaml
+++ b/.github/workflows/supervisor_e2e_kurtosis.yaml
@@ -26,7 +26,7 @@ jobs:
             test-pkg: pre_interop
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: true
       

--- a/.github/workflows/supervisor_e2e_sysgo.yaml
+++ b/.github/workflows/supervisor_e2e_sysgo.yaml
@@ -14,7 +14,7 @@ jobs:
         test-pkg: ["pre_interop", "l1reorg/sysgo"]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: true
 

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           submodules: true
           token: ${{ secrets.PAT_TOKEN }}
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           submodules: true
           token: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
Updates `actions/checkout` to v6 in CI workflows. No code changes.

https://github.com/actions/checkout/releases/tag/v6.0.0