### PR TITLE
fix(node): remove incorrect LocalNode->ListenConfig

### DIFF
--- a/crates/node/disc/src/builder.rs
+++ b/crates/node/disc/src/builder.rs
@@ -21,15 +21,6 @@ pub struct LocalNode {
     pub udp_port: u16,
 }
 
-impl From<&LocalNode> for discv5::ListenConfig {
-    fn from(local_node: &LocalNode) -> Self {
-        match local_node.ip {
-            IpAddr::V4(ip) => Self::Ipv4 { ip, port: local_node.tcp_port },
-            IpAddr::V6(ip) => Self::Ipv6 { ip, port: local_node.tcp_port },
-        }
-    }
-}
-
 impl LocalNode {
     /// Creates a new [`LocalNode`] instance.
     pub const fn new(


### PR DESCRIPTION
discv5’s ListenConfig.port is the UDP discovery port (see sigp/discv5 socket/mod.rs where it binds UdpSocket). The LocalNode->ListenConfig conversion used tcp_port, which is semantically wrong, and it was not used anywhere in the codebase. Keeping this impl risks future misuse when tcp_port != udp_port, causing the node to listen on a different UDP port than the one advertised in the ENR. 