### PR TITLE
fix(sources): migrate from rustls-pemfile to rustls-pki-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5437,7 +5437,6 @@ dependencies = [
  "op-alloy-rpc-types-engine",
  "reqwest",
  "rustls",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -10109,15 +10108,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework 3.5.1",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,6 @@ jsonrpsee = "0.26.0"
 jsonrpsee-types = "0.26.0"
 tokio-util = "0.7.15"
 rustls = { version = "0.23", default-features = false }
-rustls-pemfile = { version = "2.0", default-features = false }
 vergen-git2 = "1.0.7"
 async-trait = "0.1.88"
 tokio-stream = "0.1.17"

--- a/crates/node/sources/Cargo.toml
+++ b/crates/node/sources/Cargo.toml
@@ -45,7 +45,6 @@ url.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 rustls.workspace = true
-rustls-pemfile = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["full"] }
 notify.workspace = true
 


### PR DESCRIPTION
## Changes
- `crates/node/sources/src/signer/remote/cert.rs`: Use `CertificateDer::pem_file_iter` and `PrivateKeyDer::from_pem_file` instead of `rustls_pemfile` functions
- `crates/node/sources/Cargo.toml`: Remove `rustls-pemfile` dependency
- `Cargo.toml`: Remove `rustls-pemfile` from workspace dependencies

Closes #3149