### PR TITLE
chore: avoid unnecessary clone in remote signer cert watcher PR Descri

### DIFF
--- a/crates/node/sources/src/signer/remote/cert.rs
+++ b/crates/node/sources/src/signer/remote/cert.rs
@@ -104,7 +104,7 @@ impl RemoteSigner {
         &self,
         client: Arc<RwLock<RpcClient>>,
     ) -> Result<Option<RecommendedWatcher>, notify::Error> {
-        let Some(ref client_cert) = self.client_cert.clone() else {
+        let Some(client_cert) = self.client_cert.as_ref() else {
             return Ok(None);
         };
 


### PR DESCRIPTION
borrow the configured ClientCert in start_certificate_watcher, drop the redundant clone() allocation while keeping behavior unchanged