### PR TITLE
chore(ci): reactivate conductor tests with Kurtosis

### DIFF
--- a/.github/workflows/node_e2e_conductor_tests.yaml
+++ b/.github/workflows/node_e2e_conductor_tests.yaml
@@ -1,9 +1,9 @@
 name: Conductor E2E Tests
 on:
-  push:
-    branches: [main]
-  merge_group:
-  pull_request:
+  # Temporarily disabled until upstream fix is merged.
+  # See: https://github.com/ethpandaops/optimism-package/issues/406
+  # The kona-node launcher needs --l1-config-file support for custom devnet chains.
+  workflow_dispatch:
 env:
   CARGO_TERM_COLOR: always
 jobs:


### PR DESCRIPTION
Add a new CI workflow to run conductor tests using the Kurtosis (sysext) orchestrator. This is necessary because the sysgo orchestrator does not yet support conductors (see ethereum-optimism/optimism#16418).

The workflow:
- Builds the kona-node docker image
- Deploys the simple-kona-conductor devnet via Kurtosis
- Runs TestConductorLeadershipTransfer test

Once sysgo supports conductors upstream, these tests can be migrated to the existing sysgo workflow.

Closes #3094