### PR TITLE
docs: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ getting started with building your own programs, and a reference for the librari
 
 - [`client`](./bin/client): The bare-metal program that executes the state transition, to be run on a prover.
 - [`host`](./bin/host): The host program that runs natively alongside the prover, serving as the [Preimage Oracle][g-preimage-oracle] server.
-- [`node`](./bin/node): [WIP] A [Rollup Node][rollup-node-spec] implementation, backed by [`kona-derive`](./crates/protocol/derive). Supports flexible chain ID specification via `--l2-chain-id` using either numeric IDs (`10`) or chain names (`optimism`).
+- [`node`](./bin/node): A [Rollup Node][rollup-node-spec] implementation, backed by [`kona-derive`](./crates/protocol/derive). Supports flexible chain ID specification via `--l2-chain-id` using either numeric IDs (`10`) or chain names (`optimism`).
 - [`supervisor`](./bin/supervisor): [WIP] A [Supervisor][supervisor-spec] implementation.
 
 **Protocol**


### PR DESCRIPTION
As far as I know, the WIP prefix is ​​already outdated and does not correspond to reality