### PR TITLE
fix(supervisor): correct misleading error comment in LogIndexer

### DIFF
--- a/crates/supervisor/core/src/logindexer/indexer.rs
+++ b/crates/supervisor/core/src/logindexer/indexer.rs
@@ -166,7 +166,7 @@ pub enum LogIndexerError {
     #[error(transparent)]
     StateWrite(#[from] StorageError),
 
-    /// Failed to fetch logs for a block from the state manager.   
+    /// Failed to fetch receipts for a block from the managed node.
     #[error(transparent)]
     FetchReceipt(#[from] ManagedNodeError),
 }


### PR DESCRIPTION
The comment for `FetchReceipt` error variant incorrectly said "Failed to fetch logs for a block from the state manager" but the error wraps `ManagedNodeError` from receipt fetching operations, not log fetching from state manager. Updated to accurately describe what the error represents.