### PR TITLE
chore(core): remove dead metrics_enabled from ChainProcessor

### DIFF
--- a/crates/supervisor/core/src/chain_processor/chain.rs
+++ b/crates/supervisor/core/src/chain_processor/chain.rs
@@ -21,7 +21,6 @@ use tracing::debug;
 #[derive(Debug)]
 pub struct ChainProcessor<P, W, V> {
     chain_id: ChainId,
-    metrics_enabled: Option<bool>,
 
     // state
     state: ProcessorState,
@@ -82,7 +81,6 @@ where
 
         Self {
             chain_id,
-            metrics_enabled: None,
 
             state: ProcessorState::new(),
 
@@ -100,7 +98,6 @@ where
 
     /// Enables metrics on the database environment.
     pub fn with_metrics(mut self) -> Self {
-        self.metrics_enabled = Some(true);
         super::Metrics::init(self.chain_id);
         self
     }


### PR DESCRIPTION
The metrics_enabled field in ChainProcessor was unused and misleading. with_metrics() did not gate metrics but only initialized descriptors/zero-values. This change removes the dead field and leaves with_metrics() as a metrics initializer to align with the existing pattern used in reorg and RPC modules. This avoids confusion without altering handler behavior or introducing config-level gating.