### PR TITLE
chore(node/service): remove unused constructor and unnecessary underscore

### DIFF
--- a/crates/node/service/src/actors/l1_watcher/actor.rs
+++ b/crates/node/service/src/actors/l1_watcher/actor.rs
@@ -50,37 +50,6 @@ where
     /// A stream over the finalized block accepted as canonical.
     finalized_stream: BS,
 }
-impl<BS, L1P> L1WatcherActor<BS, L1P>
-where
-    BS: Stream<Item = BlockInfo> + Unpin + Send,
-    L1P: Provider,
-{
-    /// Instantiate a new [`L1WatcherActor`].
-    #[allow(clippy::too_many_arguments)]
-    pub const fn new(
-        rollup_config: Arc<RollupConfig>,
-        l1_provider: L1P,
-        l1_query_rx: mpsc::Receiver<L1WatcherQueries>,
-        l1_head_updates_tx: watch::Sender<Option<BlockInfo>>,
-        finalized_l1_block_tx: watch::Sender<Option<BlockInfo>>,
-        signer: mpsc::Sender<Address>,
-        cancellation: CancellationToken,
-        head_stream: BS,
-        finalized_stream: BS,
-    ) -> Self {
-        Self {
-            rollup_config,
-            l1_provider,
-            inbound_queries: l1_query_rx,
-            latest_head: l1_head_updates_tx,
-            latest_finalized: finalized_l1_block_tx,
-            block_signer_sender: signer,
-            cancellation,
-            head_stream,
-            finalized_stream,
-        }
-    }
-}
 
 #[async_trait]
 impl<BS, L1P> NodeActor for L1WatcherActor<BS, L1P>

--- a/crates/node/service/src/actors/sequencer/actor.rs
+++ b/crates/node/service/src/actors/sequencer/actor.rs
@@ -154,12 +154,12 @@ where
 
         // If the conductor is available, commit the payload to it.
         if let Some(conductor) = &self.conductor {
-            let _conductor_commitment_start = Instant::now();
+            let conductor_commitment_start = Instant::now();
             if let Err(err) = conductor.commit_unsafe_payload(&payload).await {
                 error!(target: "sequencer", ?err, "Failed to commit unsafe payload to conductor");
             }
 
-            update_conductor_commitment_duration_metrics(_conductor_commitment_start.elapsed());
+            update_conductor_commitment_duration_metrics(conductor_commitment_start.elapsed());
         }
 
         self.unsafe_payload_gossip_client


### PR DESCRIPTION
Remove unused constructor.

Remove unnecessary underscore.