### PR TITLE
refactor(rpc): move rollup_boost_health to separate endpoint

### DIFF
--- a/crates/node/rpc/src/jsonrpsee.rs
+++ b/crates/node/rpc/src/jsonrpsee.rs
@@ -1,6 +1,9 @@
 //! The Optimism RPC API using `jsonrpsee`
 
-use crate::{OutputResponse, SafeHeadResponse, health::HealthzResponse};
+use crate::{
+    OutputResponse, SafeHeadResponse,
+    health::{HealthzResponse, RollupBoostHealthzResponse},
+};
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::B256;
 use core::net::IpAddr;
@@ -219,4 +222,13 @@ pub trait HealthzApi {
     /// Gets the health of the kona-node.
     #[method(name = "healthz")]
     async fn healthz(&self) -> RpcResult<HealthzResponse>;
+}
+
+/// The rollup boost health namespace.
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "kona-rollup-boost"))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "kona-rollup-boost"))]
+pub trait RollupBoostHealthzApi {
+    /// Gets the rollup boost health.
+    #[method(name = "healthz")]
+    async fn rollup_boost_healthz(&self) -> RpcResult<RollupBoostHealthzResponse>;
 }

--- a/crates/node/rpc/src/lib.rs
+++ b/crates/node/rpc/src/lib.rs
@@ -35,7 +35,7 @@ pub use dev::DevEngineRpc;
 mod jsonrpsee;
 pub use jsonrpsee::{
     AdminApiServer, DevEngineApiServer, HealthzApiServer, MinerApiExtServer, OpAdminApiServer,
-    OpP2PApiServer, RollupNodeApiServer, WsServer,
+    OpP2PApiServer, RollupBoostHealthzApiServer, RollupNodeApiServer, WsServer,
 };
 
 mod rollup;
@@ -48,4 +48,7 @@ mod ws;
 pub use ws::WsRPC;
 
 mod health;
-pub use health::{HealthzResponse, HealthzRpc, RollupBoostHealth, RollupBoostHealthQuery};
+pub use health::{
+    HealthzResponse, HealthzRpc, RollupBoostHealth, RollupBoostHealthQuery,
+    RollupBoostHealthzResponse,
+};


### PR DESCRIPTION
## Summary

Moves `rollup_boost_health` from the `/healthz` endpoint to a dedicated `/kona-rollup-boost/healthz` endpoint.

## Changes

- `/healthz` now returns only `{ "version": "..." }`
- New `/kona-rollup-boost/healthz` endpoint returns `{ "rollup_boost_health": "..." }`