### PR TITLE
cleanup: remove redundant clone in rollup boost new_payload_v4

### DIFF
--- a/crates/node/engine/src/rollup_boost.rs
+++ b/crates/node/engine/src/rollup_boost.rs
@@ -164,7 +164,7 @@ impl<T: EngineApiExt + Send + Sync + 'static + Debug> RollupBoostServerLike
     ) -> Result<PayloadStatus, RollupBoostServerError> {
         EngineApiServer::new_payload_v4(
             self,
-            payload.clone(),
+            payload,
             versioned_hashes,
             parent_beacon_block_root,
             execution_requests,


### PR DESCRIPTION
eliminate an unnecessary clone of `OpExecutionPayloadV4` in `rollup_boost::new_payload_v4`, let the original payload move into `EngineApiServer::new_payload_v4` to avoid extra allocation