### PR TITLE
chore: bump msrv

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 edition = "2024"
 license = "MIT"
-rust-version = "1.88"
+rust-version = "1.91"
 authors = ["clabby", "refcell", "theochap", "emhane"]
 homepage = "https://github.com/op-rs/kona"
 repository = "https://github.com/op-rs/kona"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.88"
+channel = "1.91"


### PR DESCRIPTION
## Description

Bump the rust msrv. I doubled checked with succinct and risc0 teams that this version was supported by their respective zkvms