### PR TITLE
chore(proof): add panic message to riscv exit syscall

### DIFF
--- a/crates/proof/std-fpvm/src/riscv64/io.rs
+++ b/crates/proof/std-fpvm/src/riscv64/io.rs
@@ -65,7 +65,7 @@ impl BasicKernelInterface for RiscV64IO {
     fn exit(code: usize) -> ! {
         unsafe {
             let _ = syscall::syscall1(SyscallNumber::Exit as usize, code);
-            panic!()
+            panic!("exit syscall returned unexpectedly with code: {}", code)
         }
     }
 }


### PR DESCRIPTION
Add a diagnostic message to the riscv exit syscall panic, ensuring consistency with the mips implementation and aiding debugging if the syscall fails.