### PR TITLE
feat: bump rollup-boost

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9851,7 +9851,7 @@ dependencies = [
 [[package]]
 name = "rollup-boost"
 version = "0.1.0"
-source = "git+https://github.com/flashbots/rollup-boost.git?rev=7fda98f#7fda98f6a514c0d7ce9b0c44992ff679dca482ef"
+source = "git+https://github.com/flashbots/rollup-boost.git?rev=34bb8738a2f9b7cd14b27f8965bc72e6e84955bd#34bb8738a2f9b7cd14b27f8965bc72e6e84955bd"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -274,5 +274,5 @@ secp256k1 = { version = "0.31.0", default-features = false }
 ark-bls12-381 = { version = "0.5.0", default-features = false }
 
 # Rollup Boost (required for rollup-boost integration)
-rollup-boost = { git = "https://github.com/flashbots/rollup-boost.git", rev = "7fda98f" }
+rollup-boost = { git = "https://github.com/flashbots/rollup-boost.git", rev = "34bb8738a2f9b7cd14b27f8965bc72e6e84955bd" }
 parking_lot = "0.12.3"

--- a/bin/node/src/flags/engine/flashblocks.rs
+++ b/bin/node/src/flags/engine/flashblocks.rs
@@ -9,6 +9,7 @@ const DEFAULT_FLASHBLOCKS_BUILDER_WS_INITIAL_RECONNECT_MS: u64 = 10;
 const DEFAULT_FLASHBLOCKS_BUILDER_WS_MAX_RECONNECT_MS: u64 = 5000;
 const DEFAULT_FLASHBLOCKS_BUILDER_WS_PING_INTERVAL_MS: u64 = 500;
 const DEFAULT_FLASHBLOCKS_BUILDER_WS_PONG_TIMEOUT_MS: u64 = 1500;
+const DEFAULT_FLASHBLOCKS_BUILDER_WS_CONNECT_TIMEOUT_MS: u64 = 5000;
 
 /// Flashblocks flags.
 #[derive(Clone, Debug, clap::Args)]
@@ -106,6 +107,15 @@ pub struct FlashblocksWebsocketFlags {
         default_value_t = DEFAULT_FLASHBLOCKS_BUILDER_WS_PONG_TIMEOUT_MS
     )]
     pub flashblock_builder_ws_pong_timeout_ms: u64,
+
+    /// Timeout in milliseconds to wait for initial connection to upstream servers
+    #[arg(
+        long,
+        visible_alias = "rollup-boost.flashblocks-connect-timeout-ms",
+        env = "KONA_NODE_FLASHBLOCKS_BUILDER_WS_CONNECT_TIMEOUT_MS",
+        default_value_t = DEFAULT_FLASHBLOCKS_BUILDER_WS_CONNECT_TIMEOUT_MS
+    )]
+    pub flashblock_builder_ws_connect_timeout_ms: u64,
 }
 
 impl FlashblocksFlags {
@@ -130,6 +140,9 @@ impl FlashblocksFlags {
                 flashblock_builder_ws_pong_timeout_ms: self
                     .flashblocks_ws_config
                     .flashblock_builder_ws_pong_timeout_ms,
+                flashblock_builder_ws_connect_timeout_ms: self
+                    .flashblocks_ws_config
+                    .flashblock_builder_ws_connect_timeout_ms,
             },
         }
     }
@@ -142,6 +155,7 @@ impl Default for FlashblocksWebsocketFlags {
             flashblock_builder_ws_max_reconnect_ms: 5000,
             flashblock_builder_ws_ping_interval_ms: 500,
             flashblock_builder_ws_pong_timeout_ms: 1500,
+            flashblock_builder_ws_connect_timeout_ms: 5000,
         }
     }
 }

--- a/bin/node/src/flags/engine/rollup_boost.rs
+++ b/bin/node/src/flags/engine/rollup_boost.rs
@@ -107,6 +107,10 @@ impl RollupBoostFlags {
                             .flashblocks
                             .flashblocks_ws_config
                             .flashblock_builder_ws_pong_timeout_ms,
+                        flashblock_builder_ws_connect_timeout_ms: self
+                            .flashblocks
+                            .flashblocks_ws_config
+                            .flashblock_builder_ws_connect_timeout_ms,
                     },
                 },
             ),

--- a/crates/node/engine/src/client.rs
+++ b/crates/node/engine/src/client.rs
@@ -182,6 +182,8 @@ impl EngineClientBuilder {
                                     .flashblock_builder_ws_ping_interval_ms,
                                 flashblock_builder_ws_pong_timeout_ms: ws_config
                                     .flashblock_builder_ws_pong_timeout_ms,
+                                flashblock_builder_ws_connect_timeout_ms: ws_config
+                                    .flashblock_builder_ws_connect_timeout_ms,
                             },
                         )
                         .map_err(|e| EngineClientBuilderError::FlashblocksError(e.to_string()))?,

--- a/crates/node/engine/src/rollup_boost.rs
+++ b/crates/node/engine/src/rollup_boost.rs
@@ -64,6 +64,9 @@ pub struct FlashblocksWebsocketConfig {
     /// Timeout in milliseconds to wait for pong responses from upstream servers before considering
     /// the connection dead
     pub flashblock_builder_ws_pong_timeout_ms: u64,
+
+    /// Timeout in milliseconds to wait for the connection to be established
+    pub flashblock_builder_ws_connect_timeout_ms: u64,
 }
 
 /// An error that occurred in the rollup-boost server.

--- a/crates/node/service/tests/rollup_boost_missing_jwt.rs
+++ b/crates/node/service/tests/rollup_boost_missing_jwt.rs
@@ -42,6 +42,7 @@ mod tests {
                     flashblock_builder_ws_max_reconnect_ms: 5000,
                     flashblock_builder_ws_ping_interval_ms: 500,
                     flashblock_builder_ws_pong_timeout_ms: 1500,
+                    flashblock_builder_ws_connect_timeout_ms: 5000,
                 },
             },
             block_selection_policy: None,


### PR DESCRIPTION
Part of https://github.com/op-rs/kona/pull/3085
Context: https://github.com/op-rs/kona/pull/3085#discussion_r2586456741

Bumps `rollup-boost` to the latest commit and fixes a few breaking changes on the upstream