### PR TITLE
feat(host): Configuration using a single l1 genesis

### DIFF
--- a/bin/host/src/interop/local_kv.rs
+++ b/bin/host/src/interop/local_kv.rs
@@ -39,8 +39,8 @@ impl KeyValueStore for InteropLocalInputs {
                 serde_json::to_vec(&rollup_configs).ok()
             }
             L1_CONFIG_KEY => {
-                let l1_configs = self.cfg.read_l1_configs()?.ok()?;
-                serde_json::to_vec(&l1_configs).ok()
+                let l1_config = self.cfg.read_l1_config().ok()?;
+                serde_json::to_vec(&l1_config).ok()
             }
             _ => None,
         }


### PR DESCRIPTION
This patch fixes an oversight in the kona-interop configuration where it accepted an optional set of L1 genesis paths. There's no good usecase to configure a host with multiple L1 genesis. As interop can only occur across chains that have identical L1.

### Testing

With this change, the interop action tests now work as it's already compatible with the op-challenger:
```
export KONA_HOST_PATH=target/debug/kona-host
cd tests/optimism/op-e2e/actions/interop && gotestsum -- -run TestInteropFaultProofs
```

I'll follow up with another change to reenable the interop action tests in gh ci