### PR TITLE
feat(rpc): add /kona-rollup-boost/healthz endpoint

### DIFF
--- a/crates/node/rpc/src/health.rs
+++ b/crates/node/rpc/src/health.rs
@@ -1,36 +1,15 @@
 use async_trait::async_trait;
-use jsonrpsee::{
-    core::RpcResult,
-    types::{ErrorCode, ErrorObject},
-};
+use jsonrpsee::core::RpcResult;
 use rollup_boost::Health;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::oneshot;
 
 use crate::jsonrpsee::HealthzApiServer;
 
-/// Key for the rollup boost health status.
-/// +----------------+-------------------------------+--------------------------------------+-------------------------------+
-/// | Execution Mode | Healthy                       | PartialContent                       | Service Unavailable           |
-/// +----------------+-------------------------------+--------------------------------------+-------------------------------+
-/// | Enabled        | - Request-path: L2 succeeds   | - Request-path: builder fails/stale  | - Request-path: L2 fails      |
-/// |                |   (get/new payload) → 200     |   while L2 succeeds → 206            |   (error from L2) → 503       |
-/// |                | - Background: builder         | - Background: builder fetch fails or | - Background: never sets 503  |
-/// |                |   latest-unsafe is fresh →    |   latest-unsafe is stale → 206       |                               |
-/// |                |   200                         |                                      |                               |
-/// +----------------+-------------------------------+--------------------------------------+-------------------------------+
-/// | DryRun         | - Request-path: L2 succeeds   | - Never set in DryRun                | - Request-path: L2 fails      |
-/// |                |   (always returns L2) → 200   |   (degrade only in Enabled)          |   (error from L2) → 503       |
-/// |                | - Background: builder stale   |                                      | - Background: never sets 503  |
-/// |                |   ignored (remains 200)       |                                      |                               |
-/// +----------------+-------------------------------+--------------------------------------+-------------------------------+
-/// | Disabled       | - Request-path: L2 succeeds   | - Never set in Disabled              | - Request-path: L2 fails      |
-/// |                |   (builder skipped) → 200     |   (degrade only in Enabled)          |   (error from L2) → 503       |
-/// |                | - Background: N/A             |                                      | - Background: never sets 503  |
-/// +----------------+-------------------------------+--------------------------------------+-------------------------------+
+/// The rollup boost health status.
 ///
 /// This type is the same as [`Health`], but it implements `serde::Serialize`
 /// and `serde::Deserialize`.
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub enum RollupBoostHealth {
     /// Rollup boost is healthy.
     Healthy,
@@ -55,8 +34,6 @@ impl From<Health> for RollupBoostHealth {
 pub struct HealthzResponse {
     /// The application version.
     pub version: String,
-    /// The rollup boost health.
-    pub rollup_boost_health: RollupBoostHealth,
 }
 
 /// A query to get the health of the rollup boost server.
@@ -67,32 +44,19 @@ pub struct RollupBoostHealthQuery {
 }
 
 /// The healthz rpc server.
-#[derive(Debug)]
-pub struct HealthzRpc {
-    /// The rollup boost health.
-    pub rollup_boost_health: mpsc::Sender<RollupBoostHealthQuery>,
-}
+#[derive(Debug, Default)]
+pub struct HealthzRpc;
 
 impl HealthzRpc {
-    /// Constructs a new [`HealthzRpc`] given the rollup boost health sender.
-    pub const fn new(rollup_boost_health: mpsc::Sender<RollupBoostHealthQuery>) -> Self {
-        Self { rollup_boost_health }
+    /// Constructs a new [`HealthzRpc`].
+    pub const fn new() -> Self {
+        Self
     }
 }
 
 #[async_trait]
 impl HealthzApiServer for HealthzRpc {
     async fn healthz(&self) -> RpcResult<HealthzResponse> {
-        let (tx, rx) = oneshot::channel();
-
-        self.rollup_boost_health
-            .send(RollupBoostHealthQuery { sender: tx })
-            .await
-            .map_err(|_| ErrorObject::from(ErrorCode::InternalError))?;
-
-        let rollup_boost_health =
-            rx.await.map_err(|_| ErrorObject::from(ErrorCode::InternalError))?;
-
-        Ok(HealthzResponse { version: env!("CARGO_PKG_VERSION").to_string(), rollup_boost_health })
+        Ok(HealthzResponse { version: env!("CARGO_PKG_VERSION").to_string() })
     }
 }

--- a/crates/node/service/Cargo.toml
+++ b/crates/node/service/Cargo.toml
@@ -66,6 +66,7 @@ jsonrpsee = { workspace = true, features = ["server"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tower.workspace = true
 http-body-util.workspace = true
+http.workspace = true
 
 # metrics
 metrics = { workspace = true, optional = true }


### PR DESCRIPTION
## Summary

Separates rollup boost health into a dedicated `/kona-rollup-boost/healthz` HTTP endpoint with proper status codes.

## Changes

- Add tower middleware to serve `/kona-rollup-boost/healthz` with HTTP status codes:
  - `200 OK` — healthy
  - `206 Partial Content` — L2 healthy but builder unhealthy
  - `503 Service Unavailable` — L2 unhealthy
- Remove `rollup_boost_health` field from `/healthz` response
- Simplify `HealthzRpc` to only return version info