### PR TITLE
fix(peers): correct error message in OpStackEnr decode

### DIFF
--- a/crates/node/peers/src/enr.rs
+++ b/crates/node/peers/src/enr.rs
@@ -115,7 +115,7 @@ impl Decodable for OpStackEnr {
         let (chain_id, rest) = decode::u64(&bytes)
             .map_err(|_| alloy_rlp::Error::Custom("could not decode chain id"))?;
         let (version, _) =
-            decode::u64(rest).map_err(|_| alloy_rlp::Error::Custom("could not decode chain id"))?;
+            decode::u64(rest).map_err(|_| alloy_rlp::Error::Custom("could not decode version"))?;
         Ok(Self { chain_id, version })
     }
 }


### PR DESCRIPTION
Fixed a copy-paste error in the OpStackEnr decoder where the error message for version decoding incorrectly said "could not decode chain id" instead of "could not decode version". Small fix but makes debugging easier when ENR parsing fails.