### PR TITLE
chore(providers): recover provider

### DIFF
--- a/bin/host/src/single/cfg.rs
+++ b/bin/host/src/single/cfg.rs
@@ -277,12 +277,14 @@ impl SingleChainHost {
                 .ok_or(SingleChainHostError::Other("Provider must be set"))?,
         )
         .await;
+
         let blob_provider = OnlineBlobProvider::init(OnlineBeaconClient::new_http(
             self.l1_beacon_address
                 .clone()
                 .ok_or(SingleChainHostError::Other("Beacon API URL must be set"))?,
         ))
         .await;
+
         let l2_provider = rpc_provider::<Optimism>(
             self.l2_node_address
                 .as_ref()

--- a/crates/node/service/src/actors/derivation.rs
+++ b/crates/node/service/src/actors/derivation.rs
@@ -135,18 +135,20 @@ impl PipelineBuilder for DerivationBuilder {
             self.l2_trust_rpc,
         );
 
+        let blob_provider = OnlineBlobProvider::init(self.l1_beacon.clone()).await;
+
         let pipeline = match self.interop_mode {
             InteropMode::Polled => OnlinePipeline::new_polled(
                 self.rollup_config.clone(),
                 self.l1_config.clone(),
-                OnlineBlobProvider::init(self.l1_beacon.clone()).await,
+                blob_provider,
                 l1_derivation_provider,
                 l2_derivation_provider,
             ),
             InteropMode::Indexed => OnlinePipeline::new_indexed(
                 self.rollup_config.clone(),
                 self.l1_config.clone(),
-                OnlineBlobProvider::init(self.l1_beacon.clone()).await,
+                blob_provider,
                 l1_derivation_provider,
                 l2_derivation_provider,
             ),


### PR DESCRIPTION
## Description

Nit PR to recover from known slot interval if we cannot query the beacon node for the config/spec endpoint. This is the only place in the derivation process where we're using that endpoint (ideally I'd like to make this RPC call go away but I want to maintain forward compatibility).

The main use of this PR is to make `kona-node` fully compatible with anvil (running both as an EL and a CL client).