### PR TITLE
chore(gossip): remove unnecessary dead_code allow on Event::Ping

### DIFF
--- a/crates/node/gossip/src/event.rs
+++ b/crates/node/gossip/src/event.rs
@@ -13,7 +13,6 @@ pub enum Event {
     /// Network connectivity check event from the ping protocol.
     ///
     /// Used to verify peer connectivity and measure round-trip times.
-    #[allow(dead_code)]
     Ping(ping::Event),
 
     /// GossipSub mesh networking event.


### PR DESCRIPTION
Removes the `#[allow(dead_code)]` attribute from the `Event::Ping` variant in the gossip event module, as this variant is actively used and the suppression is unnecessary.