### PR TITLE
fix(registry): avoid extra allocation in default_blob_schedule keys

### DIFF
--- a/crates/protocol/registry/src/l1/mod.rs
+++ b/crates/protocol/registry/src/l1/mod.rs
@@ -1,5 +1,4 @@
 //! L1 genesis configurations.
-use crate::alloc::string::ToString;
 use alloc::{collections::BTreeMap, string::String};
 use alloy_eips::eip7840::BlobParams;
 use alloy_genesis::EthashConfig;


### PR DESCRIPTION
Replaced name().to_string().to_lowercase() with name().to_lowercase() when building blob_schedule keys in 
L1Config. name() returns &'static str, so going straight to to_lowercase() avoids an intermediate allocation without changing behavior. Tests already use the same lowercase form for lookups.