### PR TITLE
Remove redundant client_cert clone in remote signer watcher

### DIFF
--- a/crates/node/sources/src/signer/remote/cert.rs
+++ b/crates/node/sources/src/signer/remote/cert.rs
@@ -104,7 +104,7 @@ impl RemoteSigner {
         &self,
         client: Arc<RwLock<RpcClient>>,
     ) -> Result<Option<RecommendedWatcher>, notify::Error> {
-        let Some(ref client_cert) = self.client_cert.clone() else {
+        let Some(client_cert) = self.client_cert.as_ref() else {
             return Ok(None);
         };
 


### PR DESCRIPTION
borrow the configured ClientCert with as_ref() instead of cloning, avoid pointless allocations while keeping the watcher behaviour identical