### PR TITLE
Remove redundant DeserializeOwned bound from ConvertRuint

### DIFF
--- a/crates/utilities/serde/src/quantity.rs
+++ b/crates/utilities/serde/src/quantity.rs
@@ -40,12 +40,7 @@ mod private {
 
     #[doc(hidden)]
     pub trait ConvertRuint: Copy + Sized {
-        type Ruint: Copy
-            + serde::Serialize
-            + serde::de::DeserializeOwned
-            + TryFrom<Self>
-            + TryInto<Self>
-            + FromStr;
+        type Ruint: Copy + serde::Serialize + TryFrom<Self> + TryInto<Self> + FromStr;
 
         #[inline]
         fn into_ruint(self) -> Self::Ruint {


### PR DESCRIPTION
drop the unused serde::de::DeserializeOwned requirement from ConvertRuint::Ruint, keeping only the traits exercised by the helpers