### PR TITLE
fix(protocol): accept zlib only when CM=8 in CMF header

### DIFF
--- a/crates/protocol/protocol/src/batch/reader.rs
+++ b/crates/protocol/protocol/src/batch/reader.rs
@@ -79,9 +79,7 @@ impl BatchReader {
             }
 
             let compression_type = data[0];
-            if (compression_type & 0x0F) == Self::ZLIB_DEFLATE_COMPRESSION_METHOD ||
-                (compression_type & 0x0F) == Self::ZLIB_RESERVED_COMPRESSION_METHOD
-            {
+            if (compression_type & 0x0F) == Self::ZLIB_DEFLATE_COMPRESSION_METHOD {
                 self.decompressed =
                     decompress_to_vec_zlib(&data).map_err(|_| DecompressionError::ZlibError)?;
 


### PR DESCRIPTION
The zlib CMF byte’s lower nibble (CM) must be 8 (DEFLATE) per RFC 1950. We previously also accepted 15, which is reserved and not a valid method. This could misclassify invalid inputs as zlib and defer failure to the decompressor, masking the real issue. The detection now only treats CM=8 as zlib. Brotli handling is unchanged. This improves correctness and error signaling