### PR TITLE
 feat(executor): add InspectorFactory support for EVM execution tracing

### DIFF
--- a/bin/client/src/interop/consolidate.rs
+++ b/bin/client/src/interop/consolidate.rs
@@ -31,8 +31,8 @@ pub(crate) async fn consolidate_dependencies<P, H, Evm>(
     evm_factory: Evm,
 ) -> Result<(), FaultProofProgramError>
 where
-    P: PreimageOracleClient + Send + Sync + Debug + Clone,
-    H: HintWriterClient + Send + Sync + Debug + Clone,
+    P: PreimageOracleClient + Send + Sync + Debug + Clone + 'static,
+    H: HintWriterClient + Send + Sync + Debug + Clone + 'static,
     Evm: EvmFactory<Spec = OpSpecId, BlockEnv = BlockEnv> + Send + Sync + Debug + Clone + 'static,
     <Evm as EvmFactory>::Tx:
         FromTxWithEncoded<OpTxEnvelope> + FromRecoveredTx<OpTxEnvelope> + OpTxEnv,

--- a/bin/client/src/interop/transition.rs
+++ b/bin/client/src/interop/transition.rs
@@ -33,8 +33,8 @@ pub(crate) async fn sub_transition<P, H, Evm>(
     evm_factory: Evm,
 ) -> Result<(), FaultProofProgramError>
 where
-    P: PreimageOracleClient + Send + Sync + Debug + Clone,
-    H: HintWriterClient + Send + Sync + Debug + Clone,
+    P: PreimageOracleClient + Send + Sync + Debug + Clone + 'static,
+    H: HintWriterClient + Send + Sync + Debug + Clone + 'static,
     Evm: EvmFactory<Spec = OpSpecId, BlockEnv = BlockEnv> + Send + Sync + Debug + Clone + 'static,
     <Evm as EvmFactory>::Tx:
         FromTxWithEncoded<OpTxEnvelope> + FromRecoveredTx<OpTxEnvelope> + OpTxEnv,
@@ -126,6 +126,7 @@ where
         l2_provider,
         evm_factory,
         None,
+        None::<()>,
     );
     let mut driver = Driver::new(cursor, executor, pipeline);
 

--- a/bin/client/src/kona.rs
+++ b/bin/client/src/kona.rs
@@ -37,5 +37,5 @@ fn main() -> Result<(), String> {
             .expect("Failed to set tracing subscriber");
     }
 
-    kona_proof::block_on(kona_client::single::run(ORACLE_READER, HINT_WRITER))
+    kona_proof::block_on(kona_client::single::run(ORACLE_READER, HINT_WRITER, None::<()>))
 }

--- a/bin/client/src/single.rs
+++ b/bin/client/src/single.rs
@@ -3,11 +3,12 @@
 use crate::fpvm_evm::FpvmOpEvmFactory;
 use alloc::sync::Arc;
 use alloy_consensus::Sealed;
+use alloy_evm::revm::{Inspector, database::State};
 use alloy_primitives::B256;
 use core::fmt::Debug;
 use kona_derive::{EthereumDataSource, PipelineErrorKind};
 use kona_driver::{Driver, DriverError};
