### PR TITLE
feat(node/actor): Make NetworkActor generic

### DIFF
--- a/crates/node/service/src/actors/mod.rs
+++ b/crates/node/service/src/actors/mod.rs
@@ -29,9 +29,10 @@ pub use l1_watcher_rpc::{
 
 mod network;
 pub use network::{
-    NetworkActor, NetworkActorError, NetworkBuilder, NetworkBuilderError, NetworkConfig,
-    NetworkContext, NetworkDriver, NetworkDriverError, NetworkHandler, NetworkInboundData,
-    QueuedUnsafePayloadGossipClient, UnsafePayloadGossipClient, UnsafePayloadGossipClientError,
+    NetworkActor, NetworkActorError, NetworkBuilder, NetworkBuilderError, NetworkBuilderExt,
+    NetworkConfig, NetworkContext, NetworkDriver, NetworkDriverError, NetworkHandler,
+    NetworkInboundData, QueuedUnsafePayloadGossipClient, UnsafePayloadGossipClient,
+    UnsafePayloadGossipClientError,
 };
 
 mod sequencer;

--- a/crates/node/service/src/actors/network/builder.rs
+++ b/crates/node/service/src/actors/network/builder.rs
@@ -15,6 +15,8 @@ use crate::{
     actors::network::{NetworkConfig, NetworkDriver},
 };
 
+use super::NetworkBuilderExt;
+
 /// Constructs a [`NetworkDriver`] for the OP Stack Consensus Layer.
 #[derive(Debug)]
 pub struct NetworkBuilder {
@@ -170,6 +172,12 @@ impl NetworkBuilder {
             signer: self.signer,
             enr_update: self.enr_update,
         })
+    }
+}
+
+impl NetworkBuilderExt for NetworkBuilder {
+    fn build(self) -> Result<NetworkDriver, NetworkBuilderError> {
+        self.build()
     }
 }
 

--- a/crates/node/service/src/actors/network/mod.rs
+++ b/crates/node/service/src/actors/network/mod.rs
@@ -5,6 +5,8 @@ pub use actor::{NetworkActor, NetworkActorError, NetworkContext, NetworkInboundD
 
 mod builder;
 pub use builder::NetworkBuilder;
+mod network_builder;
+pub use network_builder::NetworkBuilderExt;
 
 mod driver;
 pub use driver::{NetworkDriver, NetworkDriverError};

--- a/crates/node/service/src/actors/network/network_builder.rs
+++ b/crates/node/service/src/actors/network/network_builder.rs
@@ -1,0 +1,11 @@
+//! Contains traits for working with Network Builder.
+
+use core::fmt::Debug;
+
+use super::{NetworkBuilderError, NetworkDriver};
+
+/// Contains methods for building a [`NetworkDriver`].
+pub trait NetworkBuilderExt: Debug + Send {
+    /// Builds a [`NetworkDriver`].
+    fn build(self) -> Result<NetworkDriver, NetworkBuilderError>;
+}

--- a/crates/node/service/src/lib.rs
+++ b/crates/node/service/src/lib.rs
@@ -21,12 +21,12 @@ pub use actors::{
     InboundDerivationMessage, L1OriginSelector, L1OriginSelectorError, L1OriginSelectorProvider,
     L1WatcherRpc, L1WatcherRpcContext, L1WatcherRpcError, L1WatcherRpcInboundChannels,
     L1WatcherRpcState, L2Finalizer, NetworkActor, NetworkActorError, NetworkBuilder,
-    NetworkBuilderError, NetworkConfig, NetworkContext, NetworkDriver, NetworkDriverError,
-    NetworkHandler, NetworkInboundData, NodeActor, OriginSelector, PipelineBuilder,
-    QueuedBlockBuildingClient, QueuedSequencerAdminAPIClient, QueuedUnsafePayloadGossipClient,
-    ResetRequest, RpcActor, RpcActorError, RpcContext, SealRequest, SequencerActor,
-    SequencerActorBuilder, SequencerActorError, SequencerAdminQuery, SequencerConfig,
-    UnsafePayloadGossipClient, UnsafePayloadGossipClientError,
+    NetworkBuilderError, NetworkBuilderExt, NetworkConfig, NetworkContext, NetworkDriver,
+    NetworkDriverError, NetworkHandler, NetworkInboundData, NodeActor, OriginSelector,
+    PipelineBuilder, QueuedBlockBuildingClient, QueuedSequencerAdminAPIClient,
+    QueuedUnsafePayloadGossipClient, ResetRequest, RpcActor, RpcActorError, RpcContext,
+    SealRequest, SequencerActor, SequencerActorBuilder, SequencerActorError, SequencerAdminQuery,
+    SequencerConfig, UnsafePayloadGossipClient, UnsafePayloadGossipClientError,
 };
 
 mod metrics;

--- a/examples/gossip/src/main.rs
+++ b/examples/gossip/src/main.rs
@@ -21,7 +21,7 @@ use clap::Parser;
 use discv5::enr::CombinedKey;
 use kona_cli::{LogArgs, LogConfig};
 use kona_disc::LocalNode;
-use kona_node_service::{NetworkActor, NetworkConfig, NetworkContext, NodeActor};
+use kona_node_service::{NetworkActor, NetworkBuilder, NetworkConfig, NetworkContext, NodeActor};
 use kona_registry::ROLLUP_CONFIGS;
 use libp2p::{Multiaddr, identity::Keypair};
 use std::{
@@ -81,7 +81,7 @@ impl GossipCommand {
         let disc_addr =
             LocalNode::new(secret_key, IpAddr::V4(disc_ip), self.disc_port, self.disc_port);
 
-        let (_, network) = NetworkActor::new(
+        let (_, network) = NetworkActor::<NetworkBuilder>::new(
             NetworkConfig {
                 discovery_address: disc_addr,
                 gossip_address: gossip_addr,


### PR DESCRIPTION
Fixes #3074

Creates a trait called `NetworkBuilderExt` which encompasses the `build` function under `NetworkBuilder`. I assume this is the only field in `NetworkActor` that we want to generalize