### PR TITLE
docs: fix derive links

### DIFF
--- a/docs/docs/pages/sdk/protocol/derive/intro.mdx
+++ b/docs/docs/pages/sdk/protocol/derive/intro.mdx
@@ -12,10 +12,10 @@ in this section will provide a comprehensive overview of Derivation Pipeline
 extensibility including trait-abstracted providers, custom stages, signaling,
 and hardfork activation including multiplexed stages.
 
-- [Swapping out a stage](/sdk/protocol/derive/stages)
-- [Defining a custom Provider](/sdk/protocol/derive/providers)
-- [Extending Pipeline Signals](/sdk/protocol/derive/signaling)
-- [Implementing Hardfork Activations](/sdk/protocol/hardforks)
+- [Swapping out a stage](https://rollup.yoga/sdk/protocol/derive/stages/)
+- [Defining a custom Provider](https://rollup.yoga/sdk/protocol/derive/providers/)
+- [Extending Pipeline Signals](https://rollup.yoga/sdk/protocol/derive/signaling/)
+- [Implementing Hardfork Activations](https://rollup.yoga/sdk/protocol/derive/signaling/#the-signal-type)
 
 
 ## What is a Derivation Pipeline?


### PR DESCRIPTION
Fix broken derive section links in intro