-use kona_executor::{ExecutorError, TrieDBProvider};
+use kona_executor::{ExecutorError, InspectorFactory, TrieDB, TrieDBProvider};
 use kona_preimage::{CommsClient, HintWriterClient, PreimageKey, PreimageOracleClient};
 use kona_proof::{
     BootInfo, CachingOracle, HintType,
@@ -39,10 +40,25 @@ pub enum FaultProofProgramError {
 
 /// Executes the fault proof program with the given [PreimageOracleClient] and [HintWriterClient].
 #[inline]
-pub async fn run<P, H>(oracle_client: P, hint_client: H) -> Result<(), FaultProofProgramError>
+pub async fn run<P, H, IF>(
+    oracle_client: P,
+    hint_client: H,
+    inspector_factory: Option<IF>,
+) -> Result<(), FaultProofProgramError>
 where
     P: PreimageOracleClient + Send + Sync + Debug + Clone + 'static,
     H: HintWriterClient + Send + Sync + Debug + Clone + 'static,
+    IF: InspectorFactory + Clone + Send + Sync + Debug,
+    for<'a> IF::Inspector: Inspector<
+        <FpvmOpEvmFactory<H, P> as alloy_evm::EvmFactory>::Context<
+            &'a mut State<
+                &'a mut TrieDB<
+                    OracleL2ChainProvider<CachingOracle<P, H>>,
+                    OracleL2ChainProvider<CachingOracle<P, H>>,
+                >,
+            >,
+        >,
+    >,
 {
     const ORACLE_LRU_SIZE: usize = 1024;
 
@@ -130,6 +146,7 @@ where
         l2_provider,
         evm_factory,
         None,
+        inspector_factory,
     );
     let mut driver = Driver::new(cursor, executor, pipeline);
 

--- a/bin/host/src/interop/handler.rs
+++ b/bin/host/src/interop/handler.rs
@@ -550,6 +550,7 @@ impl HintHandler for InteropHintHandler {
                             l2_provider,
                             OpEvmFactory::default(),
                             None,
+                            None::<()>,
                         );
                         let mut driver = Driver::new(cursor, executor, pipeline);
 

--- a/bin/host/src/single/cfg.rs
+++ b/bin/host/src/single/cfg.rs
@@ -213,6 +213,7 @@ impl SingleChainHost {
         let client_task = task::spawn(kona_client::single::run(
             OracleReader::new(preimage.client),
             HintWriter::new(hint.client),
+            None::<()>,
         ));
 
         let (_, client_result) = tokio::try_join!(server_task, client_task)?;

--- a/crates/proof/executor/src/builder/assemble.rs
+++ b/crates/proof/executor/src/builder/assemble.rs
@@ -2,7 +2,7 @@
 
 use super::StatelessL2Builder;
 use crate::{
-    ExecutorError, ExecutorResult, TrieDBError, TrieDBProvider,
+    ExecutorError, ExecutorResult, InspectorFactory, TrieDBError, TrieDBProvider,
     util::{encode_holocene_eip_1559_params, encode_jovian_eip_1559_params},
 };
 use alloc::vec::Vec;
@@ -18,11 +18,12 @@ use op_alloy_consensus::OpReceiptEnvelope;
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use revm::{context::BlockEnv, database::BundleState};
 
-impl<P, H, Evm> StatelessL2Builder<'_, P, H, Evm>
+impl<P, H, Evm, IF> StatelessL2Builder<'_, P, H, Evm, IF>
 where
     P: TrieDBProvider,
     H: TrieHinter,
     Evm: EvmFactory,
+    IF: InspectorFactory,
 {
     /// Seals the block executed from the given [OpPayloadAttributes] and [BlockEnv], returning the
     /// computed [Header].

--- a/crates/proof/executor/src/builder/core.rs
+++ b/crates/proof/executor/src/builder/core.rs
@@ -22,9 +22,85 @@ use op_alloy_consensus::{OpReceiptEnvelope, OpTxEnvelope};
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use op_revm::OpSpecId;
 use revm::{
+    Inspector,
     context::BlockEnv,
     database::{State, states::bundle_state::BundleRetention},
+    inspector::NoOpInspector,
 };
+
+/// A factory trait for creating EVM inspectors.
+///
+/// This trait allows for flexible inspector creation strategies while ensuring
+/// that the inspector's lifetime is scoped to the block execution.
+///
+/// # Important: Inspector Implementation Requirements
+///
+/// The inspector type produced by this factory **must** implement `Inspector<Ctx>`
+/// for **any** context type `Ctx`. This is required because the EVM context type
+/// includes references to the state database, and the borrow checker needs to be
+/// able to prove that the inspector doesn't capture these references.
+///
+/// The simplest way to achieve this is to implement `Inspector` generically:
+///
+/// ```rust,ignore
+/// impl<Ctx> Inspector<Ctx> for MyInspector {
+///     // ... method implementations that don't depend on Ctx's lifetime
+/// }
+/// ```
+///
+/// Inspectors that try to capture references from the context or store state
+/// with lifetime dependencies will cause borrow checker errors.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use revm::{Inspector, inspector::NoOpInspector};
+///
+/// // A simple inspector that logs call depth
+/// #[derive(Debug, Clone)]
+/// struct CallDepthLogger {
+///     max_depth: usize,
+/// }
+///
+/// // Implement Inspector for any context type
+/// impl<Ctx> Inspector<Ctx> for CallDepthLogger {
+///     // Implementation here
+/// }
+///
+/// struct CallDepthLoggerFactory;
+///
+/// impl InspectorFactory for CallDepthLoggerFactory {
+///     type Inspector = CallDepthLogger;
+///
+///     fn create(&self) -> Self::Inspector {
+///         CallDepthLogger { max_depth: 0 }
+///     }
+/// }
+/// ```
+pub trait InspectorFactory {
+    /// The inspector type produced by this factory.
+    ///
+    /// This type must implement `Inspector<Ctx>` for any context type `Ctx`.
+    type Inspector;
+
+    /// Creates a new inspector instance.
+    ///
+    /// This method is called once per block execution to create a fresh inspector.
+    fn create(&self) -> Self::Inspector;
+}
+
+/// Implementation of [`InspectorFactory`] for the unit type `()`.
+///
+/// This is used as the default type parameter for [`StatelessL2Builder`] and
+/// satisfies the `IF: InspectorFactory` bound when `None::<()>` is passed.
+/// The produced inspector is [`NoOpInspector`].
+impl InspectorFactory for () {
+    type Inspector = NoOpInspector;
+
+    fn create(&self) -> Self::Inspector {
+        NoOpInspector
+    }
+}
 
 /// Stateless OP Stack L2 block builder that derives state from trie proofs during execution.
 ///
@@ -72,12 +148,15 @@ use revm::{
 /// * `P` - Trie database provider implementing [`TrieDBProvider`]
 /// * `H` - Trie hinter implementing [`TrieHinter`] for state access optimization
 /// * `Evm` - EVM factory implementing [`EvmFactory`] for execution environment creation
+/// * `IF` - Optional inspector factory implementing [`InspectorFactory`] for creating EVM
+///   inspectors
 #[derive(Debug)]
-pub struct StatelessL2Builder<'a, P, H, Evm>
+pub struct StatelessL2Builder<'a, P, H, Evm, IF>
 where
     P: TrieDBProvider,
     H: TrieHinter,
     Evm: EvmFactory,
+    IF: InspectorFactory,
 {
     /// The rollup configuration containing chain parameters and activation heights.
     ///
@@ -97,15 +176,22 @@ where
     /// understand OP-specific transaction types, system calls, and state
     /// management required for proper L2 block execution.
     pub(crate) factory: OpBlockExecutorFactory<OpAlloyReceiptBuilder, RollupConfig, Evm>,
+    /// The optional inspector factory for creating EVM inspectors.
+    ///
+    /// When `Some`, uses [`EvmFactory::create_evm_with_inspector`] with the factory-created
+    /// inspector to trace or monitor EVM execution.
+    /// When `None`, uses [`EvmFactory::create_evm`] without any custom inspector.
+    pub(crate) inspector_factory: Option<IF>,
 }
 
-impl<'a, P, H, Evm> StatelessL2Builder<'a, P, H, Evm>
+impl<'a, P, H, Evm, IF> StatelessL2Builder<'a, P, H, Evm, IF>
 where
     P: TrieDBProvider + Debug,
     H: TrieHinter + Debug,
     Evm: EvmFactory<Spec = OpSpecId, BlockEnv = BlockEnv> + 'static,
     <Evm as EvmFactory>::Tx:
         FromTxWithEncoded<OpTxEnvelope> + FromRecoveredTx<OpTxEnvelope> + OpTxEnv,
+    IF: InspectorFactory,
 {
     /// Creates a new stateless L2 block builder instance.
     ///
@@ -118,18 +204,32 @@ where
     /// * `provider` - Trie database provider for state access
     /// * `hinter` - Trie hinter for optimizing state access patterns
     /// * `parent_header` - Sealed header of the parent block to build upon
+    /// * `inspector_factory` - Optional inspector factory for creating EVM inspectors. Pass `None`
+    ///   to use the default no-op inspector.
     ///
     /// # Returns
     /// A new [`StatelessL2Builder`] ready for block building operations
     ///
     /// # Usage
     /// ```rust,ignore
+    /// // Without custom inspector (recommended for most use cases)
     /// let builder = StatelessL2Builder::new(
     ///     &rollup_config,
     ///     evm_factory,
     ///     trie_provider,
     ///     trie_hinter,
     ///     parent_header,
+    ///     None,
+    /// );
+    ///
+    /// // With custom inspector factory
+    /// let builder = StatelessL2Builder::new(
+    ///     &rollup_config,
+    ///     evm_factory,
+    ///     trie_provider,
+    ///     trie_hinter,
+    ///     parent_header,
+    ///     Some(MyInspectorFactory),
     /// );
     /// ```
     pub fn new(
@@ -138,6 +238,7 @@ where
         provider: P,
         hinter: H,
         parent_header: Sealed<Header>,
+        inspector_factory: Option<IF>,
     ) -> Self {
         let trie_db = TrieDB::new(parent_header, provider, hinter);
         let factory = OpBlockExecutorFactory::new(
@@ -145,7 +246,7 @@ where
             config.clone(),
             evm_factory,
         );
-        Self { config, trie_db, factory }
+        Self { config, trie_db, factory, inspector_factory }
     }
 
     /// Builds and executes a new L2 block using the provided payload attributes.
@@ -212,7 +313,10 @@ where
     pub fn build_block(
         &mut self,
         attrs: OpPayloadAttributes,
-    ) -> ExecutorResult<BlockBuildingOutcome> {
+    ) -> ExecutorResult<BlockBuildingOutcome>
+    where
+        for<'b> IF::Inspector: Inspector<Evm::Context<&'b mut State<&'b mut TrieDB<P, H>>>>,
+    {
         // Step 1. Set up the execution environment.
         let (base_fee_params, min_base_fee) = Self::active_base_fee_params(
             self.config,
@@ -247,27 +351,67 @@ where
             "Beginning block building."
         );
 
-        // Step 2. Create the executor, using the trie database.
-        let mut state = State::builder()
-            .with_database(&mut self.trie_db)
-            .with_bundle_update()
-            .without_state_clear()
-            .build();
-        let evm = self.factory.evm_factory().create_evm(&mut state, evm_env);
-        let ctx = OpBlockExecutionCtx {
-            parent_hash,
-            parent_beacon_block_root: attrs.payload_attributes.parent_beacon_block_root,
-            // This field is unused for individual block building jobs.
-            extra_data: Default::default(),
-        };
-        let executor = self.factory.create_executor(evm, ctx);
-
-        // Step 3. Execute the block containing the transactions within the payload attributes.
         let transactions = attrs
             .recovered_transactions_with_encoded()
             .collect::<Result<Vec<_>, RecoveryError>>()
             .map_err(ExecutorError::Recovery)?;
-        let ex_result = executor.execute_block(transactions.iter())?;
+
+        let ctx = OpBlockExecutionCtx {
+            parent_hash,
+            parent_beacon_block_root: attrs.payload_attributes.parent_beacon_block_root,
+            extra_data: Default::default(),
+        };
+
+        let (bundle, ex_result) = {
+            let mut state = State::builder()
+                .with_database(&mut self.trie_db)
+                .with_bundle_update()
+                .without_state_clear()
+                .build();
+
+            let ex_result = match &self.inspector_factory {
+                // When no custom inspector factory is provided, use the standard create_evm().
+                None => {
+                    // Step 2. Create the executor, using the trie database.
+                    let evm = self.factory.evm_factory().create_evm(&mut state, evm_env);
+
+                    // Step 3. Execute the block containing the transactions within the payload attributes.
+                    let executor = self.factory.create_executor(evm, ctx);
+                    executor.execute_block(transactions.iter())?
+                }
+                // When a custom inspector factory is provided, we need to use raw pointers
+                // to work around the borrow checker's limitations with generic types.
+                //
+                // NOTE: With a generic IF::Inspector, Rust cannot prove that the mutable
+                // borrow of state ends when the EVM is dropped. We use raw pointers to work
+                // around this. This is safe because:
+                // 1. The state is valid for the entire duration of EVM usage
+                // 2. The EVM is consumed by execute_block before we access state again
+                // 3. No other references to state exist during EVM usage
+                Some(factory) => {
+                    let state_ptr = &mut state as *mut _;
+                    let inspector = factory.create();
+
+                    // Step 2. Create the executor, using the trie database.
+                    // SAFETY: state is valid and not accessed elsewhere during EVM usage.
+                    // The EVM is consumed by execute_block, ending the borrow.
+                    let evm = self.factory.evm_factory().create_evm_with_inspector(
+                        unsafe { &mut *state_ptr },
+                        evm_env,
+                        inspector,
+                    );
+
+                    // Step 3. Execute the block containing the transactions within the payload attributes.
+                    let executor = self.factory.create_executor(evm, ctx);
+                    executor.execute_block(transactions.iter())?
+                }
+            };
+
+            // Step 4. Merge state transitions and seal the block.
+            state.merge_transitions(BundleRetention::Reverts);
+            let bundle = state.take_bundle();
+            (bundle, ex_result)
+        };
 
         info!(
             target: "block_builder",
@@ -275,10 +419,6 @@ where
             gas_limit = block_env.gas_limit,
             "Finished block building. Beginning sealing job."
         );
-
-        // Step 4. Merge state transitions and seal the block.
-        state.merge_transitions(BundleRetention::Reverts);
-        let bundle = state.take_bundle();
         let header = self.seal_block(&attrs, parent_hash, &block_env, &ex_result, bundle)?;
 
         info!(

--- a/crates/proof/executor/src/builder/env.rs
+++ b/crates/proof/executor/src/builder/env.rs
@@ -2,7 +2,7 @@
 
 use super::StatelessL2Builder;
 use crate::{
-    ExecutorError, ExecutorResult, TrieDBProvider,
+    ExecutorError, ExecutorResult, InspectorFactory, TrieDBProvider,
     util::{
         decode_holocene_eip_1559_params_block_header, decode_jovian_eip_1559_params_block_header,
     },
@@ -23,11 +23,12 @@ use revm::{
     },
 };
 
-impl<P, H, Evm> StatelessL2Builder<'_, P, H, Evm>
+impl<P, H, Evm, IF> StatelessL2Builder<'_, P, H, Evm, IF>
 where
     P: TrieDBProvider,
     H: TrieHinter,
     Evm: EvmFactory,
+    IF: InspectorFactory,
 {
     /// Returns the active [`EvmEnv`] for the executor.
     pub(crate) fn evm_env(

--- a/crates/proof/executor/src/builder/mod.rs
+++ b/crates/proof/executor/src/builder/mod.rs
@@ -1,7 +1,7 @@
 //! Stateless OP Stack block builder implementation.
 
 mod core;
-pub use core::{BlockBuildingOutcome, StatelessL2Builder};
+pub use core::{BlockBuildingOutcome, InspectorFactory, StatelessL2Builder};
 
 mod assemble;
 pub use assemble::compute_receipts_root;

--- a/crates/proof/executor/src/lib.rs
+++ b/crates/proof/executor/src/lib.rs
@@ -16,7 +16,9 @@ mod db;
 pub use db::{NoopTrieDBProvider, TrieDB, TrieDBProvider};
 
 mod builder;
-pub use builder::{BlockBuildingOutcome, StatelessL2Builder, compute_receipts_root};
+pub use builder::{
+    BlockBuildingOutcome, InspectorFactory, StatelessL2Builder, compute_receipts_root,
+};
 
 mod errors;
 pub use errors::{

--- a/crates/proof/executor/src/test_utils.rs
+++ b/crates/proof/executor/src/test_utils.rs
@@ -49,6 +49,7 @@ pub async fn run_test_fixture(fixture_path: PathBuf) {
         provider,
         NoopTrieHinter,
         fixture.parent_header.seal_slow(),
+        None::<()>,
     );
 
     let outcome = executor.build_block(fixture.executing_payload).unwrap();
@@ -185,6 +186,7 @@ impl ExecutorTestFixtureCreator {
             self,
             NoopTrieHinter,
             parent_header,
+            None::<()>,
         );
         let outcome = executor.build_block(payload_attrs).expect("Failed to execute block");
 

--- a/crates/proof/proof-interop/src/consolidation.rs
+++ b/crates/proof/proof-interop/src/consolidation.rs
@@ -44,7 +44,7 @@ where
 
 impl<'a, C, Evm> SuperchainConsolidator<'a, C, Evm>
 where
-    C: CommsClient + Debug + Send + Sync,
+    C: CommsClient + Debug + Send + Sync + 'static,
     Evm: EvmFactory<Spec = OpSpecId, BlockEnv = BlockEnv> + Send + Sync + Debug + Clone + 'static,
     <Evm as EvmFactory>::Tx:
         FromTxWithEncoded<OpTxEnvelope> + FromRecoveredTx<OpTxEnvelope> + OpTxEnv,
@@ -230,6 +230,7 @@ where
                 l2_provider.clone(),
                 l2_provider.clone(),
                 parent_header.seal_slow(),
+                None::<()>,
             );
 
             // Execute the block and take the new header. At this point, the block is guaranteed to

--- a/crates/proof/proof/src/executor.rs
+++ b/crates/proof/proof/src/executor.rs
@@ -2,13 +2,18 @@
 
 use alloc::boxed::Box;
 use alloy_consensus::{Header, Sealed};
-use alloy_evm::{EvmFactory, FromRecoveredTx, FromTxWithEncoded, revm::context::BlockEnv};
+use alloy_evm::{
+    EvmFactory, FromRecoveredTx, FromTxWithEncoded,
+    revm::{Inspector, context::BlockEnv, database::State},
+};
 use alloy_op_evm::block::OpTxEnv;
 use alloy_primitives::B256;
 use async_trait::async_trait;
 use core::fmt::Debug;
 use kona_driver::Executor;
-use kona_executor::{BlockBuildingOutcome, StatelessL2Builder, TrieDBProvider};
+use kona_executor::{
+    BlockBuildingOutcome, InspectorFactory, StatelessL2Builder, TrieDB, TrieDBProvider,
+};
 use kona_genesis::RollupConfig;
 use kona_mpt::TrieHinter;
 use op_alloy_consensus::OpTxEnvelope;
@@ -17,11 +22,12 @@ use op_revm::OpSpecId;
 
 /// An executor wrapper type.
 #[derive(Debug)]
-pub struct KonaExecutor<'a, P, H, Evm>
+pub struct KonaExecutor<'a, P, H, Evm, IF>
 where
     P: TrieDBProvider + Send + Sync + Clone,
     H: TrieHinter + Send + Sync + Clone,
     Evm: EvmFactory + Send + Sync + Clone,
+    IF: InspectorFactory,
 {
     /// The rollup config for the executor.
     rollup_config: &'a RollupConfig,
@@ -32,14 +38,17 @@ where
     /// The evm factory for the executor.
     evm_factory: Evm,
     /// The executor.
-    inner: Option<StatelessL2Builder<'a, P, H, Evm>>,
+    inner: Option<StatelessL2Builder<'a, P, H, Evm, IF>>,
+    /// The optional inspector factory for the executor.
+    inspector_factory: Option<IF>,
 }
 
-impl<'a, P, H, Evm> KonaExecutor<'a, P, H, Evm>
+impl<'a, P, H, Evm, IF> KonaExecutor<'a, P, H, Evm, IF>
 where
     P: TrieDBProvider + Send + Sync + Clone,
     H: TrieHinter + Send + Sync + Clone,
     Evm: EvmFactory + Send + Sync + Clone,
+    IF: InspectorFactory + Clone,
 {
     /// Creates a new executor.
     pub const fn new(
@@ -47,20 +56,23 @@ where
         trie_provider: P,
         trie_hinter: H,
         evm_factory: Evm,
-        inner: Option<StatelessL2Builder<'a, P, H, Evm>>,
+        inner: Option<StatelessL2Builder<'a, P, H, Evm, IF>>,
+        inspector_factory: Option<IF>,
     ) -> Self {
-        Self { rollup_config, trie_provider, trie_hinter, evm_factory, inner }
+        Self { rollup_config, trie_provider, trie_hinter, evm_factory, inner, inspector_factory }
     }
 }
 
 #[async_trait]
-impl<P, H, Evm> Executor for KonaExecutor<'_, P, H, Evm>
+impl<P, H, Evm, IF> Executor for KonaExecutor<'_, P, H, Evm, IF>
 where
     P: TrieDBProvider + Debug + Send + Sync + Clone,
     H: TrieHinter + Debug + Send + Sync + Clone,
     Evm: EvmFactory<Spec = OpSpecId, BlockEnv = BlockEnv> + Send + Sync + Clone + 'static,
     <Evm as EvmFactory>::Tx:
         FromTxWithEncoded<OpTxEnvelope> + FromRecoveredTx<OpTxEnvelope> + OpTxEnv,
+    IF: InspectorFactory + Clone + Send + Sync,
+    for<'b> IF::Inspector: Inspector<Evm::Context<&'b mut State<&'b mut TrieDB<P, H>>>>,
 {
     type Error = kona_executor::ExecutorError;
 
@@ -81,6 +93,7 @@ where
             self.trie_provider.clone(),
             self.trie_hinter.clone(),
             header,
+            self.inspector_factory.clone(),
         ));
     }
 


### PR DESCRIPTION
 ## Summary

  - Add `InspectorFactory` trait to enable custom EVM inspector injection during block execution
  - Extend `StatelessL2Builder` and `KonaExecutor` with optional inspector factory support
  - Use `create_evm_with_inspector` when a custom inspector is provided

  ## Motivation

  This change enables external tooling to observe and trace EVM execution during block building. The `InspectorFactory` pattern allows inspectors to be created fresh for each block execution, ensuring clean state and proper scoping.

  This is useful for investigating derivation errors like the one seen in #3108.

  ## Changes

  - **New `InspectorFactory` trait** (`kona-executor`): Defines a factory pattern for creating EVM inspectors with full documentation on implementation requirements
  - **`StatelessL2Builder`**: Added `IF` type parameter and `inspector_factory` field
  - **`KonaExecutor`**: Extended to propagate inspector factory through the execution pipeline
  - **Call sites**: Updated to pass `None::<()>` for default no-op inspector behavior

  ## API

  ```rust
  // Without custom inspector (default behavior)
  let executor = KonaExecutor::new(config, provider, hinter, evm_factory, None, None::<()>);

  // With custom inspector factory
  let executor = KonaExecutor::new(config, provider, hinter, evm_factory, None, Some(my_factory));
```