### PR TITLE
Avoid cloning payload before rollup-boost new_payload_v4

### DIFF
--- a/crates/node/engine/src/client.rs
+++ b/crates/node/engine/src/client.rs
@@ -287,12 +287,8 @@ impl OpEngineApi<Optimism, Http<HyperAuthClient>> for EngineClient {
         payload: OpExecutionPayloadV4,
         parent_beacon_block_root: B256,
     ) -> TransportResult<PayloadStatus> {
-        let call = self.rollup_boost.server.new_payload_v4(
-            payload.clone(),
-            vec![],
-            parent_beacon_block_root,
-            vec![],
-        );
+        let call =
+            self.rollup_boost.server.new_payload_v4(payload, vec![], parent_beacon_block_root, vec![]);
 
         record_call_time(call, Metrics::NEW_PAYLOAD_METHOD).await.map_err(Into::into)
     }


### PR DESCRIPTION
move OpExecutionPayloadV4 directly into rollup_boost.server.new_payload_v4, drop the redundant clone, removing an unnecessary allocation without changing behaviour