### PR TITLE
chore: minor improvement for docs

### DIFF
--- a/crates/protocol/protocol/src/batch/mod.rs
+++ b/crates/protocol/protocol/src/batch/mod.rs
@@ -10,7 +10,7 @@
 //! Traditional batch format containing transactions for a single L2 block.
 //! Simple, straightforward format used before span batch optimization.
 //!
-//! ## Span Batches  
+//! ## Span Batches
 //! Advanced batch format that can contain transactions for multiple L2 blocks,
 //! providing significant compression and efficiency improvements. Introduced
 //! to reduce L1 data costs for high-throughput L2 chains.

--- a/crates/protocol/protocol/src/batch/tx_data/eip7702.rs
+++ b/crates/protocol/protocol/src/batch/tx_data/eip7702.rs
@@ -20,7 +20,7 @@ pub struct SpanBatchEip7702TransactionData {
     pub data: Bytes,
     /// Access list, used to pre-warm storage slots through static declaration.
     pub access_list: AccessList,
-    /// Authorization list, used to allow a signer to delegate code to a contract
+    /// Authorization list, used to allow a signer to delegate code to a contract.
     pub authorization_list: Vec<SignedAuthorization>,
 }
 
@@ -34,12 +34,12 @@ impl SpanBatchEip7702TransactionData {
         chain_id: u64,
         signature: Signature,
     ) -> Result<Signed<TxEip7702>, SpanBatchError> {
-        // SAFETY: A U256 as be bytes is always 32 bytes long.
+        // SAFETY: A U256 as big-endian bytes is always 32 bytes long.
         let mut max_fee_per_gas = [0u8; 16];
         max_fee_per_gas.copy_from_slice(&self.max_fee_per_gas.to_be_bytes::<32>()[16..]);
         let max_fee_per_gas = u128::from_be_bytes(max_fee_per_gas);
 
-        // SAFETY: A U256 as be bytes is always 32 bytes long.
+        // SAFETY: A U256 as big-endian bytes is always 32 bytes long.
         let mut max_priority_fee_per_gas = [0u8; 16];
         max_priority_fee_per_gas
             .copy_from_slice(&self.max_priority_fee_per_gas.to_be_bytes::<32>()[16..]);

--- a/crates/protocol/protocol/src/block.rs
+++ b/crates/protocol/protocol/src/block.rs
@@ -206,7 +206,7 @@ impl L2BlockInfo {
         Ok(Self { block_info, l1_origin, seq_num: sequence_number })
     }
 
-    /// Constructs an [`L2BlockInfo`] From a given [`OpExecutionPayload`] and [`ChainGenesis`].
+    /// Constructs an [`L2BlockInfo`] from a given [`OpExecutionPayload`] and [`ChainGenesis`].
     pub fn from_payload_and_genesis(
         payload: OpExecutionPayload,
         parent_beacon_block_root: Option<B256>,


### PR DESCRIPTION
The term "be" here is confusing. Change it to "big-endian" to make the document more readable.

