### PR TITLE
feat(docker): Build cannon kona prestates for custom chains

### DIFF
--- a/crates/protocol/registry/build.rs
+++ b/crates/protocol/registry/build.rs
@@ -198,10 +198,20 @@ fn merge_superchain_configs(custom_path: &Path, target_path: &Path) {
     for custom in custom_superchains.superchains {
         match superchains.entry(custom.name.clone()) {
             Entry::Occupied(mut entry) => {
+                println!(
+                    "cargo:warning=debug: merging custom chains {}: [{}]",
+                    custom.name,
+                    custom.chains.iter().map(|c| c.name.as_str()).collect::<Vec<_>>().join(",")
+                );
                 let existing = entry.get_mut();
                 *existing = merge_superchain_entry(std::mem::take(existing), custom);
             }
             Entry::Vacant(entry) => {
+                println!(
+                    "cargo:warning=debug: inserting new custom chain {}: [{}]",
+                    custom.name,
+                    custom.chains.iter().map(|c| c.name.as_str()).collect::<Vec<_>>().join(",")
+                );
                 entry.insert(custom);
             }
         }

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -100,6 +100,19 @@ variable "CLIENT_BIN" {
   description = "The kona-client binary to use in the proof prestate targets. Valid options: kona, kona-int"
 }
 
+variable "KONA_CUSTOM_CONFIGS" {
+  // Used to build a kona prestate using custom chain configurations
+  default = "false"
+  description = "Enables custom chain configurations to be built into kona artifacts"
+}
+
+variable "CUSTOM_CONFIGS_CONTEXT" {
+  // The build context for custom chain configurations to add to the prestate build
+  default = ""
+  description = "The build context for custom chain configurations to add to the prestate build"
+}
+
+
 target "asterisc-builder" {
   description = "Rust build environment for bare-metal RISC-V 64-bit IMA (Asterisc FPVM ISA)"
   inherits = ["docker-metadata-action"]
@@ -135,10 +148,14 @@ target "kona-cannon-prestate" {
   inherits = ["docker-metadata-action"]
   context = "."
   dockerfile = "docker/fpvm-prestates/cannon-repro.dockerfile"
+  contexts = {
+    custom_configs = "${CUSTOM_CONFIGS_CONTEXT}"
+  }
   args = {
     CLIENT_BIN = "${CLIENT_BIN}"
     CLIENT_TAG = "${GIT_REF_NAME}"
     CANNON_TAG = "${CANNON_TAG}"
+    KONA_CUSTOM_CONFIGS = "${KONA_CUSTOM_CONFIGS}"
   }
   # Only build on linux/amd64 for a single source of reproducibility.
   platforms = ["linux/amd64"]

--- a/docker/fpvm-prestates/README.md
+++ b/docker/fpvm-prestates/README.md
@@ -25,3 +25,13 @@ just asterisc <kona|kona-int> <kona_tag> <asterisc_tag>
 # Produce the prestate artifacts for `kona-client` running on `cannon` (version specified by `cannon_tag`)
 just cannon <kona|kona-int> <kona_tag> <cannon_tag>
 ```
+
+### `kona-client` + `cannon` prestate artifacts for custom chains
+
+To create a reproducible kona-client prestate build that supports custom or devnet chain configurations that are not in the superchain-registry:
+
+```sh
+# Produce the prestate artifacts for `kona-client` running on `cannon` (version specified by `cannon_tag`)
+just cannon <kona|kona-int> <kona_tag> <cannon_tag> <artifacts_output_dir> <custom_config_dir>
+```
+

--- a/docker/fpvm-prestates/cannon-repro.dockerfile
+++ b/docker/fpvm-prestates/cannon-repro.dockerfile
@@ -35,12 +35,18 @@ SHELL ["/bin/bash", "-c"]
 
 ARG CLIENT_BIN
 ARG CLIENT_TAG
+ARG KONA_CUSTOM_CONFIGS
+
+COPY --from=custom_configs / /usr/local/kona-custom-configs
 
 # Install deps
 RUN apt-get update && apt-get install -y --no-install-recommends git
 
 # Clone kona at the specified tag
 RUN git clone https://github.com/op-rs/kona
+
+ENV KONA_CUSTOM_CONFIGS=$KONA_CUSTOM_CONFIGS
+ENV KONA_CUSTOM_CONFIGS_DIR=/usr/local/kona-custom-configs
 
 # Build kona-client on the selected tag
 RUN cd kona && \

--- a/docker/fpvm-prestates/justfile
+++ b/docker/fpvm-prestates/justfile
@@ -64,7 +64,11 @@ build-client-prestate-asterisc-artifacts kona_client_variant kona_tag asterisc_t
     kona-asterisc-prestate
 
 # Build the `kona-client` prestate artifacts for the latest release (cannon).
-build-client-prestate-cannon-artifacts kona_client_variant kona_tag cannon_tag out='./prestate-artifacts-cannon':
+build-client-prestate-cannon-artifacts \
+    kona_client_variant \
+    kona_tag cannon_tag \
+    out='./prestate-artifacts-cannon' \
+    custom_config_dir='':
   #!/bin/bash
   OUTPUT_DIR={{out}}
 
@@ -77,6 +81,21 @@ build-client-prestate-cannon-artifacts kona_client_variant kona_tag cannon_tag o
   # Navigate to workspace root
   cd ../..
 
+  if [[ -n "{{custom_config_dir}}" ]]; then
+    export KONA_CUSTOM_CONFIGS="true"
+    export CUSTOM_CONFIGS_CONTEXT="{{custom_config_dir}}"
+    if [ ! -d "{{custom_config_dir}}" ]; then
+        echo "Invalid custom config directory: {{custom_config_dir}}"
+        exit 1
+    fi
+    echo "Using custom config directory: {{custom_config_dir}}"
+  else
+    # set to an empty directory to satisfy the docker build context requirement
+    TEMP_DIR=$(mktemp -d)
+    trap "rm -rf $TEMP_DIR" EXIT
+    export CUSTOM_CONFIGS_CONTEXT="$TEMP_DIR"
+  fi
+
   # Create the output directory
   mkdir -p $OUTPUT_DIR
 
@@ -84,4 +103,5 @@ build-client-prestate-cannon-artifacts kona_client_variant kona_tag cannon_tag o
   docker buildx bake \
     --set "*.output=$OUTPUT_DIR" \
     -f docker/docker-bake.hcl \
+    --allow fs=${CUSTOM_CONFIGS_CONTEXT} \
     kona-cannon-prestate


### PR DESCRIPTION
This patch adds support for custom chain configurations when invoking the `just cannon` recipe to build cannon kona prestates.
This is useful for devnets and unannounced chains to also enjoy reproducible prestate builds.

## Testing

- [x] Build canonical prestates of kona-client releases and ensure the hashes are [standard prestates hashes](https://github.com/ethereum-optimism/superchain-registry/blob/17e5b8f2639324402f192d379cba0d09cddd2a6c/validation/standard/standard-prestates.toml).
- [x] Verify that custom prestates contain the custom chain configs